### PR TITLE
Minor fix

### DIFF
--- a/bin/jinja2_templates/driver.md.j2
+++ b/bin/jinja2_templates/driver.md.j2
@@ -31,7 +31,7 @@ We were not able to verify the hash of this driver successfully, it has not been
 {% if driver.Commands.Description %}
 {{driver.Commands.Description}}
 {% else %}
-{{ driver.Id }} is a vulnerable driver and more information will be added as found.
+{{ driver.Tags[0] }} is a vulnerable driver and more information will be added as found.
 {% endif %}
 - **UUID**: {{ driver.Id }}
 - **Created**: {{driver.Created}}


### PR DESCRIPTION
Noticed the description had the UUID instead of `driver.Tags`
<img width="596" alt="image" src="https://user-images.githubusercontent.com/5632822/236724640-983167d6-9db5-41a5-bebe-01d24fa4ec1f.png">
