### PR TITLE
TPwSav.sys BYOVD

### DIFF
--- a/YML-Template.yml
+++ b/YML-Template.yml
@@ -9,7 +9,7 @@ Author: Your Name # Example: John Doe
 Created: 'YYYY-MM-DD' # Example: '2023-04-15'
 MitreID: TXXXX # Example: T1000
 CVE:
-    - N/A # Example: CVE-2023-20222
+    - CVE-XXXX-XXXX # Example: CVE-2023-20222
 Category: Category Name # Example: vulnerable driver
 Verified: 'TRUE or FALSE' # Example: 'TRUE'
 Commands:

--- a/YML-Template.yml
+++ b/YML-Template.yml
@@ -9,7 +9,7 @@ Author: Your Name # Example: John Doe
 Created: 'YYYY-MM-DD' # Example: '2023-04-15'
 MitreID: TXXXX # Example: T1000
 CVE:
-    - CVE-XXXX-XXXX # Example: CVE-2023-20222
+    - N/A # Example: CVE-2023-20222
 Category: Category Name # Example: vulnerable driver
 Verified: 'TRUE or FALSE' # Example: 'TRUE'
 Commands:

--- a/yaml/c0634ed7-840e-4a7e-8b34-33efe50405c2.yaml
+++ b/yaml/c0634ed7-840e-4a7e-8b34-33efe50405c2.yaml
@@ -13,7 +13,7 @@ Commands:
   Privileges: kernel
   OperatingSystem: Windows
 Resources:
-- Coming soon...
+- https://blackpointcyber.com/resources/blog/qilin-ransomware-and-the-hidden-dangers-of-byovd/
 Acknowledgement:
   Person: ''
   Handle: ''

--- a/yaml/c0634ed7-840e-4a7e-8b34-33efe50405c2.yaml
+++ b/yaml/c0634ed7-840e-4a7e-8b34-33efe50405c2.yaml
@@ -1,0 +1,37 @@
+Id: c0634ed7-840e-4a7e-8b34-33efe50405c2
+Author: Robel Campbell
+Created: '2025-01-31'
+MitreID: T1068
+Category: vulnerable driver
+Verified: 'TRUE'
+Commands:
+  Command: sc.exe create TPwSav.sys binPath=C:\windows\temp\TPwSav.sys type=kernel
+    && sc.exe start TPwSav.sys
+  Description: A driver associated with Toshiba laptops power saving functionality
+    allows arbitary one byte reading and writing mapped physical addresses. Blackpoint Cyber's SOC observed this driver being used as part of a custom EDRSandblast malware to blind EDR prior to Qilin ransomware deployment.
+  Usecase: Elevate privileges, Blind EDR
+  Privileges: kernel
+  OperatingSystem: Windows
+Resources:
+- Coming soon...
+Acknowledgement:
+  Person: ''
+  Handle: ''
+Detection: []
+KnownVulnerableSamples:
+- Filename: 'TPwSav.sys'
+  MD5: b0caa4f3ac2841be683933a6af9bee0e
+  SHA1: c1130e09831c7a2e0cc8ba7335e702910b25f526
+  SHA256: 011df46e94218cbb2f0b8da13ab3cec397246fdc63436e58b1bf597550a647f6
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: ''
+  Description: ''
+  Product: ''
+  ProductVersion: ''
+  FileVersion: ''
+  MachineType: ''
+  OriginalFilename: ''
+Tags:
+- TPwSav.sys


### PR DESCRIPTION
Blackpoint Cyber's SOC observered a threat actor using a customized version of EDRSandblast with the driver TPwSav.sys. This driver is part of Toshiba laptops power saving functionality and allows arbitrary one byte reads and writes to mapped physical addresses. The driver does not require administrator priviledges to interact.

A blog with a detailed analysis on how the driver was abused to disable EDR will be released soon. 

VirusTotal: https://www.virustotal.com/gui/file/011df46e94218cbb2f0b8da13ab3cec397246fdc63436e58b1bf597550a647f6/details