### PR TITLE
Added new vulnerable samples for IoBitUnlocker, Zemana and TfSysMon

### DIFF
--- a/drivers/85def55323cfc4a04a270127a20f4d2c.bin
+++ b/drivers/85def55323cfc4a04a270127a20f4d2c.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ba404c50684d59b701959a1732617dec6a6a25c8005294c0d2b3822b38479a4
+size 39000

--- a/drivers/a87587ee2f2281297f24bbd96902faa5.bin
+++ b/drivers/a87587ee2f2281297f24bbd96902faa5.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:078e7fb479ad6f0734682d41a17d41518de35bf4f6c5c212643b7d37e641041e
+size 223328

--- a/drivers/b4eaacce30f51eaf2a36cea680b45a66.bin
+++ b/drivers/b4eaacce30f51eaf2a36cea680b45a66.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15e84d040c2756b2d1b6c3f99d5a1079dc8854844d3c24d740fafd8c668e5fb9
+size 63640

--- a/yaml/bd9f084e-b235-4978-bf2a-5f1dc02937df.yaml
+++ b/yaml/bd9f084e-b235-4978-bf2a-5f1dc02937df.yaml
@@ -252,3 +252,188 @@ KnownVulnerableSamples:
                 Signing 2004 CA
             Version: 1
     LoadsDespiteHVCI: 'FALSE'
+- Filename: amdi2c.sys
+  SHA256: 15e84d040c2756b2d1b6c3f99d5a1079dc8854844d3c24d740fafd8c668e5fb9
+  MD5: b4eaacce30f51eaf2a36cea680b45a66
+  SHA1: 94493d7739c5ee7346da31d9523404d62682b195
+  Imphash: 9e7c36ff0dc8862002283773ace05f9e
+  Authentihash:
+    MD5: 5dc807d139dd6bfaa485cc32b65c5677
+    SHA1: 47e517f8a5cf5259f3a35c7c4000d4cf07f288d5
+    SHA256: 37d07c39dc10ae82a9d292c74f7c5f93c7bc133a0225402dafc21f664af079b6
+  RichPEHeaderHash:
+    MD5: 7401835ee57bfad89c8355b1bd87ef20
+    SHA1: 5467c4177559d5b83ce52dd4c8f1366c7ad5ca20
+    SHA256: b40447d856fa680f34064911a1f0285f58dac4ec40e90b306c546ce11615a005
+  Sections:
+    .text:
+      Entropy: 6.326690300828168
+      Virtual Size: '0xa0b8'
+    .rdata:
+      Entropy: 5.328583885941854
+      Virtual Size: '0xca0'
+    .data:
+      Entropy: 0.6238885848006501
+      Virtual Size: '0x7e0'
+    .pdata:
+      Entropy: 4.439637717036265
+      Virtual Size: '0x480'
+    INIT:
+      Entropy: 5.125170195862426
+      Virtual Size: '0xcc4'
+    .rsrc:
+      Entropy: 3.309535713036311
+      Virtual Size: '0x3a8'
+    .reloc:
+      Entropy: 1.2636865525783176
+      Virtual Size: '0x30'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2010-02-01 20:16:19'
+  Description: AMD I2C Controller Driver
+  Company: Advanced Micro Devices, Inc
+  InternalName: amdi2c.sys
+  OriginalFilename: amdi2c.sys
+  FileVersion: 1.2.0.124
+  Product: AMD I2C Controller Driver
+  ProductVersion: 1.2.0.124
+  Copyright: "Copyright \xA9 2014-2023 Advanced Micro Devices, Inc"
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ExAllocatePoolWithTag
+  - ExFreePoolWithTag
+  - PsLookupProcessByProcessId
+  - RtlDowncaseUnicodeString
+  - RtlInitUnicodeString
+  - KeSetEvent
+  - MmGetSystemRoutineAddress
+  - KeInitializeEvent
+  - ZwQuerySystemInformation
+  - KeReleaseSpinLock
+  - KeUnstackDetachProcess
+  - KeInitializeTimer
+  - PsCreateSystemThread
+  - DbgBreakPoint
+  - ZwQueryValueKey
+  - ExAllocatePool
+  - ExInterlockedInsertTailList
+  - PsTerminateSystemThread
+  - KeQueryTimeIncrement
+  - ZwClose
+  - ObReferenceObjectByHandle
+  - KeWaitForSingleObject
+  - KeSetTimer
+  - PsGetVersion
+  - ExInterlockedRemoveHeadList
+  - ZwQueryInformationProcess
+  - PsGetCurrentProcessId
+  - ObfDereferenceObject
+  - KeCancelTimer
+  - ZwQueryInformationFile
+  - KeWaitForMultipleObjects
+  - RtlUpcaseUnicodeChar
+  - ObOpenObjectByPointer
+  - KeStackAttachProcess
+  - PsLookupThreadByThreadId
+  - ZwAllocateVirtualMemory
+  - ZwOpenKey
+  - KeAcquireSpinLockRaiseToDpc
+  - ExReleaseFastMutex
+  - RtlAnsiStringToUnicodeString
+  - ExAcquireFastMutex
+  - PsSetLoadImageNotifyRoutine
+  - IoFreeWorkItem
+  - RtlInitAnsiString
+  - PsSetCreateThreadNotifyRoutine
+  - RtlUnicodeStringToAnsiString
+  - PsSetCreateProcessNotifyRoutine
+  - RtlEqualUnicodeString
+  - RtlFreeUnicodeString
+  - IoAllocateWorkItem
+  - ZwOpenProcess
+  - RtlCompareMemory
+  - FsRtlDissectName
+  - PsGetCurrentThreadId
+  - IoQueueWorkItem
+  - ExAcquireResourceExclusiveLite
+  - KeLeaveCriticalRegion
+  - RtlAppendUnicodeToString
+  - ZwDeleteValueKey
+  - ZwSetValueKey
+  - RtlDeleteNoSplay
+  - KeEnterCriticalRegion
+  - ObQueryNameString
+  - ExReleaseResourceLite
+  - ZwEnumerateValueKey
+  - RtlAppendUnicodeStringToString
+  - RtlCompareUnicodeString
+  - RtlCopyUnicodeString
+  - ExInitializeResourceLite
+  - ZwDeleteKey
+  - RtlSplay
+  - ZwEnumerateKey
+  - ZwQueryKey
+  - IoBuildDeviceIoControlRequest
+  - IoDeleteDevice
+  - IoGetDeviceObjectPointer
+  - InitSafeBootMode
+  - IofCompleteRequest
+  - IoGetRequestorProcessId
+  - IoCreateSymbolicLink
+  - MmIsAddressValid
+  - IoCreateDevice
+  - ZwTerminateProcess
+  - IofCallDriver
+  - ZwOpenThread
+  - RtlDeleteElementGenericTableAvl
+  - RtlInsertElementGenericTableAvl
+  - ZwReadFile
+  - RtlGetElementGenericTableAvl
+  - IoCreateFile
+  - RtlIsGenericTableEmptyAvl
+  - ExAcquireResourceSharedLite
+  - RtlInitializeGenericTableAvl
+  - RtlUnicodeStringToInteger
+  - RtlLookupElementGenericTableAvl
+  - RtlEnumerateGenericTableWithoutSplayingAvl
+  - KeBugCheckEx
+  - __C_specific_handler
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2024-10-10 19:04:53'
+      ValidTo: '2025-10-08 19:04:53'
+      Signature: 3870e583035a72db64856d80e17833cd3badd24f19abf9a3d7c7485743dd875f69102820df4992d74f8fba0529be4e16f4234910064a3a1863299a29b82d3fac869915a368ec0e5d0127282221bce84db444d2e9974dc2761a2080a7bc7508d7064f32b2d97b0263d0d937527a8af95f18bcb54ec21a453ba35e55869791416a2a8813fcf95e889e65158dbb5b4cba653c989179947d286051ef6b0d56f41da479db08c6b93c44fa5c8399e126594cc53dfa756180607a1dd29559061d828b0ce2c5a462245ed0995a196ad96223b6eb1a787b4d10b5a7d4e3a130750103bc9c713fc8f32015273bb238b15aae25e4765d7ab81c5d3df82ef6a7d3c2e7a61dab024ff02df6876a86ec7198aa6e28c8e69a015129a717b1036113911f0aeefa8d05081974d026196f24bc1e4ef942599fafbd1b2c316bda73237f1822296888df2344c92b08c363976beb7020242b3069e6691f19e715e1d1a19ddc03235263c9bb7b8390145af57603105ced358f394547e3be96718835917234eb7fd7134d9fb605656717ed6b15f0583068c84c6c01abf31cc1df1fe7c4d2935590e6017cf8cc5635e1cd7054240fd0059f168e90ec1a49f24e0f050034d99e4aa6599a64d280d00ea8af57d3125caddb342a0b2c160a2f95d97e6045e69dc1c1b3fa56dfd40380ce60536a59750edf0069dc7c27f8ccc8f073b46d169b8fed1fd40ac6f00c
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 330000006e1229856f0ade6cfc00000000006e
+      Version: 3
+      TBS:
+        MD5: 3066a9830894e57ce6e47f7a6b58b84f
+        SHA1: ce441ecd2f11e400515a85d5a592da38f950f3dc
+        SHA256: 3e30a731a3b620db0971ecd743ecd312bcdf14c82b9bdc9918102bacbf70520d
+        SHA384: 68c6537d64e3a4f02a2c1d04257c13ab1def23c9c54bafc434176be50a411a75c118c9f8edc81f97b8a1db2dc1d009e3
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      ValidFrom: '2014-10-15 20:31:27'
+      ValidTo: '2029-10-15 20:41:27'
+      Signature: 96b5c33b31f27b6ba11f59dd742c3764b1bca093f9f33347e9f95df21d89f4579ee33f10a3595018053b142941b6a70e5b81a2ccbd8442c1c4bed184c2c4bd0c8c47bcbd8886fb5a0896ae2c2fdfbf9366a32b20ca848a6945273f732332936a23e9fffdd918edceffbd6b41738d579cf8b46d499805e6a335a9f07e6e86c06ba8086725afc0998cdba7064d4093188ba959e69914b912178144ac57c3ae8eae947bcb3b8edd7ab4715bba2bc3c7d085234b371277a54a2f7f1ab763b94459ed9230cce47c099212111f52f51e0291a4d7d7e58f8047ff189b7fd19c0671dcf376197790d52a0fbc6c12c4c50c2066f50e2f5093d8cafb7fe556ed09d8a753b1c72a6978dcf05fe74b20b6af63b5e1b15c804e9c7aa91d4df72846782106954d32dd6042e4b61ac4f24636de357302c1b5e55fb92b59457a9243d7c4e963dd368f76c728caa8441be8321a66cde5485c4a0a602b469206609698dcd933d721777f886dac4772daa2466eab64682bd24e98fb35cc7fec3f136d11e5db77edc1c37e1f6a4a14f8b4a721c671866770cdd819a35d1fa09b9a7cc55d4d728e74077fa74d00fcdd682412772a557527cda92c1d8e7c19ee692c9f7425338208db38cc7cc74f6c3a6bc237117872fe55596460333e2edfc42de72cd7fb0a82256fb8d70c84a5e1c4746e2a95329ea0fecdb4188fd33bad32b2b19ab86d0543fbff0d0f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 330000000d690d5d7893d076df00000000000d
+      Version: 3
+      TBS:
+        MD5: 83f69422963f11c3c340b81712eef319
+        SHA1: 0c5e5f24590b53bc291e28583acb78e5adc95601
+        SHA256: d8be9e4d9074088ef818bc6f6fb64955e90378b2754155126feebbbd969cf0ae
+        SHA384: 260ad59ba706420f68ba212931153bd89f760c464b21be55fba9d014fff322407859d4ebfb78ea9a3330f60dc9821a63
+    Signer:
+    - SerialNumber: 330000006e1229856f0ade6cfc00000000006e
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      Version: 1

--- a/yaml/e368efc7-cf69-47ae-8204-f69dac000b22.yaml
+++ b/yaml/e368efc7-cf69-47ae-8204-f69dac000b22.yaml
@@ -3965,3 +3965,158 @@ KnownVulnerableSamples:
                 Class 3 SHA256 Code Signing CA
             Version: 1
     LoadsDespiteHVCI: 'FALSE'
+- Filename: IObitUnlocker.sys
+  SHA256: 2ba404c50684d59b701959a1732617dec6a6a25c8005294c0d2b3822b38479a4
+  MD5: 85def55323cfc4a04a270127a20f4d2c
+  SHA1: 0e6ef35f6f68be6d72e4a225494c02557d39cacc
+  Imphash: 1dcbb2cd7749f70f37329cb3e15406f8
+  Authentihash:
+    MD5: 155f7930fae72378e7efe52ba679b69a
+    SHA1: d389fa80da574506516aa49b70a8be946744edbc
+    SHA256: e35d11538406dd03ac93236be37c16b2da3ad1d38fb59b70b85c484804546b6d
+  RichPEHeaderHash:
+    MD5: 4bced431c6abb303e6bb74e69153fc03
+    SHA1: 3662ab731022d9217b1af69a69c114660492ba31
+    SHA256: 9a3bd07ed6821b4b33ef5c86f3e848d811b60341711a54c3ef6323c6868756f4
+  Sections:
+    .text:
+      Entropy: 6.175954592086079
+      Virtual Size: '0x5586'
+    .rdata:
+      Entropy: 4.78340156437448
+      Virtual Size: '0x5f4'
+    .data:
+      Entropy: 0.8079955727472564
+      Virtual Size: '0x170'
+    .pdata:
+      Entropy: 4.231501285963187
+      Virtual Size: '0x258'
+    INIT:
+      Entropy: 5.20589742734384
+      Virtual Size: '0x6d2'
+    .rsrc:
+      Entropy: 3.263395141973913
+      Virtual Size: '0x368'
+    .reloc:
+      Entropy: 1.2987909647818572
+      Virtual Size: '0x24'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2020-10-10 10:04:32'
+  Description: Unlocker Driver
+  Company: IObit Information Technology
+  InternalName: IObitUnlocker.sys
+  OriginalFilename: IObitUnlocker.sys
+  FileVersion: 1.2.0.2
+  Product: Unlocker
+  ProductVersion: 1.2.0.2
+  Copyright: "IObit Copyright \xA9 2005-2018"
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ExAllocatePoolWithTag
+  - IoDeleteSymbolicLink
+  - ExFreePoolWithTag
+  - IoDeleteDevice
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - IoCreateDevice
+  - _wcsnicmp
+  - ZwReadFile
+  - IoGetRelatedDeviceObject
+  - MmGetSystemRoutineAddress
+  - KeInitializeEvent
+  - ExInterlockedPopEntryList
+  - KeDelayExecutionThread
+  - IoFileObjectType
+  - ZwWaitForSingleObject
+  - ZwClose
+  - ObReferenceObjectByHandle
+  - KeWaitForSingleObject
+  - RtlCompareUnicodeString
+  - IoAllocateIrp
+  - ObfDereferenceObject
+  - ZwWriteFile
+  - DbgPrint
+  - IofCallDriver
+  - _wcsicmp
+  - PsGetProcessPeb
+  - PsLookupProcessByProcessId
+  - ZwQuerySymbolicLinkObject
+  - RtlInitUnicodeString
+  - KeSetEvent
+  - RtlAppendUnicodeToString
+  - IoCreateFile
+  - ZwQuerySystemInformation
+  - ZwOpenSymbolicLinkObject
+  - KeUnstackDetachProcess
+  - ObQueryNameString
+  - ZwCreateFile
+  - wcsrchr
+  - ZwQueryDirectoryFile
+  - _vsnwprintf
+  - RtlAppendUnicodeStringToString
+  - ZwDuplicateObject
+  - IoFreeIrp
+  - ZwOpenProcess
+  - PsGetCurrentProcessId
+  - MmIsAddressValid
+  - ZwTerminateProcess
+  - ZwQueryInformationFile
+  - ExInterlockedPushEntryList
+  - KeStackAttachProcess
+  - KeBugCheckEx
+  - __C_specific_handler
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert High Assurance
+        EV Root CA
+      ValidFrom: '2011-04-15 19:45:33'
+      ValidTo: '2021-04-15 19:55:33'
+      Signature: 208cc159ed6f9c6b2dc14a3e751d454c41501cbd80ead9b0928b062a133f53169e56396a8a63b6782479f57db8b947a10a96c2f6cbbda2669f06e1acd279090efd3cdcac020c70af3f1bec787ed4eb4b056026d973619121edb06863e09712ab6fa012edd99fd2da273cb3e456f9d1d4810f71bd427ca689dccdd5bd95a2abf193117de8ac3129a85d6670419dfc75c9d5b31a392ad08505508bac91cac493cb71a59da4946f580cfa6e20c40831b5859d7e81f9d23dca5b18856c0a86ec22091ba574344f7f28bc954aab1db698b05d09a477767eefa78e5d84f61824cbd16da6c3a19cc2107580ff9d32fde6cf433a82f7ce8fe1722a9b62b75fed951a395c2f946d48b7015f332fbbdc2d73348904420a1c8b79f9a3fa17effaa11a10dfe0b2c195eb5c0c05973b353e18884ddb6cbf24898dc8bdd89f7b393a24a0d5dfd1f34a1a97f6a66f7a1fb090a9b3ac013991d361b764f13e573803afce7ad2b590f5aedc3999d5b63c97eda6cb16c77d6b2a4c9094e64c54fd1ecd20ecce689c8758e96160beeb0ec9d5197d9fe978bd0eac2175078fa96ee08c6a2a6b9ce3e765bcbc2d3c6ddc04dc67453632af0481bca8006e614c95c55cd48e8e9f2fc13274bdbd11650307cdefb75e0257da86d41a2834af8849b2cfa5dd82566f68aa14e25954feffeaeeefea9270226081e32523c09fcc0f49b235aa58c33ac3d9169410
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 61204db4000000000027
+      Version: 3
+      TBS:
+        MD5: 8e3ffc222fbcebdbb8b23115ab259be7
+        SHA1: ee20bff28ffe13be731c294c90d6ded5aae0ec0e
+        SHA256: 59826b69bc8c28118c96323b627da59aaca0b142cc5d8bad25a8fcfd399aa821
+        SHA384: f2dab7e56a33298654924501499487f6ba72c7d9477476a186e1ed7a9be031fade0e35ac09eff5e56bbbab95ae5374e7
+    - Subject: ??=CN, ??=Sichuan, ??=Wuhou District, Chengdu, ??=Private Organization,
+        serialNumber=91510107072412418F, C=CN, ST=Sichuan, L=Chengdu, O=IObit CO.,
+        LTD, CN=IObit CO., LTD
+      ValidFrom: '2019-08-27 00:00:00'
+      ValidTo: '2022-08-30 12:00:00'
+      Signature: 89d53256ccf4b2e50a8e05d88de9ed33f6adde16e143a6f7f042ec4ed9220c7c4195b543ad1ae9c5ae5421f192140d62b28449c83a0c31759765c127fed77c447072976f2d5e8d44e07dafbbc5a0cea9e8020081c3f8a22a1519e53d8c69ff3ffbd7e090e92593a738b8bd6d583b27e5e797672294147fd1b8492683b1b3f202c3e0c571f9fad02d95f8204e054fa722ac42bf21e54ec1891942ab339f004ab57cb01838539bf5196fc1579e0add7c42206ff5e10bb0934b4a801fab12ed748a6a858af5c9601296ce6ca9b14b46f731a0485f49f142ab65dacb0103daaee13b2269f2c2b2d2bb2b04abe93642ecc988fa536170194acc1c73d48a781d3d5f0e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0d98f5df96c592c5b76bfde1cb823096
+      Version: 3
+      TBS:
+        MD5: d0ba095f2bdb679cea084b4106479484
+        SHA1: 80aba0ecbd2b71c84bc73ac42963bc9ce247a020
+        SHA256: a93f8b7111c3e2288e164e42131e2ad52867060479ade1f6e6b3124cde822cfa
+        SHA384: 8293c567ba382434adab5899693e47e5d6e06c0b9f3c158bf17675d5a1476627db51d00dc9573bf4b89412617e651ba6
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert EV Code Signing
+        CA
+      ValidFrom: '2012-04-18 12:00:00'
+      ValidTo: '2027-04-18 12:00:00'
+      Signature: 9e5b963a2e1288acab016da49f75e40187a3a532d7bcbaa97ea3d61417f7c2136b7c738f2b6ae50f265968b08e259b6ceffa6c939208c14dcf459e9c46d61e74a19b14a3fa012f4ab101e1724048111368b9369d914bd7c2391210c1c4dcbb6214142a615d4f387c661fc61bffadbe4f7f945b7343000f4d73b751cf0ef677c05bcd348cd96313aa0e6111d6f28e27fcb47bb8b91120918678ea0ed428ff2ad52438e837b2ec96bb9fbc4a1650e15ebf517d23a032c7c1949e7ac9c026a2cc2587a0127e749f2d8db1c8e784beb9d1e9debb6a4e887371e12238cb2487e9737e51b2ff98eb4e7e2fe0ca0efab35ed1ba0542a8489f83f63fc4caa8df68a05061
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 0dd0e3374ac95bdbfa6b434b2a48ec06
+      Version: 3
+      TBS:
+        MD5: f92649915476229b093c211c2b18e6c4
+        SHA1: 2d54c16a8f8b69ccdea48d0603c132f547a5cf75
+        SHA256: 2cd702a7dec30aa441345672e8992ef9770ce4946f276d767b45b0ed627658fb
+        SHA384: 511b0e0d7f3a48935cf2413348ff5f327887dc1e58f887bb5ed528d09f79173b55ab6439cf097fc7693b5749f7304ace
+    Signer:
+    - SerialNumber: 0d98f5df96c592c5b76bfde1cb823096
+      Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert EV Code Signing
+        CA
+      Version: 1

--- a/yaml/e5f12b82-8d07-474e-9587-8c7b3714d60c.yaml
+++ b/yaml/e5f12b82-8d07-474e-9587-8c7b3714d60c.yaml
@@ -3046,3 +3046,308 @@ KnownVulnerableSamples:
     CreationTimestamp: '2016-08-17 11:06:53'
     Imphash: 3edc60bda68569cac7ad7604728ff40d
     LoadsDespiteHVCI: 'TRUE'
+- Filename: tProtect.dll
+  SHA256: 078e7fb479ad6f0734682d41a17d41518de35bf4f6c5c212643b7d37e641041e
+  MD5: a87587ee2f2281297f24bbd96902faa5
+  SHA1: 63399ac91e92f0c92ffaeac43616e1b7c77a9791
+  Imphash: 3edc60bda68569cac7ad7604728ff40d
+  Authentihash:
+    MD5: 096b2f20901609e482340d5f8cbc79ac
+    SHA1: 1c6501199c9d759970a11cc41b9077a946c3c276
+    SHA256: 196c803aa8217eb8d2783ad9750cd27bbe540a449480c842cc128cc7a5a64f04
+  RichPEHeaderHash:
+    MD5: c0210f91c028886456549a7aa78f8147
+    SHA1: ea5478898d988d1bfa1287940ad74e5445f80a8d
+    SHA256: 820b53e3b20277040944a1286a3f401ca8fb24b4f93535dc570e2261632e2f26
+  Sections:
+    .text:
+      Entropy: 6.318212914980563
+      Virtual Size: '0x217b5'
+    .hook:
+      Entropy: 5.11599521430575
+      Virtual Size: '0x9af'
+    .rdata:
+      Entropy: 5.529476686216564
+      Virtual Size: '0x4744'
+    .data:
+      Entropy: 4.888903009535537
+      Virtual Size: '0x53c88'
+    .pdata:
+      Entropy: 5.138271966562841
+      Virtual Size: '0x8d0'
+    INIT:
+      Entropy: 5.334070329167121
+      Virtual Size: '0x1106'
+    .rsrc:
+      Entropy: 3.1311542715985277
+      Virtual Size: '0x25c'
+    .reloc:
+      Entropy: 4.064239284774715
+      Virtual Size: '0x60'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2016-08-17 19:06:53'
+  Description: ZAM
+  Company: Zmana Ltd.
+  InternalName: ''
+  OriginalFilename: ''
+  FileVersion: ''
+  Product: ZAM
+  ProductVersion: 2.21.63
+  Copyright: Zmana Ltd. All rights reserved.
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - FLTMGR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - FsRtlIsNameInExpression
+  - PsGetProcessImageFileName
+  - ZwQueryInformationProcess
+  - __C_specific_handler
+  - strchr
+  - RtlAppendUnicodeToString
+  - KeInitializeSemaphore
+  - KeReleaseSemaphore
+  - KeWaitForSingleObject
+  - KeAcquireSpinLockRaiseToDpc
+  - KeReleaseSpinLock
+  - PsCreateSystemThread
+  - PsTerminateSystemThread
+  - ZwQueryInformationFile
+  - ZwWriteFile
+  - PsGetCurrentThreadId
+  - ZwDeleteFile
+  - _vsnprintf
+  - PsThreadType
+  - PsSetCreateProcessNotifyRoutine
+  - PsGetProcessSessionId
+  - RtlAppendUnicodeStringToString
+  - ZwDeleteValueKey
+  - ZwSetValueKey
+  - towupper
+  - RtlIntegerToUnicodeString
+  - KeInitializeEvent
+  - KeSetEvent
+  - KeAcquireSpinLockAtDpcLevel
+  - KeReleaseSpinLockFromDpcLevel
+  - MmProbeAndLockPages
+  - IoAllocateIrp
+  - IoAllocateMdl
+  - IofCallDriver
+  - IoFreeIrp
+  - IoFreeMdl
+  - IoGetDeviceObjectPointer
+  - IoGetRelatedDeviceObject
+  - ObCloseHandle
+  - ObfReferenceObject
+  - ZwSetInformationFile
+  - ZwReadFile
+  - ZwOpenSymbolicLinkObject
+  - ZwQuerySymbolicLinkObject
+  - IoCreateFileSpecifyDeviceObjectHint
+  - IoGetDeviceAttachmentBaseRef
+  - FsRtlGetFileSize
+  - ObQueryNameString
+  - IoFileObjectType
+  - KeReadStateEvent
+  - ExQueueWorkItem
+  - ExGetPreviousMode
+  - MmGetSystemRoutineAddress
+  - NtOpenProcess
+  - ZwCreateEvent
+  - ZwWaitForSingleObject
+  - ZwSetEvent
+  - NtQuerySystemInformation
+  - ExEventObjectType
+  - NtBuildNumber
+  - ZwDeleteKey
+  - ObReferenceObjectByName
+  - IoDriverObjectType
+  - MmIsDriverVerifying
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - RtlSetDaclSecurityDescriptor
+  - MmMapLockedPagesSpecifyCache
+  - PsGetProcessId
+  - IoThreadToProcess
+  - PsGetCurrentProcessSessionId
+  - ZwTerminateProcess
+  - KeStackAttachProcess
+  - KeUnstackDetachProcess
+  - ZwOpenThread
+  - PsProcessType
+  - ExInterlockedInsertHeadList
+  - ExInterlockedRemoveHeadList
+  - CmRegisterCallback
+  - CmUnRegisterCallback
+  - RtlCreateRegistryKey
+  - ZwOpenKey
+  - ZwEnumerateKey
+  - ZwQueryKey
+  - ZwQueryValueKey
+  - RtlUnicodeStringToAnsiString
+  - RtlFreeAnsiString
+  - ProbeForWrite
+  - PsSetLoadImageNotifyRoutine
+  - PsRemoveLoadImageNotifyRoutine
+  - PsGetProcessSectionBaseAddress
+  - MmSystemRangeStart
+  - KeBugCheckEx
+  - PsLookupProcessByProcessId
+  - ZwOpenProcess
+  - PsGetCurrentProcessId
+  - RtlUpcaseUnicodeString
+  - RtlUpperString
+  - ZwClose
+  - ZwCreateFile
+  - ObfDereferenceObject
+  - ObReferenceObjectByHandle
+  - ProbeForRead
+  - ExFreePoolWithTag
+  - ExAllocatePoolWithTag
+  - KeDelayExecutionThread
+  - RtlGetVersion
+  - DbgPrint
+  - RtlCopyUnicodeString
+  - RtlInitUnicodeString
+  - wcsstr
+  - ZwQuerySystemInformation
+  - strstr
+  - FltSendMessage
+  - FltCloseCommunicationPort
+  - FltCreateCommunicationPort
+  - FltReleaseContext
+  - FltGetStreamHandleContext
+  - FltSetStreamHandleContext
+  - FltAllocateContext
+  - FltCancelFileOpen
+  - FltQueryInformationFile
+  - FltReadFile
+  - FltParseFileNameInformation
+  - FltReleaseFileNameInformation
+  - FltGetFileNameInformation
+  - FltFreePoolAlignedWithTag
+  - FltAllocatePoolAlignedWithTag
+  - FltStartFiltering
+  - FltUnregisterFilter
+  - FltRegisterFilter
+  - FltBuildDefaultSecurityDescriptor
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: OU=GlobalSign Root CA , R3, O=GlobalSign, CN=GlobalSign
+      ValidFrom: '2018-09-19 00:00:00'
+      ValidTo: '2028-01-28 12:00:00'
+      Signature: 2370e9cfe2bef559ae94426fc44333aacd3f3ab96417f262064b48f140880617a1feabd15f3cc633f2f38edd1f1d3ecc1a6099820bacc7fc7e9a872aa57d0fa657eeac3b6a85d6debd4063f8ada6c888b012fcf641df0f09971e38ea539fbe05f43eead39f501276be098bc20b487d1e2e51f68d53d3ab1f401b8a8eed7dfb4f7956705f0cd38e1bb3a7700d372b9795abdae0126b1c40cec5c77eedc26258ec77ed7322c28af5864388adea136efdd8fe422fb97d5ead18ef9490ca3d27ab26949975c7cbd37bf7ca4cd3af5121925b847d2b9f153f74cb51e89e830e166f1be746ce23bdf9e4a28bd2396baa791c912ce261242d8e2a487090c41ec5e8e070
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 01ee5f169dff97352b6465d66a
+      Version: 3
+      TBS:
+        MD5: 51c3959a45cecf3d21a3effb05762573
+        SHA1: ecfcd25fd0525448a74875ba271566bc0bfbf061
+        SHA256: de1da11668f0a8d5e13346ed3ab2755f5d25bebffcfd1d0bde5b9f87bc292c91
+        SHA384: f0eab75baf1f24a53d63bd795cd07292a312f603513c8cb0f40fe5acbdb477ed72607d309fad21471a16f6223fb3a838
+    - Subject: C=BE, O=GlobalSign nv,sa, OU=Root CA, CN=GlobalSign Root CA
+      ValidFrom: '2011-04-15 19:55:08'
+      ValidTo: '2021-04-15 20:05:08'
+      Signature: 5ff8d065746a81c6a6ca5b03b6914ae84bbdef2ba142f0efb4a5adcd3389ec0b9585ac62501108aa58d25aa08310e5a6337af25af2c5fe787cf09c83df190ad97396002dd62ccde914d41d9de83f3c1a76f7904efb01350a6c9313a0c356eb67a0e4d17a96dec267f190f80a7bf5321b94ec5f751f8d1b34da6c58a7cb2d279e2226b7c9aa30cc0777b836e38201b5393ccc8dd9a75f7f23b3877fdb5798918bd7ce2520e39d644fdd87f72b68490318e0a5df7c5f68644d36838d4781f2e9e0a869abfa7b163c05a449ea8830190a6c73055178dfd41ddd3ad47f2de44e54be83431e7a7433b4a4ebd77073bc2a02988966eef6bc8f749378e329025a5a43e258ce7ccf9acad236893be25fda26054ec8d4e72c910e1797c5beee8b13112323294ffa83d050f6bafad53db3173df4ff034aa325dce67561d1fa35086bd62744d068b78d45e0eb852cc8a15d614474160e5958aed2b5eea5bcd6d7076ab62978fd976767dd8d4f17944fd2ed0caf972437c3a29c81da6be143b6577b4cecbf791319e79fe844e94781b75e701e91f83dd17b27f50b7056434805dda92fab86101d0b12e31ad04c6e75ded645b30b748887935c564a41029af7aeb799d8b67f88fa11f2457cf4d71b91c01cf1a0fbd4080a411a142acef4eb34486e66879ed54b7a397fbb0e3d3861cf735706e412066bd96b5308cd7018c22d4f974691bca9f0
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 6129152700000000002a
+      Version: 3
+      TBS:
+        MD5: 0bb058d116f02817737920f112d9fd3b
+        SHA1: fd116235171a4feafedee586b7a59185fb5fd7e6
+        SHA256: f970426cc46d2ae0fc5f899fa19dbe76e05f07e525654c60c3c9399492c291f4
+        SHA384: c0df876be008c26ca407fe904e6f5e7ccded17f9c16830ce9f8022309c9e64c97f494810f152811ae43e223b82ad7cc6
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Trusted Root
+        G4
+      ValidFrom: '2022-08-01 00:00:00'
+      ValidTo: '2031-11-09 23:59:59'
+      Signature: 70a0bf435c55e7385fa0a3741b3db616d7f7bf5707bd9aaca1872cec855ea91abb22f8871a695422eda488776dbd1a14f4134a7a2f2db738eff4ff80b9f8a1f7f272de24bc5203c84ed02adefa2d56cff9f4f7ac307a9a8bb25ed4cfd143449b4321eb9672a148b499cb9d4fa7060313772744d4e77fe859a8f0bf2f0ba6e9f2343cecf703c787a8d24c401935466a6954b0b8a1568eeca4d53de8b1dcfd1cd8f4775a5c548c6fefa1503dfc760968849f6fcadb208d35601c0203cb20b0ac58a00e4063c59822c1b259f5556bcf27ab6c76ce6f232df47e716a236b22ff12b8542d277ed83ad9f0b68796fd5bd15cac18c34d9f73b701a99f57aa5e28e2b994
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 0e9b188ef9d02de7efdb50e20840185a
+      Version: 3
+      TBS:
+        MD5: 21a266bd49f2778b24d13d95641ea6ac
+        SHA1: 21319f341fdf06bf6a104427afa8b7823b1ea7f3
+        SHA256: e933dc68ee65abd1f9b1aa6738eff60a6895d3d8cc4accf0c69069aa3decd757
+        SHA384: 11533efd6b326a4e065a936de300fe0586a479f93d569d2403bd62c7ad35f1b2199daee3adb510f429c4fc97b4b024e3
+    - Subject: C=BE, O=GlobalSign nv,sa, CN=GlobalSign Code Signing Root R45
+      ValidFrom: '2020-07-28 00:00:00'
+      ValidTo: '2029-03-18 00:00:00'
+      Signature: acf7cc158b3079a81d0b28881909d71c7ffe86bd7b5a336e0d670e7b62d9e1185cb0bd135d1d23ae39507637aa44fd5f01235986564cccadbc64131430a420a8e03fe89c72dc7ef3d80c23baa82daa3cf6ec9f87310765f539a7518275e1f22f97f6d1e165968364fea11d51fbb5249bf5d27769bc852c5cfa5877d1aea7b10be2d677bba9b4344aa96f3df4f30d955de6f97a45b02517312edbf70f68e6831fa9f7e5d49d988cd3614b2fc3287e7ade930eb47da00a6d92c4b4663f7da758eeacf7ecc30801ab38fc0a1ca9c597b288c8090219f65c9a1af14d6c30d4b306ab0060480d78abcf17ad9293622077756cbdc832b4dc4debd9dfc1909629bdc17f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 7803184245708a41cf6f01b8eeb4a954
+      Version: 3
+      TBS:
+        MD5: a33260428269bc902bc1cd280e4b1837
+        SHA1: 254209ca172cffcc67bd2a88996556d2f09538f0
+        SHA256: a67411358594f2cf016741a63fd49f36de917f86531b3e3a43eb6a421c654868
+        SHA384: fec727af43d1569995cea26e8eb97167165842a5b185304425a92c03b71254c5d51222837515f33e60cb8ed2e8c625ba
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 RSA4096 SHA256 TimeStamping
+        CA
+      ValidFrom: '2022-03-23 00:00:00'
+      ValidTo: '2037-03-22 23:59:59'
+      Signature: 7d598ec093b66f98a94422017e66d6d82142e1b0182e104d13cf3053cebf18fbc7505de24b29fb708a0daa2969fc69c1cf1d07e93e60c8d80be55c5bd76d87fa842025343167cdb612966fc4504c621d0c0882a816bda956cf15738d012225ce95693f4777fb727414d7ffab4f8a2c7aab85cd435fed60b6aa4f91669e2c9ee08aace5fd8cbc6426876c92bd9d7cd0700a7cefa8bc754fba5af7a910b25de9ff285489f0d58a717665daccf072a323fac0278244ae99271bab241e26c1b7de2aebf69eb1799981a35686ab0a45c9dfc48da0e798fbfba69d72afc4c7c1c16a71d9c6138009c4b69fcd878724bb4fa349b9776691f1729ce94b0252a7377e9353ac3b1d08490f94cd397addff256399272c3d3f6ba7f166c341cd4fb6409b212140d0b71324cddc1d783ae49eade5347192d7266be43873aba6014fbd3f3b78ad4cadfbc4957bed0a5f33398741787a38e99ce1dd23fd1d28d3c7f9e8f1985ffb2bd87ef2469d752c1e272c26db6f157b1e198b36b893d4e6f2179959ca70f037bf9800df20164f27fb606716a166badd55c03a2986b098a02bed9541b73ad5159831b462090f0abd81d913febfa4d1f357d9bc04fa82de32df0489f000cd5dc2f9d0237f000be4760226d9f0657642a6298709472be67f1aa4850ffc9896f655542b1f80fac0f20e2be5d6fba92f44154ae7130e1ddb37381aa12bf6edd67cfc
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 073637b724547cd847acfd28662a5e5b
+      Version: 3
+      TBS:
+        MD5: e4b8ad9932ff9205f580cf8fb2afbb86
+        SHA1: 5301f7044d78bf94dd2b6e4871083a17fdba1dcc
+        SHA256: c3d01499a5d1d2f71e0f44e78fbfa4b8aadb43dd4f226401e0c1d7a6d53357fa
+        SHA384: 84b5f399da5a4f4387269adfd951ef7d2197c29552ed2d2e449060664c3825d6bdb2acc3e563d999e54652f7384f445e
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Timestamp 2023
+      ValidFrom: '2023-07-14 00:00:00'
+      ValidTo: '2034-10-13 23:59:59'
+      Signature: 811ad6dea0a9b59817bc708d4f8a3c689cd825ffcb2ce4cdea5d2292ec8c2202a9b8cf80a8d9e7e3c5ed26828a712f18dd4eb6de6cd7e1609c2beded3d488eb86bba7c5dbdc26137684977a3eb90aa12d72785f38e1e92dac240389f5dc8a02e2578259d2a057a842998b657798fdb26562bb0f3a7bd370cd898764f56b952c2b69d38a981e76d415c8c69d1b92bc4c67bcf9cfa78e2931a76a26975d350e44412be200d9ea944d0f8e54977085a21c5b4cf98951a54bab9bcc16919bacf16f28337346eb04126ddde5a974f338dd48d777d7545a1a558266a0345ded950b5508caf56bd4cc5e146c528d3ade7430070decc989e198903ead49137ef4d52f3c96021c45647edda114b8c32c388e658e2b6db3ef95fb042d68fe31791d1aac055e386bfac272c41d09a334aa836d4b972967e977938485fcac2dc3d32df75d636675a89f8f6a7c7e54f353c00bdbe9c2a6c7901dcda44e63ade383b075e3958f47c733155a08011cb140c7eaebcfea4eb7965aa68d622ca3beb9a8235572816cb69f2329ab2d2d83ab8b146866bba17fdc4776c156caeabaf733ae84946b7d57fccb638c0d8ec1cf5b6a1b8432cdf4e4c7d1e6870c0770ad402e05c60bb28ff38e5525ad6ac1722234ef4ecd317fb506bff07771f71974441c9b846d36c327c582f674765e51b73b699f96b2c0646ef411ef0f05fe0dbd9ad908044af8010418a
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 0544aff3949d0839a6bfdb3f5fe56116
+      Version: 3
+      TBS:
+        MD5: 7630cbd02cc6732394e9fdfe99d0d8f8
+        SHA1: bc1890d694f9d392c4cbae6a174e35d70e7ec8b1
+        SHA256: 594a02de632b3a08ed6644c36994025e57f35bc8e7bd16cec5d347883390d1d8
+        SHA384: 31d9fb75262762d17046f31e5c54509f58a295d505e411019544000b64f607b44b3346b708fa50d48f199dba56f0c0b1
+    - Subject: C=BE, O=GlobalSign nv,sa, CN=GlobalSign GCC R45 EV CodeSigning CA 2020
+      ValidFrom: '2020-07-28 00:00:00'
+      ValidTo: '2030-07-28 00:00:00'
+      Signature: 2575a009c939bab7a139892f189fabd6eb1d4be8947c0d07689b1c9def71b6176a6b024fb33f864587cc659b4ce35806022266d56102c5638fd4a2f1b65e250b7796e9cd7140338829eceef3a26dbc4db53e064bc97333ca08142d3d4ce8b0ba75a6742da4583a6c1349f8a5150a149685b16a68342542af9656f410fa247df12b72c116e16bebe6a998c73e5af4d0189dfd74978677462a3d237d28738aaeef2b1b9abf6c53a7149e3c8771c05e8ec8fbd32a9233ea574d5e075ecac118ac812d1a21fa6ecf97617bdf717a3aca63f7d530443732febb4385dcbafca6ca33192b776ddbcb05f07e5f752ea2b6bf35aa3663c9ce64d9bdfcbc2cf3495600c8122bc627bb37af57efc4cf1e29c4f4e22dce2a61cf57edf50a40e2f518d61ee9902fcad3875f938a481a111de537859f2e66629a5e814e95ac555743dc538b257e3c610f8a0bbaf53fa6d78ef704565e21bb9fd76a7180bf96de7203d8d8222bf327164f38e851400cae92efbe3d7df780c64c36578495a7841548300e5227088d8ea2bd22c719c9a6ca0ea87a36db6aba615f112495a4e28e68ee19a949995ed0b434bdd6f940c710973152393529118724d3c4fba963cb7748d5fa62fc24e0047a4ed0e46edece9e385026f4217165d70925d4c907007ab8c7f377e8c5d4e255d0d31ef67f52e2498db911720c88442633660144dfe4330e21de62894807daf5
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 77bd0e05b7590bb61d4761531e3f75ed
+      Version: 3
+      TBS:
+        MD5: 65fd1dac1f115d9507f4e1840c8cb36a
+        SHA1: c7cf5607e19b22fe60c055e71d9b555d70f71f66
+        SHA256: d9c7db0b704f07089440c56e69a0f31d730edf77cfbf7514630e8b5390a270fe
+        SHA384: defe810317bd1215b4d1ee0ec8a5fb38b21d094ef1173cae670956cd899232638e4f9473fd947bd550a4a77300bbb2ab
+    - Subject: ??=Private Organization, serialNumber=91440300MA5FD6WK46, ??=CN, ??=Guangdong,
+        ??=Shenzhen, C=CN, ST=Guangdong, L=Shenzhen, O=CleverSoar Electronic Technology
+        Co., Ltd., CN=CleverSoar Electronic Technology Co., Ltd.
+      ValidFrom: '2023-07-24 08:30:28'
+      ValidTo: '2024-07-24 08:30:28'
+      Signature: 81e71777c185f29a3d776650ad84c90e6419af36c0041dbf22561902437ea07c17adddd61992777afa3afa1868cd90b5c1b1a0539c8a23f03134ee0fbd128497f1dbcf42ba3bc2108c013dbdadbb8b8b4f8e1da4d38f6467a237726090c32399514c87099fe5e143462081dda34a986817de71808ac8b682ca973731156648fd38f20d8c5f3b3bff004098d1e0633bced928b8b708ea94104a227f2591794c12f82b45141bba1333f7f12c5c7e84be6b1773cda0745ef788d54af51e1639c2b00cd6986e4bb32840ff5925fa1e1deecdda8287d47b9ce51afa81baa5d62dfc07fbf8c96ae842a6cf299b0182a11eca956e6506deb18e48b3a0f635b1dc352b4a238aa01fe9d0b3a79b6596b572331e22dbbc734a745761d7d38889ad03690f8ac7531dc09ba0bdcb525af1ba58165c436c1005330f7cc3b44e1ede21e736e767bc2939d1acd00487bb5175ab2ad3d77d0b9ba75d472ed672b02f90c49dc453925f22265e66cd5ff872e80d554c016efb6377dcf61bf0eb04c0f0b697278f9c1e8c10f601e36ca9fd3b2dbfab74f66df00488995217394ee05c9b8b2af03a00589b7add6d10a341e36abf81898576cc6856ecd4443d2fa8bcdd5a4d79812d5a95ae19e69de79d6280eff57738c42f4ca318086ae54c3e47aeb0691b17bee017cfd272efd2d3a5efb6a7476b5fb1986ec1d5254741c683318a63affaf1ec2c0497
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 5b3b40442fc61bf39d4ad414
+      Version: 3
+      TBS:
+        MD5: 69e097228223b745d14e726062ecbd27
+        SHA1: aebee16d3f77ca075ede3e4896b6e46e2a9274f0
+        SHA256: d54dc9cdcee1f196c17901082956b7be8d78bdd2cd91e72fbda164e4909341df
+        SHA384: 4749e6d5bc7cdb0ef47528b6bb927f9738f98b7cc2f14ede3424d601d6ec635b030ef97a278fe874dc65ceeb5ee83f18
+    Signer:
+    - SerialNumber: 5b3b40442fc61bf39d4ad414
+      Issuer: C=BE, O=GlobalSign nv,sa, CN=GlobalSign GCC R45 EV CodeSigning CA 2020
+      Version: 1


### PR DESCRIPTION
Added new versions for
- IObitUnlocker, used by `64030dbd5a77510a00d33ea4e5d9f4d11643f77686b7100b5e98ffff1938bdf3` to terminate Defender
- Zemana, used by `60483e8755a4d977de3c93189dfcd29bb9519d3813602797469751b0dad39fc7` to terminate Defender
- TfSysMon,  used by `6cc73c52156f1c7ecd36951aaeb146ce5e690afd62214c5e4bedb328e859d013` to terminate Defender
