### PR TITLE
fix: encoding for version info

### DIFF
--- a/bin/yara-generator/yara-generator.py
+++ b/bin/yara-generator/yara-generator.py
@@ -278,8 +278,8 @@ def generate_string_values(version_info):
 	string_values = []
 	for field, value in version_info.items():
 		if value: # if not empty
-			field_hex = binascii.hexlify(field.encode('utf-16-be')).decode()
-			value_hex = binascii.hexlify(value.encode('utf-16-be')).decode()
+			field_hex = binascii.hexlify(field.encode('utf-16-le')).decode()
+			value_hex = binascii.hexlify(value.encode('utf-16-le')).decode()
 			search_value = "{ %s[1-8]%s } /* %s %s */" % (field_hex, value_hex, field, removeNonAsciiDrop(value))
 			string_values.append(search_value)
 	return string_values


### PR DESCRIPTION
The string values in the version information resource are encoded using UTF-16LE instead of UTF-16BE.
Samples with non-ASCII characters in the version information were not matched.

For example:
`e1123b59a801e243a64270d0c6ab1277e5e3afba9c19023807409f53c1b0204b` (driver_e1123b59.sys)
`44ebb0f534e7cdfec06d5234358d219798a313219b214d72aa23afc5a57d7ea9` (idmtdi.sys)