### PR TITLE
Added new vulnerable sample for Truesight

### DIFF
--- a/drivers/531121e7ed50084b493a69f8f8a7a927.bin
+++ b/drivers/531121e7ed50084b493a69f8f8a7a927.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfbfcb7cae421739163e7630865009d3197f587265e9e5797142d93e1b72b191
+size 37624

--- a/yaml/e0e93453-1007-4799-ad02-9b461b7e0398.yaml
+++ b/yaml/e0e93453-1007-4799-ad02-9b461b7e0398.yaml
@@ -219,3 +219,181 @@ KnownVulnerableSamples:
     Imports:
     - ntoskrnl.exe
     LoadsDespiteHVCI: 'FALSE'
+- Filename: Truesight
+  SHA256: bfbfcb7cae421739163e7630865009d3197f587265e9e5797142d93e1b72b191
+  MD5: 531121e7ed50084b493a69f8f8a7a927
+  SHA1: 28c37b1c0af4a2a75a9662544fb3181a71c45dd2
+  Imphash: ba0a77ce9e566f704a1655d999d41048
+  Authentihash:
+    MD5: e500e54b63b017a00fddcc37a6d47a90
+    SHA1: 79573b1d088101b2ebea80da1ab2dbb83725336a
+    SHA256: 13a64ee87e5e407cb592026b7d0bed501a2ae5bfaa33312d89e0f62fe4278828
+  RichPEHeaderHash:
+    MD5: a6c1f42a8235df4fdeca277b0de64953
+    SHA1: 725ef7e2e32e5bb3967731cbd53e3c389f952aff
+    SHA256: fc4499c41e1a142b40d14a0028e422248600741a7f6902df2a06aa4a05c129fe
+  Sections:
+    .text:
+      Entropy: 5.424374484530396
+      Virtual Size: '0x4b9d'
+    .rdata:
+      Entropy: 4.628987885701563
+      Virtual Size: '0x620'
+    .data:
+      Entropy: 1.5265215132315526
+      Virtual Size: '0x280'
+    .pdata:
+      Entropy: 4.080753814993614
+      Virtual Size: '0x378'
+    PAGE:
+      Entropy: 4.301844237954086
+      Virtual Size: '0x8c'
+    INIT:
+      Entropy: 5.441294021519896
+      Virtual Size: '0x820'
+    .rsrc:
+      Entropy: 3.264676131647557
+      Virtual Size: '0x3c8'
+    .reloc:
+      Entropy: 2.1994049281814134
+      Virtual Size: '0xa8'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2014-12-04 12:36:12'
+  Description: Antirootkit module
+  Company: Adlice Software
+  InternalName: Truesight
+  OriginalFilename: Truesight
+  FileVersion: 1.0.3
+  Product: Truesight
+  ProductVersion: 1.0.3
+  Copyright: Copyright Adlice Software(C) 2014
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - IoDeleteSymbolicLink
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - IoCreateDevice
+  - RtlAssert
+  - DbgPrint
+  - KeBugCheckEx
+  - _wcsicmp
+  - ExFreePoolWithTag
+  - ObOpenObjectByName
+  - ZwOpenDirectoryObject
+  - ObQueryNameString
+  - IoDriverObjectType
+  - IoGetDeviceObjectPointer
+  - ExAllocatePool
+  - ZwClose
+  - ObReferenceObjectByHandle
+  - ZwQueryDirectoryObject
+  - MmIsAddressValid
+  - ObfDereferenceObject
+  - KeResetEvent
+  - KeInitializeApc
+  - KeSetEvent
+  - KeInsertQueueApc
+  - KeInitializeEvent
+  - KeWaitForSingleObject
+  - RtlCaptureStackBackTrace
+  - PsGetCurrentThreadId
+  - PsLookupThreadByThreadId
+  - ExAllocatePoolWithTag
+  - ZwDeleteKey
+  - ZwEnumerateKey
+  - ZwQueryKey
+  - ZwOpenKey
+  - ZwQuerySystemInformation
+  - ZwOpenProcess
+  - ZwTerminateProcess
+  - IoGetAttachedDevice
+  - IoGetRelatedDeviceObject
+  - IoCreateFile
+  - IoFileObjectType
+  - IoFreeIrp
+  - IoAllocateIrp
+  - IofCallDriver
+  - RtlGetVersion
+  - PsGetVersion
+  - __C_specific_handler
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=FR, ST=Loire Atlantique, L=Orvault, O=Adlice, CN=Adlice
+      ValidFrom: '2014-06-17 00:00:00'
+      ValidTo: '2015-06-22 12:00:00'
+      Signature: ab003b79f4255d9aca48b450b1d8326306a4641de1c4a8f01a2d9e62daacc5a741d44371e1a529d0f97e3d02da65cd0f6ba70081e636fd025aacafb53d6f7ed8e6d7854e5442ebb642b97415b25df1852a1f5667dc732f5eef2dea21863e40e32dc809bf0b098260352d7babf9f90e0cf3a6e6c8d93377d1829c94deb2c84757a5e1ed914bf0ca4e08567a68bf3c8a3bbc9701220b621c68f61e9fcd38aafeaa6facbb5cb6194f24f6bbbc6354616a77d39a16018ec2c8ffd6042f22291140c03d57b32351a652d2a83817236089e0ab9a7c31715ca37583e383536ceea934f3cdbff211abaf61ba3fe0c6eba9a86b11000124d6b4d8d16d5a97764f955a7771
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0da5be52ad798cf036b2b2322ff0f774
+      Version: 3
+      TBS:
+        MD5: 71b84e8a2695ca99a1fcf2246051b7ee
+        SHA1: cf5993cd8054d6190ba44a3f05b2d0921899ca08
+        SHA256: d0c8fd4b3cc1b744a67c131a49e03831cf30884ff54b03308dd1fed4354465c7
+        SHA384: ce5657df7509120afd43b09dffcf7479a094f45b6ce6c0e19a73ff8efa88aee01237d46726a3da22edc25058b2366cf7
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert High Assurance
+        EV Root CA
+      ValidFrom: '2011-04-15 19:45:33'
+      ValidTo: '2021-04-15 19:55:33'
+      Signature: 208cc159ed6f9c6b2dc14a3e751d454c41501cbd80ead9b0928b062a133f53169e56396a8a63b6782479f57db8b947a10a96c2f6cbbda2669f06e1acd279090efd3cdcac020c70af3f1bec787ed4eb4b056026d973619121edb06863e09712ab6fa012edd99fd2da273cb3e456f9d1d4810f71bd427ca689dccdd5bd95a2abf193117de8ac3129a85d6670419dfc75c9d5b31a392ad08505508bac91cac493cb71a59da4946f580cfa6e20c40831b5859d7e81f9d23dca5b18856c0a86ec22091ba574344f7f28bc954aab1db698b05d09a477767eefa78e5d84f61824cbd16da6c3a19cc2107580ff9d32fde6cf433a82f7ce8fe1722a9b62b75fed951a395c2f946d48b7015f332fbbdc2d73348904420a1c8b79f9a3fa17effaa11a10dfe0b2c195eb5c0c05973b353e18884ddb6cbf24898dc8bdd89f7b393a24a0d5dfd1f34a1a97f6a66f7a1fb090a9b3ac013991d361b764f13e573803afce7ad2b590f5aedc3999d5b63c97eda6cb16c77d6b2a4c9094e64c54fd1ecd20ecce689c8758e96160beeb0ec9d5197d9fe978bd0eac2175078fa96ee08c6a2a6b9ce3e765bcbc2d3c6ddc04dc67453632af0481bca8006e614c95c55cd48e8e9f2fc13274bdbd11650307cdefb75e0257da86d41a2834af8849b2cfa5dd82566f68aa14e25954feffeaeeefea9270226081e32523c09fcc0f49b235aa58c33ac3d9169410
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 61204db4000000000027
+      Version: 3
+      TBS:
+        MD5: 8e3ffc222fbcebdbb8b23115ab259be7
+        SHA1: ee20bff28ffe13be731c294c90d6ded5aae0ec0e
+        SHA256: 59826b69bc8c28118c96323b627da59aaca0b142cc5d8bad25a8fcfd399aa821
+        SHA384: f2dab7e56a33298654924501499487f6ba72c7d9477476a186e1ed7a9be031fade0e35ac09eff5e56bbbab95ae5374e7
+    - Subject: C=US, O=DigiCert, CN=DigiCert Timestamp Responder
+      ValidFrom: '2014-10-22 00:00:00'
+      ValidTo: '2024-10-22 00:00:00'
+      Signature: 9d257e1b334db226815c9b86ce23200f8087e588ffffb1d46a2c31ed3a17197117cda91bbc5a1639009de36c84e45a40fbde06018c37fa9bb19d247efe20a457ad5bb79ab06026ea6957215d342f1f71b0839419056b359010a07b97c7f63fe7e21141a6bd62d9f0273d381d286f3a5209f0ec7062d3624bb0e073a692c0d38e31d82fe36d171306eee403b614abf38f43a7719d21dd14ca155d9241daf90f81d199740d26c40e7f1bb5f5a0f1c677062815e9d893e55516f0bb0aab1cdb5c482766c8a38b0a1ce595daaec42e59a061dddaf36da261e98a0b6dec1218bdf755544003922b6bc251c20a48afb0d46ee0f4140a3a1be38f3dcaaf6a8d7bdcd844
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 03019a023aff58b16bd6d5eae617f066
+      Version: 3
+      TBS:
+        MD5: a752afee44f017e8d74e3f3eb7914ae3
+        SHA1: 8eca80a6b80e9c69dcef7745748524afb8019e2d
+        SHA256: 82560fa7efec30b5ff82af643e6f3bf3d46868bbd5e7d76f93db185e9e3553a1
+        SHA384: e8b11408c88f877ade4ca51114a175fb5dfd2d18d2a66be547c1c9e080fa8f592c7870e30dfab1c04d234993dd0907f3
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert High Assurance
+        Code Signing CA,1
+      ValidFrom: '2011-02-11 12:00:00'
+      ValidTo: '2026-02-10 12:00:00'
+      Signature: 49eb7c60beaeefc97cb3c5ba4b64df1669e286fa29d9de98857d406626332f4455aaaa90e935700a34bed3ae542e8e6500d67a32203e6c26b898a939b1bc95c7aae9f5ee4666c6b3e812f8b3979dff74588234997550ac448fe892ce7d8b0f3196c7dcd31130987416c6e56b4576a39401cd33007a48f66f8631c9562b3322d5f801b644ce8cb4ca88d2e416e3e7f6e23ee109c09d7943437f555c05ad9310c62c0d6bc09eea78e5d277d6b8da9a987fba4c922b9dbda488b1ddafc34cd2979b03c6ae5f1b440f333715e3cbff2f56d316a45b55679da2cadb346c0c734ab57ba4b6b3e935027870ec007acbfc4b4f2236bb1484c98f91dd0f3c758cca0b88e7
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 02c4d1e58a4a680c568da3047e7e4d5f
+      Version: 3
+      TBS:
+        MD5: 829995f702421dea833a24fb2c7f4442
+        SHA1: 1d7e838accd498c2e5ba9373af819ec097bb955c
+        SHA256: 92914d016cc46e125e50c4bd0bd7f72db87eed4ba68f3c589b4e86aa563108db
+        SHA384: dbb72e38c3bc17b08aa00535ebd48502058ce6ecfd24bd4dd45c7b33e3d523510a4a649d86dfc77436c58754bd0754ea
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID CA,1
+      ValidFrom: '2006-11-10 00:00:00'
+      ValidTo: '2021-11-10 00:00:00'
+      Signature: 46503ec9b72824a7381db65b29af52cf52e93147ab565c7bd50d0b41b3efec751f7438f2b25c61a29c95c350e482b923d1ba3a8672ad3878ac755d1717347247859456d1ebbb368477cc24a5f3041955a9e7e3e7ab62cdfb8b2d90c2c0d2b594bd5e4fb105d20e3d1aa9145ba6863162a8a833e49b39a7c4f5ce1d7876942573e42aabcf9c764bed5fc24b16e44b704c00891efcc579bc4c1257fe5fe11ebc025da8fefb07384f0dc65d91b90f6745cdd683ede7920d8db1698c4ffb59e0230fd2aaae007cee9c420ecf91d727b716ee0fc3bd7c0aa0ee2c08558522b8eb181a4dfc2a21ad49318347957771dcb11b4b4b1c109c7714c19d4f2f5a9508291026
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 06fdf9039603adea000aeb3f27bbba1b
+      Version: 3
+      TBS:
+        MD5: 4e5ad189638cf52ba9cd881d4d44668c
+        SHA1: cdc115e98d798b33904c820d63cc1e1afc19251d
+        SHA256: 37560fb9d548ab62cc3ed4669a4ab74828b5a108e67e829937ffb2d10a5f78dd
+        SHA384: 173bfb77183785621ef15f43ea807338cea6a02e8183317d9ef050c7237adda3fa2a5bdcd5a4c96da9f2c55900675b9f
+    Signer:
+    - SerialNumber: 0da5be52ad798cf036b2b2322ff0f774
+      Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert High Assurance
+        Code Signing CA,1
+      Version: 1


### PR DESCRIPTION
Added version 1.0.3 of Truesight.sys, used by `9830c640ba209cf06d090e84770acf84460f932522800a9ed31196d1d744eea8` to terminate Defender