### PR TITLE
fix: normalize category from "vulnerable drivers" to "vulnerable driver"

### DIFF
--- a/yaml/02e4a30f-8aa8-4ff0-8e02-1bff1d0f088f.yaml
+++ b/yaml/02e4a30f-8aa8-4ff0-8e02-1bff1d0f088f.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/080a834f-3e19-4cae-b940-a4ecf901db28.yaml
+++ b/yaml/080a834f-3e19-4cae-b940-a4ecf901db28.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/0baa833c-e4e1-449e-86ee-cafeb11f5fd5.yaml
+++ b/yaml/0baa833c-e4e1-449e-86ee-cafeb11f5fd5.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/0e3b0052-18c7-4c8b-a064-a1332df07af2.yaml
+++ b/yaml/0e3b0052-18c7-4c8b-a064-a1332df07af2.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/0f8e317e-ad2b-4b02-9f96-603bb8d28604.yaml
+++ b/yaml/0f8e317e-ad2b-4b02-9f96-603bb8d28604.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/1055625b-3480-48b3-9556-8628a745d8f0.yaml
+++ b/yaml/1055625b-3480-48b3-9556-8628a745d8f0.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/12ccd18a-11da-495a-b4b4-98a2f2bff180.yaml
+++ b/yaml/12ccd18a-11da-495a-b4b4-98a2f2bff180.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/181b89e5-4bdd-4e95-b1bc-a294a4adfb29.yaml
+++ b/yaml/181b89e5-4bdd-4e95-b1bc-a294a4adfb29.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/1ab1ec8c-1231-4ba4-8804-4a2cda103bb8.yaml
+++ b/yaml/1ab1ec8c-1231-4ba4-8804-4a2cda103bb8.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/1aeb1205-8b02-42b6-a563-b953ea337c19.yaml
+++ b/yaml/1aeb1205-8b02-42b6-a563-b953ea337c19.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/213676bb-ffb9-4d0d-a442-8cefee63acc1.yaml
+++ b/yaml/213676bb-ffb9-4d0d-a442-8cefee63acc1.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/2225128d-a23f-434a-aaee-69a88ea64fbd.yaml
+++ b/yaml/2225128d-a23f-434a-aaee-69a88ea64fbd.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/2a6a38ca-f2e6-456e-9ccf-db59d8c80c9e.yaml
+++ b/yaml/2a6a38ca-f2e6-456e-9ccf-db59d8c80c9e.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/35a9afeb-18f1-4c02-a3aa-830e300138ae.yaml
+++ b/yaml/35a9afeb-18f1-4c02-a3aa-830e300138ae.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/45c42e32-6261-43c1-bdbd-cab58da729d8.yaml
+++ b/yaml/45c42e32-6261-43c1-bdbd-cab58da729d8.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/4c815256-2534-4476-b15d-7cbf24c80098.yaml
+++ b/yaml/4c815256-2534-4476-b15d-7cbf24c80098.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/500e07cb-77c6-4e83-ae3f-73f70f1c10b5.yaml
+++ b/yaml/500e07cb-77c6-4e83-ae3f-73f70f1c10b5.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/51808fa6-89a4-4f4d-aabc-0a7b0e99e34d.yaml
+++ b/yaml/51808fa6-89a4-4f4d-aabc-0a7b0e99e34d.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/56b320b3-5b12-4ec6-81e2-5a16c56c7478.yaml
+++ b/yaml/56b320b3-5b12-4ec6-81e2-5a16c56c7478.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/58509acb-50b4-41a0-9de3-76c571a459e3.yaml
+++ b/yaml/58509acb-50b4-41a0-9de3-76c571a459e3.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/5961e133-ccc3-4530-8f4f-5d975c41028d.yaml
+++ b/yaml/5961e133-ccc3-4530-8f4f-5d975c41028d.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/5a03dc5a-115d-4d6f-b5b5-685f4c014a69.yaml
+++ b/yaml/5a03dc5a-115d-4d6f-b5b5-685f4c014a69.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/5ad8a3b6-6d20-4c95-8fa7-9a507167ba3c.yaml
+++ b/yaml/5ad8a3b6-6d20-4c95-8fa7-9a507167ba3c.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/6356d7d9-3b82-4731-9d5f-cc9bc37558fc.yaml
+++ b/yaml/6356d7d9-3b82-4731-9d5f-cc9bc37558fc.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/6c0c60f0-895d-428a-a8ae-e10390bceb12.yaml
+++ b/yaml/6c0c60f0-895d-428a-a8ae-e10390bceb12.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/705facba-b595-41dd-86a6-93aefe6a6234.yaml
+++ b/yaml/705facba-b595-41dd-86a6-93aefe6a6234.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/70fa8606-c147-4c40-8b7a-980290075327.yaml
+++ b/yaml/70fa8606-c147-4c40-8b7a-980290075327.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/724d7989-dfce-4bb2-9beb-dee15df5b790.yaml
+++ b/yaml/724d7989-dfce-4bb2-9beb-dee15df5b790.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/73290fcb-a0d7-481e-81a5-65a9859b50f5.yaml
+++ b/yaml/73290fcb-a0d7-481e-81a5-65a9859b50f5.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/75a66604-f024-4f11-8ba7-fdd64a0df3bf.yaml
+++ b/yaml/75a66604-f024-4f11-8ba7-fdd64a0df3bf.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/7a0842ca-1a64-4ad1-9d66-25eb983d1742.yaml
+++ b/yaml/7a0842ca-1a64-4ad1-9d66-25eb983d1742.yaml
@@ -8,7 +8,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/7abc873d-9c28-44c2-8f60-701a8e26af29.yaml
+++ b/yaml/7abc873d-9c28-44c2-8f60-701a8e26af29.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/9454a752-233e-4ba2-b585-8da242bf8f31.yaml
+++ b/yaml/9454a752-233e-4ba2-b585-8da242bf8f31.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/96c8fe71-3acc-41bc-9402-ebd69a961d74.yaml
+++ b/yaml/96c8fe71-3acc-41bc-9402-ebd69a961d74.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/97fa88f6-3819-4d56-a82c-52a492a9e2b5.yaml
+++ b/yaml/97fa88f6-3819-4d56-a82c-52a492a9e2b5.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/998ed67c-9c20-46ef-a6ba-abc606b540b9.yaml
+++ b/yaml/998ed67c-9c20-46ef-a6ba-abc606b540b9.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/9c4e2e75-a8be-4d2f-b016-e2a98281c8ec.yaml
+++ b/yaml/9c4e2e75-a8be-4d2f-b016-e2a98281c8ec.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/9ca73d04-3349-4c16-9384-94c43335a031.yaml
+++ b/yaml/9ca73d04-3349-4c16-9384-94c43335a031.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/a02e1801-f6fb-41c3-a782-05fdbed44a3c.yaml
+++ b/yaml/a02e1801-f6fb-41c3-a782-05fdbed44a3c.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/a254e684-f6eb-40c4-a50a-7b76feb6cc02.yaml
+++ b/yaml/a254e684-f6eb-40c4-a50a-7b76feb6cc02.yaml
@@ -8,7 +8,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/a2c3f6e9-25a5-4b75-8c6b-ad2d4e155822.yaml
+++ b/yaml/a2c3f6e9-25a5-4b75-8c6b-ad2d4e155822.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/b3fd8560-79d3-40b7-b05f-c78044176c8c.yaml
+++ b/yaml/b3fd8560-79d3-40b7-b05f-c78044176c8c.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/b9b835bd-b720-424b-9160-2442bc4d6e58.yaml
+++ b/yaml/b9b835bd-b720-424b-9160-2442bc4d6e58.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/b9e01a11-6395-4837-a202-0c777d717a43.yaml
+++ b/yaml/b9e01a11-6395-4837-a202-0c777d717a43.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/babe348d-f160-41ec-9db9-2413b989c1f0.yaml
+++ b/yaml/babe348d-f160-41ec-9db9-2413b989c1f0.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/c33648d7-6473-4e2b-92f6-93f195bc183f.yaml
+++ b/yaml/c33648d7-6473-4e2b-92f6-93f195bc183f.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/cacf18a5-6d7d-4a63-92d4-bda386a3da18.yaml
+++ b/yaml/cacf18a5-6d7d-4a63-92d4-bda386a3da18.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/cf94939a-703f-46a4-917b-d6af7e0685ef.yaml
+++ b/yaml/cf94939a-703f-46a4-917b-d6af7e0685ef.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/dbb58de1-a1e5-4c7f-8fe0-4033502b1c63.yaml
+++ b/yaml/dbb58de1-a1e5-4c7f-8fe0-4033502b1c63.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/e368efc7-cf69-47ae-8204-f69dac000b22.yaml
+++ b/yaml/e368efc7-cf69-47ae-8204-f69dac000b22.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/ebdde780-e142-44e7-a998-504c516f4695.yaml
+++ b/yaml/ebdde780-e142-44e7-a998-504c516f4695.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/ecabc507-2cc7-4011-89ab-7d9d659e6f88.yaml
+++ b/yaml/ecabc507-2cc7-4011-89ab-7d9d659e6f88.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List

--- a/yaml/f22e7230-5f32-4c4e-bc9d-9076ebf10baa.yaml
+++ b/yaml/f22e7230-5f32-4c4e-bc9d-9076ebf10baa.yaml
@@ -7,7 +7,7 @@ Created: '2023-07-22'
 MitreID: T1068
 CVE:
 - ''
-Category: vulnerable drivers
+Category: vulnerable driver
 Commands:
     Command: ''
     Description: Confirmed vulnerable driver from Microsoft Block List


### PR DESCRIPTION
This PR normalizes all `"vulnerable drivers"` categories to `"vulnerable driver"` across YAML files for consistency and to ensure correct warning rendering on the site.

Fixes #226
