### PR TITLE
Delete boots

### DIFF
--- a/drivers/0008d969a43a2b94edd849cdee6ae3c9.bin
+++ b/drivers/0008d969a43a2b94edd849cdee6ae3c9.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f8f266488f3b888eb77b8df43582fa8124366b7d0670ed78926410f9c9f411f
-size 1200248

--- a/drivers/007e746f6aeff8bcb4479e6e49236260.bin
+++ b/drivers/007e746f6aeff8bcb4479e6e49236260.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:62288f1f5f2f8529292eb45c2ae2a33d1057a3dec12164958e76ded36fbe712b
-size 1641224

--- a/drivers/02e7a063eae0c4b80a6793fd63bac013.bin
+++ b/drivers/02e7a063eae0c4b80a6793fd63bac013.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9da10b25786d8db0167fd66c051f7e2655781bb561b99584312b439a32be4c32
-size 1120488

--- a/drivers/07349cf7c406343bb9a9a9d9eec50790.bin
+++ b/drivers/07349cf7c406343bb9a9a9d9eec50790.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef43b4b4a755494b10b7431527aead697feab6fa48cf4684cca4fb5b8cd09035
-size 1289712

--- a/drivers/077432d8b1ae0ceea719297360357320.bin
+++ b/drivers/077432d8b1ae0ceea719297360357320.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e371dd0448f1de869ee087b59ff88d11865463715272bcc6c29b0d5e21dbd82
-size 1283736

--- a/drivers/087617bd4578c903f0a66bd157217f0f.bin
+++ b/drivers/087617bd4578c903f0a66bd157217f0f.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b65fe0af8297168749dc235340cba7c08cf6b956fdd25fc2c9f16d20da536713
-size 1354472

--- a/drivers/0887bbb1fff22018d425b56dfb642db7.bin
+++ b/drivers/0887bbb1fff22018d425b56dfb642db7.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e352109145416e3b61dcf5e09492d24410828121e7d74c08ce0d3157b45a0831
-size 1280160

--- a/drivers/09287aecf07aa294ed7f76f2234270a9.bin
+++ b/drivers/09287aecf07aa294ed7f76f2234270a9.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:860c16809e3941bebedff0bde99c32aa77379c0be1f6b174d20038a02162d3d5
-size 770920

--- a/drivers/11ca417bc767273a9de7b1355cb2908e.bin
+++ b/drivers/11ca417bc767273a9de7b1355cb2908e.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b16ad93ee38243d72ff0acd790107767b6d7d3563a4ba8edb7a23eec5c8d531
-size 1615712

--- a/drivers/16e6180b7edfa353678a459079afa5db.bin
+++ b/drivers/16e6180b7edfa353678a459079afa5db.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50484376441815f7f85aa294290a9b6072a6a9e8feae79447c5c4de855c5a3d3
-size 1191592

--- a/drivers/1854d98bc963a9a82e0d9abef6bc3873.bin
+++ b/drivers/1854d98bc963a9a82e0d9abef6bc3873.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd3ca7c4bf6698e7d72f6c2fb0eb59997336c294d604062ef495ee8e1f49931c
-size 1622872

--- a/drivers/1aa56b885cc8dcb37e0165fb6774acf3.bin
+++ b/drivers/1aa56b885cc8dcb37e0165fb6774acf3.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b334e6b147104306dd91f77e900c07383c0ddff77c2979ec79ea5d92944c13d
-size 1385800

--- a/drivers/1bdc36814a6f20464e94616f0d98a521.bin
+++ b/drivers/1bdc36814a6f20464e94616f0d98a521.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:17864e719e9c61d84e29a3cedf2b63aeaecfc10867211efc3077dd216b0a4965
-size 1268300

--- a/drivers/1c9670b5add3e4d6aa442a53427f422a.bin
+++ b/drivers/1c9670b5add3e4d6aa442a53427f422a.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3d65e174d47d3772cb431ea599bba76b8670bfaa51081895796432e2ef6461f
-size 75520

--- a/drivers/1ee7ccaae6df60e3e850ae6c4a3b7478.bin
+++ b/drivers/1ee7ccaae6df60e3e850ae6c4a3b7478.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:566ae5fb2f355b2c03ecbbab4770e92856b0d1c3d659fe0c11263f1a5f8d7086
-size 1358680

--- a/drivers/1feeb7cf14b7809b43c9044ff910afd2.bin
+++ b/drivers/1feeb7cf14b7809b43c9044ff910afd2.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:45ec69179be0f20088f10be909fc8b6104f85607db0a556482fee9384eb4d52b
-size 1280786

--- a/drivers/22534ca115844f647fd2698572201490.bin
+++ b/drivers/22534ca115844f647fd2698572201490.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24d6b301a1268ba8b373275981538855205eb0115609800f2b5b95377483b108
-size 1290704

--- a/drivers/22f93e6ecea58e543fcffa73f5c466b3.bin
+++ b/drivers/22f93e6ecea58e543fcffa73f5c466b3.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ff9f39869baafa17592820f7f5cf101b15a8423831abfa97c89cf193cdd98e89
-size 1065240

--- a/drivers/24a7545dc37bc7d366b05c68752af476.bin
+++ b/drivers/24a7545dc37bc7d366b05c68752af476.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b6e59284750fc0e6fac4d6c2a46100e9b0dde54e000b7327edd4a4dced9e9a0
-size 1197192

--- a/drivers/28196e29d41524919202b6bd1e38f35c.bin
+++ b/drivers/28196e29d41524919202b6bd1e38f35c.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f4c53c0b054413691ba25a2d162bcde9c9e35b5e706272f70bff96ed5c05a7b8
-size 1078088

--- a/drivers/28e6701303a90a81dea61addc9d06329.bin
+++ b/drivers/28e6701303a90a81dea61addc9d06329.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2f871712447dde7c3552f5aa90a2292821c6f32d92788e00dee8566f8d4de209
-size 965872

--- a/drivers/2eb1ef37d6d0425c505df369802d5d54.bin
+++ b/drivers/2eb1ef37d6d0425c505df369802d5d54.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e14396bca7712b13a5f0b209c8633d754afc3bf577b42ef78304581ddd4e02f
-size 1120488

--- a/drivers/3560dd8322a15d0e23d3747e32a04ebc.bin
+++ b/drivers/3560dd8322a15d0e23d3747e32a04ebc.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c6f0f7062aca9c286fb921917747c8b65ff4a69eb71102b90c1570b4c521fea
-size 1629528

--- a/drivers/36218d733c0afdd2d6dce6f616335a2f.bin
+++ b/drivers/36218d733c0afdd2d6dce6f616335a2f.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ed1b0fae1a6e705d1b116d08b7184e0a2ee2a0e6b0c372ce69b40e9ef34579f
-size 489168

--- a/drivers/37d03ef09bf90e11e07eed536a7fed7e.bin
+++ b/drivers/37d03ef09bf90e11e07eed536a7fed7e.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b7313be4901f1a80f84e4e8a6636f090e7125b97fc845d4454d5e4bef3d40ca7
-size 1373944

--- a/drivers/3827b6fa1f4022001328be9d79e33b18.bin
+++ b/drivers/3827b6fa1f4022001328be9d79e33b18.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3927727eb2435b28d2cf0ce1757e72ce3e92a86362b87120040c744c1c08bce9
-size 1644320

--- a/drivers/390218e8b12b9b5a8985baf49e163930.bin
+++ b/drivers/390218e8b12b9b5a8985baf49e163930.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e99607b20d537497169c506c6893243d3f1bd5960505c1566bd97c0a741adfb
-size 1205224

--- a/drivers/3aaa631aa80579a7ec4606f002de3436.bin
+++ b/drivers/3aaa631aa80579a7ec4606f002de3436.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d038eec123e1e13ab3ad27534de697c9779e9c27c62575f06771f80d3cbb7148
-size 1642768

--- a/drivers/3f5b9c90792efc13debd32233440ad32.bin
+++ b/drivers/3f5b9c90792efc13debd32233440ad32.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:537b428a0ad622765010c4405c1603ff464fcbb24ae4c2fbf559a10b8ea4593d
-size 1202928

--- a/drivers/41218ac4af41772dbaa3d4738e0c2bf3.bin
+++ b/drivers/41218ac4af41772dbaa3d4738e0c2bf3.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aef3e0a113345c1adca2d627c5853a11ddfc4e0e07fd28c10049a9b766c0fbc5
-size 1169528

--- a/drivers/45a7c3cf799b58b886c0b4c7f6f71d32.bin
+++ b/drivers/45a7c3cf799b58b886c0b4c7f6f71d32.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55a5bb13e3a985e0ab011e69b41704319de0843f9254cf91ed2964c13af345fe
-size 976224

--- a/drivers/4a7dcdd069fcdf8d7319ea5e135403fb.bin
+++ b/drivers/4a7dcdd069fcdf8d7319ea5e135403fb.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ac2943abf5ef953b939247b74331fb2c437e405a81dd5569d9cff1d6183d53a
-size 1417216

--- a/drivers/53663cb5fea6bde711171523a2206e45.bin
+++ b/drivers/53663cb5fea6bde711171523a2206e45.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:899afe09e356003605b30dc209a5ba4ef6910baef23fac268bcac6db3cfee98d
-size 1302312

--- a/drivers/5624304dd2172b7edb81741a5e7d2d06.bin
+++ b/drivers/5624304dd2172b7edb81741a5e7d2d06.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e93c368f8177bc0fe1a09d79b897a94286f3c374a18a40522c3358cb627d7e2
-size 1619800

--- a/drivers/5692b49c53b4401e76a43c82d7d496de.bin
+++ b/drivers/5692b49c53b4401e76a43c82d7d496de.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53af0ddbd3c4d33bd003403d8c9b41877e07770d3e789c781e5897858585e299
-size 1604952

--- a/drivers/5917ac93685b816492c5476071db3871.bin
+++ b/drivers/5917ac93685b816492c5476071db3871.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e79e3d0580d244c2fc2179a4f08cb80f945ad33d8c4c325de4e35e0d41584c5
-size 1101552

--- a/drivers/5cdb3b41abea2f625c0a632f4ad2cddb.bin
+++ b/drivers/5cdb3b41abea2f625c0a632f4ad2cddb.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f9398592553ee138d8db48b95789eca19324b8408cafd0f0bc46d030e7b4fd4
-size 1423088

--- a/drivers/6514d19c16df6d0d9cf75bba91350dcc.bin
+++ b/drivers/6514d19c16df6d0d9cf75bba91350dcc.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3bc9ed257486b68fac5899eaa19732a1340d06c8baf4b0ff53c7f5c052e6470f
-size 1616728

--- a/drivers/658f77c25877b5ceb68bc7e046d37ec3.bin
+++ b/drivers/658f77c25877b5ceb68bc7e046d37ec3.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d92b8ac828b827e4e5b9e9aeb02676783cdb1884f42194823769ccf033a7b9c5
-size 1290928

--- a/drivers/65e619f026af74b9c47c2cc77346ec40.bin
+++ b/drivers/65e619f026af74b9c47c2cc77346ec40.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fef56f20ef6e5065ed0fde1d85fd19f1f07212403489fd1e2b63aa41f5dc600b
-size 1358168

--- a/drivers/670eb63cbc05c4a4fa62f3c63d5b5f0a.bin
+++ b/drivers/670eb63cbc05c4a4fa62f3c63d5b5f0a.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:132d59d83c29be7351d35c44b846dfc3f37b3c62bc40eac6aec3fd68e7cfcfde
-size 1386824

--- a/drivers/69a56b18be5865ccda9ab3a5bb4987ab.bin
+++ b/drivers/69a56b18be5865ccda9ab3a5bb4987ab.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a9f6c38c2608d6f36f246e74a9fd17e915c89e54eafa2281b8ace86133df22b3
-size 958400

--- a/drivers/69b63c494c676d3a1013a775b18568e8.bin
+++ b/drivers/69b63c494c676d3a1013a775b18568e8.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:953a7719b50073e701730fcff79b2fee7054c72c54d1f0b0f2571d3ce7fdb925
-size 1035552

--- a/drivers/6b65628a2e6b0cf6bd54965da59a8b43.bin
+++ b/drivers/6b65628a2e6b0cf6bd54965da59a8b43.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dbeb49f986ec6618e7c256d3db4e3d5378a6ee3439c5949ae57e12722a73a198
-size 770920

--- a/drivers/6c1910730f135cbd5a78e3a48520e647.bin
+++ b/drivers/6c1910730f135cbd5a78e3a48520e647.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77e2945b3a2b0d14e9943f90ddd7bb87dde9cc5d8be09f9693e9f4166769363d
-size 1643312

--- a/drivers/6d83b980fd7541fbe793a891b95d5621.bin
+++ b/drivers/6d83b980fd7541fbe793a891b95d5621.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d57f40a0e9018765cd79393a0d57d8e6d6d880d93b95fa57cedbda5a0b4a1ae3
-size 1301312

--- a/drivers/7661abbf92a68466a3562ec887365e6a.bin
+++ b/drivers/7661abbf92a68466a3562ec887365e6a.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4b2bd93b32de4be7235c95c97af98e12bed5f0602b7b428700f9a1348cb2f731
-size 1157984

--- a/drivers/77164588c1c1207395ca4a64dca19f85.bin
+++ b/drivers/77164588c1c1207395ca4a64dca19f85.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e918f170a796b4b0b1400bb9bdae75be1cf86705c2d0fc8fb9dd0c5016b933b
-size 770672

--- a/drivers/77fefa9f6ac9273ee5edb4d19e87d348.bin
+++ b/drivers/77fefa9f6ac9273ee5edb4d19e87d348.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:03c8c9956938147bcc81a19e580ca8b5214e82829ec0494c22b0f59013ca22b2
-size 963416

--- a/drivers/7c2bf377d0edb86f010d202d48024145.bin
+++ b/drivers/7c2bf377d0edb86f010d202d48024145.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ec89ddd37880430cd5242f5f15d13f4cf699f50dbe04643e5b70093631608204
-size 1354472

--- a/drivers/7de3ac2823e2f7c241f2b181a8417647.bin
+++ b/drivers/7de3ac2823e2f7c241f2b181a8417647.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c7d9dab91b726dea5abaa893d8f60bd4795f489894044dc56a9d3aad9cc49740
-size 975688

--- a/drivers/7e05f116825f8e60072443b813e6192e.bin
+++ b/drivers/7e05f116825f8e60072443b813e6192e.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:09f2e41661cbbd714d22986fbb36a2b5764a5544c85f9875d227f6a26e1c8c8b
-size 370904

--- a/drivers/7f0de7a661590f1c33de0b80676e8827.bin
+++ b/drivers/7f0de7a661590f1c33de0b80676e8827.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1af02fca7522c8d27e053544b3b653ff2daffcae9c420e460235dacab53f7cd
-size 1361248

--- a/drivers/7f5843d48a960315b047e5231470e1b6.bin
+++ b/drivers/7f5843d48a960315b047e5231470e1b6.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81199ecb7a384d04f4e0f5541af731ca6ab0a04f1e2d692b4c386e0f02f15009
-size 1120488

--- a/drivers/8000831e91c318757fa911d4c879dc02.bin
+++ b/drivers/8000831e91c318757fa911d4c879dc02.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59e4fa86b1c3bb7df3cdb79a17ec36af9ad12e153172f6d8e662fcfb9dbb37d5
-size 1648968

--- a/drivers/8273287f52ffff4624121d2926ef9df4.bin
+++ b/drivers/8273287f52ffff4624121d2926ef9df4.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:599a102b6445fa88392b8c85a31d80ece950624219d846affbfb7131d4bf550b
-size 1322936

--- a/drivers/83e596b8944ed413e5bbc0c51c0b64c6.bin
+++ b/drivers/83e596b8944ed413e5bbc0c51c0b64c6.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:165a5dcdea3a7de7cfae38298597445eba59282308c7243be50f568aa610f4f2
-size 1364320

--- a/drivers/8572a7c437a9bc92225906ce5fc04497.bin
+++ b/drivers/8572a7c437a9bc92225906ce5fc04497.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc5c7db3068d99d6271fb38ab15b78c633c92249c4d783db0cdae2b918e97969
-size 1322520

--- a/drivers/86f6426a9b47dc73eb8c8bafbb46799f.bin
+++ b/drivers/86f6426a9b47dc73eb8c8bafbb46799f.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00550ccee4edfefd7b7fb54864d0aa5df059885e9e79ff80d4fb134b4487c05d
-size 1617240

--- a/drivers/8712d45e1ae024cb45067ad5918e12da.bin
+++ b/drivers/8712d45e1ae024cb45067ad5918e12da.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:702a10fa1541869f455143ed00425e4e9b2d533c3b639259bde6aac97eca15ed
-size 1347031

--- a/drivers/87ae10260e4ba99762c952c6b1781476.bin
+++ b/drivers/87ae10260e4ba99762c952c6b1781476.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b06dc8f3de1e7e5a53dc7ad0f8028f78a843df54884b4a92bcec21071f0e649b
-size 1371288

--- a/drivers/87b6d22295a16073d8d456fc574441a8.bin
+++ b/drivers/87b6d22295a16073d8d456fc574441a8.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:783d088ce72996a064c0da796579475e0aef23c5e6e0e5905c98571bf8620e20
-size 1354480

--- a/drivers/87e606dee08705c7ac75737a83a6e063.bin
+++ b/drivers/87e606dee08705c7ac75737a83a6e063.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a6f1c13eefcba07c0fc8aa0b70ab6fe2bc709a9eaf83090b735fec8e0dd576b
-size 975536

--- a/drivers/89805fbe6421f1d03023514f8fd7215d.bin
+++ b/drivers/89805fbe6421f1d03023514f8fd7215d.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:561d28e0888cdb0a8fce41754742aa8eb1bf5c8dd4eacbf9af0f40e0d36013c2
-size 1196384

--- a/drivers/89c04150c5f5b596236e04ccf5ef6a2f.bin
+++ b/drivers/89c04150c5f5b596236e04ccf5ef6a2f.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e50f1f1e9fb9198e5b094773d1d0068cc1cb1987d06583abaca20adc1f8932a9
-size 1378792

--- a/drivers/8d9e858d7fc95bfcc3690f3bddfac320.bin
+++ b/drivers/8d9e858d7fc95bfcc3690f3bddfac320.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b753bd95ae643b2543f501533ca54db34ddc9d20f336358067a7069240a6214
-size 1079624

--- a/drivers/92f1d7fd78d0353c62e5dc8e81f558e2.bin
+++ b/drivers/92f1d7fd78d0353c62e5dc8e81f558e2.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06edb9f17a9007c8b6db6ee2fc240e88e238f06c7c983f987cd9be1b80010d04
-size 1203584

--- a/drivers/958ceee3668f4eff01fb29d03518b49e.bin
+++ b/drivers/958ceee3668f4eff01fb29d03518b49e.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe26e6c2bc5ac4357e6657624180ca1e946d6dabe79cdb098d7b8b4e440851aa
-size 1629536

--- a/drivers/9618221803e2befd17607ef2d957442f.bin
+++ b/drivers/9618221803e2befd17607ef2d957442f.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:990a4dd8c86392421d680fa039af4e88d1ebdc97f61a73f8347d6b314fe8cd51
-size 1655624

--- a/drivers/9671f8d6de959b9d084f2a67f6dfadf3.bin
+++ b/drivers/9671f8d6de959b9d084f2a67f6dfadf3.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c430c719c9053a74d74dcc5e52b40d10f109db1dc9458a05a7a413b86a93467
-size 1161359

--- a/drivers/9962f9fb820e5d7f5a31b86b9d164d33.bin
+++ b/drivers/9962f9fb820e5d7f5a31b86b9d164d33.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f6208932ed98aa64f5ec0d9f59138d4c1dddbd82437315aac4aa913e5d4f825e
-size 1655624

--- a/drivers/9a3221899f456225679f8e54739100ac.bin
+++ b/drivers/9a3221899f456225679f8e54739100ac.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd69741dcd1bc0d9ab8a02c2a7ee8d466a58613562536aa8aab5ea260bbdf9c3
-size 1622872

--- a/drivers/9a795b1affc7cb4650bbd99b9a2cd819.bin
+++ b/drivers/9a795b1affc7cb4650bbd99b9a2cd819.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0dd832075d552da3d29b1ef471fc23b47c0d54b9fd1541935b23f1c5813da08c
-size 1367784

--- a/drivers/9bdc83ad343e8745e1f3d55c36cf2df6.bin
+++ b/drivers/9bdc83ad343e8745e1f3d55c36cf2df6.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:84e680f95cd31db85663a5482a68778dd236503d88e8a6d8e3c4a6c9ba201102
-size 1333030

--- a/drivers/9c77b23f662f4c5cf1da2ec62ba6fd2c.bin
+++ b/drivers/9c77b23f662f4c5cf1da2ec62ba6fd2c.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5f3952cba19c9f225aae8b57e57c7e20505ac617aeca845a8b5cde4994405c92
-size 1120488

--- a/drivers/9c9e2e8f49820dbed91f5cae846bbadb.bin
+++ b/drivers/9c9e2e8f49820dbed91f5cae846bbadb.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8844d9b3aea1568a7ff298e6dc12564c422dafae6510db377454ca6072861dde
-size 1324782

--- a/drivers/9caa5988ee5678dad93374ef1f4fd184.bin
+++ b/drivers/9caa5988ee5678dad93374ef1f4fd184.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:79baff384ed507030cbe328a3d6c04d13e77932f08d387f76cf2422fb3b2588b
-size 749288

--- a/drivers/9ea079774ed23df340ecc523ddf68045.bin
+++ b/drivers/9ea079774ed23df340ecc523ddf68045.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71083eb4f247ac78f52aa09f81054396a0dac1064e1191b5b56a43a6976c5c74
-size 1648968

--- a/drivers/a168299b9ced4e289f438408b6a047b6.bin
+++ b/drivers/a168299b9ced4e289f438408b6a047b6.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:90ea447ccfdcd9771de40de9721d0256d6d8a30d68963e82485c2e92b7eb5257
-size 1126752

--- a/drivers/a1a05331029aa3aa0fd396897cb46e8a.bin
+++ b/drivers/a1a05331029aa3aa0fd396897cb46e8a.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e5eb8d0bebf089a974bc0ca85d33d73f9a0bf72ed2a5e3a62a0387b51d509ce
-size 1283104

--- a/drivers/a1b9b882d3990b8465c7010a406ecd99.bin
+++ b/drivers/a1b9b882d3990b8465c7010a406ecd99.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:754952ff4187789c0269982d056f6a863409963f46d870c0a8d054e0fe69857b
-size 918872

--- a/drivers/a27c33dada320aff0672ce32f953ffbc.bin
+++ b/drivers/a27c33dada320aff0672ce32f953ffbc.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9be93e365a8240a03b05db26684b708b46d7585be325a3e22170cd5b324e0cb0
-size 1188115

--- a/drivers/a442859fd33fbf61ed0ea28bbf33bdbb.bin
+++ b/drivers/a442859fd33fbf61ed0ea28bbf33bdbb.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9f47991e981394076050cb8b5cddfcbf9fb01b6d7272b9079082e20e4875cc8
-size 1642776

--- a/drivers/a7077726554ee791e5a4b6e20ba8d557.bin
+++ b/drivers/a7077726554ee791e5a4b6e20ba8d557.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3fda721bc5007eab23af6e0c56a6942a7925a858f0d801fbb21011ccf758893b
-size 1604952

--- a/drivers/aa8eae148f6ac90c370eb50c88b974e1.bin
+++ b/drivers/aa8eae148f6ac90c370eb50c88b974e1.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a120f42de7b5bfcb55c40afc857b6baf4d1ac60725500c27a5b2942bda970ccf
-size 1387744

--- a/drivers/aad10724a4a2b676a69459a61124efec.bin
+++ b/drivers/aad10724a4a2b676a69459a61124efec.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:25933d1597ead1c390abc59433aec7c8f955c588551024c88c6388afbc84ed40
-size 1619800

--- a/drivers/abd377408acc02ee7f2f16320ee9b49a.bin
+++ b/drivers/abd377408acc02ee7f2f16320ee9b49a.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:475552c7476ad45e42344eee8b30d44c264d200ac2468428aa86fc8795fb6e34
-size 1293304

--- a/drivers/aed4e671b03d6e093a423c7593d423c0.bin
+++ b/drivers/aed4e671b03d6e093a423c7593d423c0.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5156a8ae596c06692aef13ac6524c7f1e20d52e4ea0f5a5ad43a6874edcc5e1f
-size 1369648

--- a/drivers/b1aea18419d0643fb2e4d8f6da2ae461.bin
+++ b/drivers/b1aea18419d0643fb2e4d8f6da2ae461.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:56f9e50da4817b1de9d9291eb5f2bc63703ca3e6f4a8571bde28cf756e2c80ba
-size 961656

--- a/drivers/b93d4a486013424efe0fb34668b50b85.bin
+++ b/drivers/b93d4a486013424efe0fb34668b50b85.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f3e97e36ec05236dc378c544310a9685d57409b87020bee731d7ddbf90987c6
-size 1359704

--- a/drivers/bad97e7203aec2bd026403a7f70688b9.bin
+++ b/drivers/bad97e7203aec2bd026403a7f70688b9.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df216fa3f13f8f7472c9586da4d0a7cd11cd60a041f486a611a4667f1c3d2cc6
-size 1617240

--- a/drivers/bc5372019b75e9e8257a83a86bd0b33d.bin
+++ b/drivers/bc5372019b75e9e8257a83a86bd0b33d.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8310f47ba34eb1aca146a5bdb8b59138173e659fbeb57a4c89355d8c54930b6b
-size 963840

--- a/drivers/bc78920fd9f058973d63495f36203685.bin
+++ b/drivers/bc78920fd9f058973d63495f36203685.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db9643f6d78c6c5bdc29b041660174324639be8b3bc6e247c8c2026e68c4e618
-size 1120496

--- a/drivers/bf4168403960a0df177f58277f06250c.bin
+++ b/drivers/bf4168403960a0df177f58277f06250c.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:669353cc31e65f896a755db94a045d9dc1b4a24baba14fce11d623bdfacec78c
-size 1344344

--- a/drivers/c1feed742caf34c142f70956e0c1259b.bin
+++ b/drivers/c1feed742caf34c142f70956e0c1259b.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e35cc798f138406bdc5e793574f62fe3be4c7dd6424aa6825e6ec7b2a345b591
-size 1355608

--- a/drivers/c2d60556e72219f9d4dd063a6843aa37.bin
+++ b/drivers/c2d60556e72219f9d4dd063a6843aa37.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d809eddc88a14239e8a069fa71f81f3e4af4dc293f7575d71d597c80f8767816
-size 1290272

--- a/drivers/c3f1acb15ea4dd4002d43c5941d1a64e.bin
+++ b/drivers/c3f1acb15ea4dd4002d43c5941d1a64e.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d23947c39680b9fcf22b092b97c9d38edcc02f7ad13d3a925d1ee0b62797e73
-size 1675264

--- a/drivers/c453084032024e3b2dcd648c9406e760.bin
+++ b/drivers/c453084032024e3b2dcd648c9406e760.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb5eebcd4100593a1b2890267037b7701c83f32c284b99908ff1c34d5693bfc2
-size 1202952

--- a/drivers/c6697cdbcf51cc54053438e644243327.bin
+++ b/drivers/c6697cdbcf51cc54053438e644243327.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1eadf7bf5fde916884a4beb82dd68ba50be05413f00aae8571190a2eaa462640
-size 1374992

--- a/drivers/c73ed000259378b96a9c57c588fc6ef0.bin
+++ b/drivers/c73ed000259378b96a9c57c588fc6ef0.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a1111555bfde8807746c8af73deceb4bdadc52dee87004e2ad7239c038687985
-size 1167480

--- a/drivers/c748cde9827385f9832a4f0ab1f02550.bin
+++ b/drivers/c748cde9827385f9832a4f0ab1f02550.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:338b89190177e950151a198823fd9d5f4ea25c1faf73e56ca5d9cf69d373fd66
-size 1211224

--- a/drivers/c77a847cc9c46de840d61ec8e3453f29.bin
+++ b/drivers/c77a847cc9c46de840d61ec8e3453f29.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a80b37c9749d6f2c2fdf64922a3142eb0fd63c72fd2989d7e75dcb4be367299a
-size 1065120

--- a/drivers/c815c638cba6bdc82a6b4f72204ed252.bin
+++ b/drivers/c815c638cba6bdc82a6b4f72204ed252.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:64604ea91f31b815bd0219d56563b9c2d307fc6c71ecc38d498221e0e0e9c4ad
-size 1649992

--- a/drivers/c831903e223d70526791119b52eaa4df.bin
+++ b/drivers/c831903e223d70526791119b52eaa4df.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86e5b25aa8072895e72e3d5f4beaccc1488a434fb10babe17fb9010da4ed93bc
-size 761704

--- a/drivers/c86257e19730c49e2abfbdf19e322c49.bin
+++ b/drivers/c86257e19730c49e2abfbdf19e322c49.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f88e92940985413acd440daa20c08df99c54613636826d9d95b898d39c44b19b
-size 1358624

--- a/drivers/c9b413ac0a31f9eb0a141e05654d1d52.bin
+++ b/drivers/c9b413ac0a31f9eb0a141e05654d1d52.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ac22c4ad2e62a3a8369a311b69e9b3dd558359cb44de8115e6bef2ae5e5e7151
-size 761184

--- a/drivers/c9d595c35045f8b200f9d3142cb3d683.bin
+++ b/drivers/c9d595c35045f8b200f9d3142cb3d683.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:545c8c806d6a8b2ab307bf7ff5dff05dd86cfc431d3920692e15e7928ac98eed
-size 1354472

--- a/drivers/ca747f0a7e1bcbc51cf4f9cd2a17f9a5.bin
+++ b/drivers/ca747f0a7e1bcbc51cf4f9cd2a17f9a5.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:777adc7e8a3e1422b3fc9c10ce31e996c057fe801a5292f0902bd5c5365e7287
-size 1371704

--- a/drivers/cd3a08a351a1e5286fdabeb5bbf371e7.bin
+++ b/drivers/cd3a08a351a1e5286fdabeb5bbf371e7.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2df05c41acc56d0f4c9371da62ec6cb311c9afb84b4a4d8c3738583ccc874d38
-size 1193184

--- a/drivers/cd78242cb85f016a3ea62002c8f07c0d.bin
+++ b/drivers/cd78242cb85f016a3ea62002c8f07c0d.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4628ec2698cfbca38d3bb4872df8e65a370ed4591e3fbd613a28b394942b8976
-size 1358168

--- a/drivers/cefe4b51ab58c74a20f0302fca66bd03.bin
+++ b/drivers/cefe4b51ab58c74a20f0302fca66bd03.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:88c2eac45b9480cc7e423558ba1b90097e8f12dbf98f4628c7a574c6371c6030
-size 754016

--- a/drivers/d0be4e86a7eaa87c849e3e137c3471dd.bin
+++ b/drivers/d0be4e86a7eaa87c849e3e137c3471dd.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df4e1cf6eaf602f99849ddb6802bd91fb13cd5c3f9fb420250d8a3d750642efa
-size 1285808

--- a/drivers/d407a4d3a9887218394aa73e94ffbde5.bin
+++ b/drivers/d407a4d3a9887218394aa73e94ffbde5.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d61099de8327efeff7e4aea81d9f3396a2218e6b22e15d05032a765897c0eba
-size 1379824

--- a/drivers/d55f2dc318b152d9d722021bf8376658.bin
+++ b/drivers/d55f2dc318b152d9d722021bf8376658.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f8e2a41c0444d7da76fc1682f3eb7e2a90140e1b68b413f4426bac357cbe14bb
-size 1190720

--- a/drivers/d6604f3caaa504ff3aedbade7d87fb97.bin
+++ b/drivers/d6604f3caaa504ff3aedbade7d87fb97.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f025a519dccf1df41951c22c6dc5cafa61e21b117e174b4983b45ccc22c6375f
-size 1375000

--- a/drivers/d984cf8612284adc59b3b73deccb777f.bin
+++ b/drivers/d984cf8612284adc59b3b73deccb777f.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24558c1cb417b6387e2406c70ff13f5438506e8d7560dd7b226499c872c8076f
-size 1211224

--- a/drivers/dbed1f7ed9e19e53bfc7f43122ce3d83.bin
+++ b/drivers/dbed1f7ed9e19e53bfc7f43122ce3d83.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6b0d030bb3e54294742b3914ae76c949e52a065abb28d08054fdf90d7eed628
-size 1354472

--- a/drivers/de3db6ac5d9d0d31d8668a74bc3332df.bin
+++ b/drivers/de3db6ac5d9d0d31d8668a74bc3332df.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1604f70608f964d1a835c3f3a421e58e449774f0291ff134ac298364e8e3f776
-size 1120488

--- a/drivers/e297beb49756fef9d2bcad4b860426b3.bin
+++ b/drivers/e297beb49756fef9d2bcad4b860426b3.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:62c6affbee1ba9a0435562db6e092a5018effeed0bd0f1d0494f34ce6cd403e9
-size 1205248

--- a/drivers/e2be3deb5a33615e127a7b2930bb544a.bin
+++ b/drivers/e2be3deb5a33615e127a7b2930bb544a.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b5dfe4f9e4ee68e3cdd9c91bcae26db334d49ae4c1f9525cecd834de48df110
-size 1285296

--- a/drivers/e2f5112aec3a2bdc5f267c18f8a6c071.bin
+++ b/drivers/e2f5112aec3a2bdc5f267c18f8a6c071.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c643c3cc182443893728101f5303aaa05b08ec8616310546edc903635c692b5e
-size 1654600

--- a/drivers/e7ae8ab50eae0f2730780d6e87a165cc.bin
+++ b/drivers/e7ae8ab50eae0f2730780d6e87a165cc.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:88582f3cae30afd77990944709ac4e272d68cdc009d9c3ff6f7c2e19e74f5975
-size 1353056

--- a/drivers/e8b4de749b80b47640ea86b06f56429f.bin
+++ b/drivers/e8b4de749b80b47640ea86b06f56429f.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:905c2df524e664759d55a6dad4b62b58220adc59fec3e852964efc2165b0fc0c
-size 1354472

--- a/drivers/eaaa74b1ac8f59f8610a8e898de54cf6.bin
+++ b/drivers/eaaa74b1ac8f59f8610a8e898de54cf6.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aa6f27b8b2ca5826f497362042c003b5e1d7ca22383d82730fbc5c45e048d839
-size 966072

--- a/drivers/ec46eab41a4c2ffd8c352d6e0dea430b.bin
+++ b/drivers/ec46eab41a4c2ffd8c352d6e0dea430b.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e0df7ce01e42a61228f4005fcdb9c42675ff7280a0be9ec1c32ad9d5e0493f10
-size 1647944

--- a/drivers/ece26d0686590a1ae0f950a412ed1a10.bin
+++ b/drivers/ece26d0686590a1ae0f950a412ed1a10.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:52febd655c84f4557de0ca35a236d468c03fa3bd0f51f54c31b37db29673da3f
-size 159632

--- a/drivers/ee4b2aa959df5211204c6165df138ecd.bin
+++ b/drivers/ee4b2aa959df5211204c6165df138ecd.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:67fe6b4b726451375e2dc3f87a0954cd01083fb4d8f4fb074bf699536450af04
-size 963616

--- a/drivers/f2c580ccd60898d4aa2676249d67c171.bin
+++ b/drivers/f2c580ccd60898d4aa2676249d67c171.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e6cb6a3dcbd85954e5123759461198af67658aa425a6186ffc9b57b772f9158f
-size 1210776

--- a/drivers/f383b5c1f0cb8806742c8df990bc7803.bin
+++ b/drivers/f383b5c1f0cb8806742c8df990bc7803.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8e8addb29426d845a0101c2c1f26c2e7fe8c78128ab04f16cfcb4e06461b0101
-size 1433600

--- a/drivers/f38a930c417139cd5ccfe3ff2277b4c7.bin
+++ b/drivers/f38a930c417139cd5ccfe3ff2277b4c7.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c4b5797189521611b809720ed9c4734f1dec8a2ee2597781ffe438f652a58ce5
-size 1200032

--- a/drivers/f3c14ba5c3670afacd47f0574922b98f.bin
+++ b/drivers/f3c14ba5c3670afacd47f0574922b98f.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5052ce3b96db73a909bf0e54355e357f8ab7284fa48f9b21c85efedbb886c100
-size 1641224

--- a/drivers/f512804db694f319cf51306dd2c2c618.bin
+++ b/drivers/f512804db694f319cf51306dd2c2c618.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f28c4f2fb32c10e5faed1debf7db6ae8c821bf286ffdb57a5b31fce0730e111
-size 1344344

--- a/drivers/f66d8bc26d38b7faaa1fbd4c4fdda3ff.bin
+++ b/drivers/f66d8bc26d38b7faaa1fbd4c4fdda3ff.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e443176d6a0621e65cadde51f4019ec7fb25e91fa87cbb6cbaf09d94e9e49918
-size 1357656

--- a/drivers/fbec641d8564e4e48784b2b07dd9c196.bin
+++ b/drivers/fbec641d8564e4e48784b2b07dd9c196.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee39a9a3fbde8b15ce4ac34519e248ea746a52ae0ae680da5b0c7ef919e583a3
-size 1367864

--- a/drivers/fcc89caed202cfa0f9d16b9e1c27d970.bin
+++ b/drivers/fcc89caed202cfa0f9d16b9e1c27d970.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d0eb15fe822c6239a8bb2b42fbc035d0956c72ac6fbd1429c1ab7f7e348b8f94
-size 135000

--- a/drivers/fe08109ce34ae68fed49348549b9ead1.bin
+++ b/drivers/fe08109ce34ae68fed49348549b9ead1.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8732eb8bd7240f17d90656424aabc0669c3d13e3117efc4805bb59dd21ceb1d
-size 1364312

--- a/drivers/ffa0df6d1cb927f4cde2741d63c7125b.bin
+++ b/drivers/ffa0df6d1cb927f4cde2741d63c7125b.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98acba206e9f3843a4a7e07c66ead4366fbe7976653b65ed0c311d4efae878ab
-size 580192


### PR DESCRIPTION
This PR deletes drivers that were added in https://github.com/magicsword-io/LOLDrivers/commit/81e81f87739638f96aeb47b1cc829d6a1d3d5d10 as part of the bootdrivers (before a dedicated website was created)