### PR TITLE
fixing render bug

### DIFF
--- a/bin/jinja2_templates/driver.md.j2
+++ b/bin/jinja2_templates/driver.md.j2
@@ -134,8 +134,9 @@ This download link contains the malicious driver!
 * {{ export }}
 {% endfor %}
 
-{% raw %}{{< /details >}}{% endraw %}
-{% endfor +%}
+{% raw %}{{< /details >}}{%+ endraw +%}
+-----
+{%+ endfor +%}
 {% endif %}
 
 


### PR DESCRIPTION
Two examples would collied if there are a ton of empty values. This was due to jinja2 template, fixed:

![image](https://user-images.githubusercontent.com/1476868/233434497-6d7ef608-7104-4fa3-84e3-bd05a3c842f7.png)
