### PR TITLE
add ace-base.sys

### DIFF
--- a/drivers/e8f177545acc656c837b74102cd76527.bin
+++ b/drivers/e8f177545acc656c837b74102cd76527.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7326aefff9ea3a32286b423a62baebe33b73251348666c1ee569afe62dd60e11
+size 1869904

--- a/yaml/ff77b58d-e143-4f61-92de-c0d9bc0af7d5.yaml
+++ b/yaml/ff77b58d-e143-4f61-92de-c0d9bc0af7d5.yaml
@@ -1,0 +1,340 @@
+Id: ff77b58d-e143-4f61-92de-c0d9bc0af7d5
+Author: 'Defence Tech security'
+Created: '2024-02-22'
+MitreID: T1068
+CVE:
+- CVE-2024-22830
+Category: vulnerable driver
+Verified: 'FALSE'
+Commands:
+  Command: ''
+  Description: Allows privilege escalation from regular user to System or PPL
+  Usecase: Elevate privileges
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- ''
+Acknowledgement:
+  Person: ''
+  Handle: ''
+Detection: []
+KnownVulnerableSamples:
+- Name: 'ACE-BASE.sys'
+  Libraries:
+  - ntoskrnl.exe
+  - FLTMGR.SYS
+  - HAL.dll
+  ImportedFunctions:
+  - PsGetCurrentThreadId
+  - PsGetProcessCreateTimeQuadPart
+  - PsGetProcessId
+  - ObOpenObjectByPointer
+  - PsGetProcessSessionId
+  - PsGetProcessInheritedFromUniqueProcessId
+  - ZwFreeVirtualMemory
+  - PsReferenceProcessFilePointer
+  - RtlInitUnicodeString
+  - ZwCreateFile
+  - ZwDeviceIoControlFile
+  - RtlNtStatusToDosError
+  - ZwFsControlFile
+  - ZwWaitForSingleObject
+  - MmGetVirtualForPhysical
+  - PsGetThreadId
+  - IoFileObjectType
+  - ExSemaphoreObjectType
+  - PsProcessType
+  - PsThreadType
+  - PsJobType
+  - SeTokenObjectType
+  - IofCompleteRequest
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - RtlUnicodeStringToAnsiString
+  - RtlFreeAnsiString
+  - KeInitializeEvent
+  - KeInitializeTimerEx
+  - KeCancelTimer
+  - KeSetTimerEx
+  - KeWaitForMultipleObjects
+  - PsCreateSystemThread
+  - ObReferenceObjectByHandle
+  - ZwClose
+  - KeClearEvent
+  - IoCreateDevice
+  - IoCreateNotificationEvent
+  - IoCreateSymbolicLink
+  - IoRegisterShutdownNotification
+  - IoUnregisterShutdownNotification
+  - KeEnterCriticalRegion
+  - KeLeaveCriticalRegion
+  - ExInitializeResourceLite
+  - ExAcquireResourceSharedLite
+  - ExAcquireResourceExclusiveLite
+  - ExReleaseResourceLite
+  - ExDeleteResourceLite
+  - RtlInitializeGenericTableAvl
+  - RtlInsertElementGenericTableAvl
+  - RtlDeleteElementGenericTableAvl
+  - RtlLookupElementGenericTableAvl
+  - RtlIsGenericTableEmptyAvl
+  - RtlUpcaseUnicodeString
+  - RtlTimeToTimeFields
+  - ExSystemTimeToLocalTime
+  - RtlEqualUnicodeString
+  - KeAcquireSpinLockRaiseToDpc
+  - KeReleaseSpinLock
+  - RtlWalkFrameChain
+  - KeInitializeDpc
+  - KeSetTargetProcessorDpc
+  - ProbeForRead
+  - KeDelayExecutionThread
+  - KeQueryTimeIncrement
+  - KeQueryActiveProcessors
+  - MmGetSystemRoutineAddress
+  - MmProbeAndLockPages
+  - MmUnlockPages
+  - MmBuildMdlForNonPagedPool
+  - MmMapLockedPagesSpecifyCache
+  - MmUnmapLockedPages
+  - IoAllocateMdl
+  - IoFreeMdl
+  - MmSecureVirtualMemory
+  - MmUnsecureVirtualMemory
+  - RtlCompareMemory
+  - ExAcquireRundownProtection
+  - ExReleaseRundownProtection
+  - PsInitialSystemProcess
+  - ExpInterlockedPopEntrySList
+  - MmAdvanceMdl
+  - MmCreateMdl
+  - PsGetProcessPeb
+  - KeNumberProcessors
+  - RtlInitAnsiString
+  - RtlAnsiStringToUnicodeString
+  - ZwOpenKey
+  - ZwQueryValueKey
+  - ZwOpenSymbolicLinkObject
+  - ZwQuerySymbolicLinkObject
+  - RtlCompareString
+  - PsGetThreadProcess
+  - ZwOpenDirectoryObject
+  - KeWaitForSingleObject
+  - RtlCompareUnicodeString
+  - PsGetProcessWow64Process
+  - RtlFreeUnicodeString
+  - IoCreateFile
+  - ZwOpenFile
+  - ZwQueryInformationFile
+  - ZwSetInformationFile
+  - ZwReadFile
+  - IoCreateFileSpecifyDeviceObjectHint
+  - NtQueryDirectoryFile
+  - IoGetBaseFileSystemDeviceObject
+  - IoQueryFileInformation
+  - ObQueryNameString
+  - ZwDeleteFile
+  - ZwQueryObject
+  - ZwCreateKey
+  - ZwDeleteKey
+  - ZwEnumerateKey
+  - ZwSetValueKey
+  - RtlAnsiCharToUnicodeChar
+  - PsGetVersion
+  - ZwQuerySystemInformation
+  - ZwSetSecurityObject
+  - IoDeviceObjectType
+  - RtlGetDaclSecurityDescriptor
+  - RtlGetGroupSecurityDescriptor
+  - RtlGetOwnerSecurityDescriptor
+  - RtlGetSaclSecurityDescriptor
+  - SeCaptureSecurityDescriptor
+  - _snwprintf
+  - RtlLengthSecurityDescriptor
+  - SeExports
+  - RtlCreateSecurityDescriptor
+  - wcschr
+  - RtlAbsoluteToSelfRelativeSD
+  - RtlAddAccessAllowedAce
+  - RtlLengthSid
+  - IoIsWdmVersionAvailable
+  - RtlSetDaclSecurityDescriptor
+  - strcpy_s
+  - KeUnstackDetachProcess
+  - KeStackAttachProcess
+  - KeInitializeGuardedMutex
+  - KeRegisterBugCheckReasonCallback
+  - KeDeregisterBugCheckReasonCallback
+  - ExEventObjectType
+  - __C_specific_handler
+  - KeSetEvent
+  - ObfDereferenceObject
+  - ExAllocatePool
+  - PsGetProcessImageFileName
+  - ExFreePoolWithTag
+  - ExAllocatePoolWithTag
+  - KeReleaseGuardedMutex
+  - KeAcquireGuardedMutex
+  - PsGetCurrentProcessId
+  - IoGetCurrentProcess
+  - KeBugCheckEx
+  - PsLookupProcessByProcessId
+  - MmIsAddressValid
+  - MmGetPhysicalAddress
+  - PsTerminateSystemThread
+  - RtlAssert
+  - ProbeForWrite
+  - PsIsThreadTerminating
+  - PsLookupThreadByThreadId
+  - ZwOpenThread
+  - ZwQueryInformationThread
+  - KeInitializeApc
+  - KeInsertQueueApc
+  - IoBuildDeviceIoControlRequest
+  - IofCallDriver
+  - IoGetDeviceObjectPointer
+  - wcsrchr
+  - RtlCopyUnicodeString
+  - RtlAppendUnicodeStringToString
+  - ZwUnloadDriver
+  - ZwOpenProcess
+  - ZwQueryInformationProcess
+  - towupper
+  - ZwCreateSection
+  - ZwMapViewOfSection
+  - ZwUnmapViewOfSection
+  - MmProtectMdlSystemAddress
+  - MmProbeAndLockProcessPages
+  - KeDeregisterNmiCallback
+  - PsGetProcessExitStatus
+  - ZwOpenSection
+  - ObReferenceObjectByName
+  - IoAllocateIrp
+  - IoFreeIrp
+  - MmUnmapIoSpace
+  - MmAllocateContiguousMemory
+  - MmMapIoSpace
+  - FltWriteFile
+  - FltReleaseFileNameInformation
+  - FltStartFiltering
+  - FltUnregisterFilter
+  - FltRegisterFilter
+  - FltObjectDereference
+  - FltEnumerateInstances
+  - FltGetVolumeProperties
+  - FltGetVolumeFromInstance
+  - FltClose
+  - FltSetInformationFile
+  - FltReadFile
+  - FltCreateFileEx
+  - FltGetVolumeName
+  - FltParseFileNameInformation
+  - FltGetFileNameInformation
+  - FltFreePoolAlignedWithTag
+  - FltAllocatePoolAlignedWithTag
+  - FltGetFileNameInformationUnsafe
+  - FltGetRequestorProcessId
+  - KeStallExecutionProcessor
+  ExportedFunctions: ''
+  MD5: e8f177545acc656c837b74102cd76527
+  SHA1: 39402a9a3d90ba62938052089c8cbde9fb4e639f
+  SHA256: 7326aefff9ea3a32286b423a62baebe33b73251348666c1ee569afe62dd60e11
+  Imphash: 13ad56e7c65468e58c468f56e33687d4
+  Machine: AMD64
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2022-02-22 15:16:48'
+  RichPEHeaderMD5: 062556004ee11c5a66737fee0c2ef190
+  RichPEHeaderSHA1: 67512e1821c28bf63354cc771c15c6e65982911d
+  RichPEHeaderSHA256: 87208680099d7e82d232a61048f4acaaa4a7b49ad81501cbff1fd3f12c80256a
+  AuthentihashMD5: dd3bfadd02f076a1bdea2279c7be339b
+  AuthentihashSHA1: d2e7cbdf71ae78df5cc61c3dc4eacca4365c0f87
+  AuthentihashSHA256: 2759e2290295a81e80ef5d8e95266aa08d67832c0af51267ad1100b89d8b890c
+  Sections:
+    .text:
+      Entropy: 5.798357152286487
+      Virtual Size: '0x5a1b5'
+    .rdata:
+      Entropy: 5.0264329620337405
+      Virtual Size: '0x4db84'
+    .data:
+      Entropy: 2.6820310018716422
+      Virtual Size: '0x97374'
+    .pdata:
+      Entropy: 5.671296849565602
+      Virtual Size: '0x42f0'
+    PAGE:
+      Entropy: 6.344388673223935
+      Virtual Size: '0x1a15'
+    INIT:
+      Entropy: 5.359883496957578
+      Virtual Size: '0x1ad0'
+    .rsrc:
+      Entropy: 3.3592051915529972
+      Virtual Size: '0x3d0'
+    .reloc:
+      Entropy: 6.834766060295567
+      Virtual Size: '0xf00'
+    .tvm0:
+      Entropy: 5.528023547055279
+      Virtual Size: '0x110000'
+  CompanyName: ANTICHEATEXPERT.COM
+  FileDescription: ACE-BASE64 NT Driver
+  InternalName: ACE-BASE64
+  OriginalFilename: ''
+  FileVersion: 1.0.2202.6217
+  ProductName: Anti-Cheat Expert
+  LegalCopyright: "\xA9 AntiCheatExpert.com Limited. All Rights Reserved."
+  ProductVersion: 1.0.0.0
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=HK, L=Hong Kong Island, O=HIGH MORALE DEVELOPMENTS LIMITED, CN=HIGH
+        MORALE DEVELOPMENTS LIMITED
+      ValidFrom: '2020-10-10 00:00:00'
+      ValidTo: '2023-10-18 12:00:00'
+      Signature: 4315b73181923749bb0bda91672c11d257dce7ae271422366ca02032c2e1350f375eda0154e630b6d99d86d2578ddf0ead7f9cc8c82e1d9e8dfad35fbb355d24c3324ae7c29756116b71e0ed23070c3fd0383ab2e761aee37dd3993a8d957396908a036277313ffa66ad800bedb0f0eab00011071aa866f1c0d3d700e8ff35450d6d1c64c8d9e0aecdb3a8f4d4fd8574be01fabdc89b49b1136662b6acae6767927d685d600afa623aa4269880652807cc3c4ac2cc79c07d12f6d139d36eb8060a81ff07e798c609bd81c11555ed70e5b5402ef362621cc638565268c71cd3c45433bbd9ee6410a8e1137b5c43ad8f7fd2998d2bb0a66d7a9a74446a6679e5a9
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0f316a214f60d59dc921aeb9685136cc
+      Version: 3
+      TBS:
+        MD5: 8cefdc7dfa7da86a8d3bfce9c642d0f4
+        SHA1: 6bc97cc3df00260304a6d1eb96795ac43974d82d
+        SHA256: 71ccc1f111e9b46aa35e5695652084505e36efec36224990cfad2dc2263ab4e3
+        SHA384: d59a26595ba8ad78d72ed0c3a1c0a578df85526471ae439212c50aed3bfcd71dacd599abc072cfeed937348a175e6bce
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root
+        CA
+      ValidFrom: '2011-04-15 19:41:37'
+      ValidTo: '2021-04-15 19:51:37'
+      Signature: 5cf5b22d02ceed01b53512d813f7aa4014c7a15ca08a55ed7e55ea6ac457176fd04722423658efc5ac61c5f62c52ce6ae6c80d85dab334420ea40225182672b92a4ea57e4b16f2a0e40c449ce24d9af474f0f927a6699031c244654348c74869d0fc8409f286140ac22996857f11eb8713176ed3ec6bff1d578ab17b1ea5a07ce9a27a68e5fac6b161d67263fa379163835599f81d614f0c6fa3f7bcb1152acc8d85e31417ef7e49443fb022c0f0acbe2fdbe10c86b0f4585c5a10a94bcdf3448a4652083e0a6210e9459504b78b8d4b074f500db7bbe7fb8ca27878c6c53b7663b2cfe521845a66fce04c79834ecfa8ee700586587cc29cd73ca3ad3c7e76625c87d0ed7cd5c55b1421f4be75a275d2e9e15ad020307841624d6b5e6e1b1710244ad8588775d015d762bbfd185665842561977faad49df4f35d6da031c2e19e02ac3e90c3327ee832903416d08b14cf95accee58c54a265b8bfed186a57073ed3e79a4a2f081a041c49871a8ae61b08a365d81c31c50d9cbab368ddf45076160675fec403e7d13edfdc862e10027e661296534e7af3365879b12042d8963f35be3f8ef2999743f5e40ce13c68728c8d49d75a52b573fb7a35943a61b08482c04885c19732d39b725fa0d2348f7ef0467cf28c7294c707b0d7b5b230b81965f09c8327b0a0abd0a2727e050fb3aeddb95b9b42bcc32663456b86f11d4643edc8
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 611cb28a000000000026
+      Version: 3
+      TBS:
+        MD5: 983a0c315a50542362f2bd6a5d71c8d0
+        SHA1: 8047f476001f5cb16a661d2a3fd0c3576168f5e2
+        SHA256: 5f6a519ed2e35cd0fa1cdfc90f4387162c36287bbf9e4d6648251d99542a9e83
+        SHA384: 5f014b60511ddab3247ef0b3c03fe82c622237ba76015e2911d1adc50dc632d56ebd1ee532f3c2b6cbfe68d80a2c91dc
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Code
+        Signing CA,1
+      ValidFrom: '2011-02-11 12:00:00'
+      ValidTo: '2026-02-10 12:00:00'
+      Signature: 7b721d64ff88c83ac1b7e9e7a9c487bbdb9492d7905933fa2b87dea85b80253f138f9b831b7c43c4e68cdf393ec315ecb0da3b21257b24c1725db84791811346fa9c3f6a5138deb425cbf0abdfc528015479104624d1380f26a161904dbabd28e63ff1c4aa9bf6da35534fc9f23dd36cdc23edaaa04d6709f33a803d3cfb364c90e776a4ddf23abf56352fa24c65e8e0d4dad1c7c8916a2d234f373b199418d4d59c103cd5b11c19ff8fc86b9b9ef8ae9c999678d1cd9c51155b4226725a8d0a4a239240e886de22c2933ad49b68a6df297f06b93c0ebd9fc4869c82474271328609997209794b9d7169f541ff7f397764f1848dbe8b1eb27d68a3a590b10cff
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 0fa8490615d700a0be2176fdc5ec6dbd
+      Version: 3
+      TBS:
+        MD5: a9a31555bbc92b6033975c5428fb3679
+        SHA1: 47f4b9898631773231b32844ec0d49990ac4eb1e
+        SHA256: c826846e4b1d73edb7561ab1b41c949354e237a91e82fe1be5b7e2e1701f52d1
+        SHA384: 86f49574f368a561914a52d7ae043ec6784ef8c718960700f834e123594605d25d39f1ad45f1eb5052c9567f3edd0e16
+    Signer:
+    - SerialNumber: 0f316a214f60d59dc921aeb9685136cc
+      Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Code
+        Signing CA,1
+      Version: 1
+Tags:
+- ''


### PR DESCRIPTION
Ace-base is a kernel anticheat driver distributed with a few popular games for Windows. We discovered a vulnerability and reported it to the vendor in 2023.

This is tracked as CVE-2024-22830
We will publish more details about the vulnerability at a later date.