### PR TITLE
Add MagicSword free signup CTAs to LOLDrivers

### DIFF
--- a/bin/jinja2_templates/driver.md.j2
+++ b/bin/jinja2_templates/driver.md.j2
@@ -43,7 +43,6 @@ We were not able to verify the hash of this driver successfully, it has not been
 {% if driver.KnownVulnerableSamples %}
 {% if driver.KnownVulnerableSamples[0].MD5 %}
 {% raw %}{{< button "https://github.com/magicsword-io/LOLDrivers/raw/main/drivers/{% endraw %}{{ driver.KnownVulnerableSamples[0].MD5 }}{% raw %}.bin" "Download" >}}{% endraw %}
-{% raw %}{{< button "https://www.magicsword.io/premium" "Block" "red" >}}{% endraw %}
 {% raw %}
 {{< tip "warning" >}}
 {% endraw %}
@@ -57,6 +56,8 @@ This download link contains the malicious driver!
 {% endraw %}
 {% endif %}
 {% endif %}
+
+{% raw %}{{< blockbanner "{% endraw %}{{ driver.Tags[0] }}{% raw %}" >}}{% endraw %}
 
 {% if driver.Commands.Command %}
 ### Commands

--- a/loldrivers.io/config/_default/menus/menu.en.toml
+++ b/loldrivers.io/config/_default/menus/menu.en.toml
@@ -10,6 +10,6 @@
   url = "about/"
 
 [[main]]
-  name = "Premium"
+  name = "Free Prevention"
   weight = 6
-  url = "https://www.magicsword.io/premium"
+  url = "https://www.magicsword.io/plan?utm_source=loldrivers&utm_medium=website&utm_campaign=free_prevention&utm_content=nav_menu"

--- a/loldrivers.io/content/_index.md
+++ b/loldrivers.io/content/_index.md
@@ -63,12 +63,43 @@ You can also get the malicious driver list via **API** using [CSV](api/drivers.c
 
 {{< block "grid-1" >}}
 {{< column >}}
-<div style="display:flex; align-items:center; gap:16px; padding:14px 16px; background:#ffffff; border:1px solid #e6f4f2; border-radius:14px; box-shadow:0 8px 24px rgba(0,0,0,0.08);">
-  <img src="images/magicsword-logo.png" alt="MagicSword Logo" style="height:84px; width:auto; display:block; filter: drop-shadow(0 6px 14px rgba(0,194,168,0.35));" />
-  <div style="line-height:1.5; color:#111;">
-    <div>Block <strong style="color:red;">Living‑off‑the‑Land</strong> techniques RMM tools, LOLBAS, and BYOVD with native Windows controls.</div>
-    <a href="https://www.magicsword.io" style="display:inline-block; margin-top:8px; padding:12px 18px; background: rgb(0 170 108 / var(--tw-bg-opacity,1)); color:#ffffff; border-radius:12px; font-weight:800; text-decoration:none;">Block with MagicSword</a>
+<style>
+.ms-cta{background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:28px 40px;text-align:center;position:relative;overflow:hidden;}
+.ms-cta::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,#10B981,transparent);}
+.ms-cta-badge{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;background:rgba(16,185,129,0.08);border:1px solid rgba(16,185,129,0.2);border-radius:20px;font-size:0.75rem;font-weight:700;color:#059669;text-transform:uppercase;letter-spacing:0.06em;margin-bottom:10px;}
+.ms-cta-badge svg{stroke:#059669;}
+.ms-cta h3{margin:0 0 6px;font-size:1.5rem;font-weight:800;color:#111;line-height:1.3;}
+.ms-cta h3 em{font-style:normal;color:#059669;}
+.ms-cta p{margin:0 auto 18px;max-width:560px;font-size:0.95rem;color:#6b7280;line-height:1.5;}
+.ms-cta-btn{display:inline-flex;align-items:center;gap:8px;padding:14px 32px;background:#111 !important;color:#fff !important;border-radius:8px;font-weight:800;font-size:1rem;text-decoration:none !important;transition:background 0.15s,transform 0.1s;}
+.ms-cta-btn:hover{background:#333 !important;color:#fff !important;text-decoration:none !important;transform:translateY(-1px);}
+.ms-cta-btn:active{transform:translateY(0);}
+[data-mode="dark"] .ms-cta{background:#08080A;border-color:rgba(255,255,255,0.06);}
+[data-mode="dark"] .ms-cta-badge{color:#10B981;background:rgba(16,185,129,0.1);}
+[data-mode="dark"] .ms-cta-badge svg{stroke:#10B981;}
+[data-mode="dark"] .ms-cta h3{color:#fff;}
+[data-mode="dark"] .ms-cta h3 em{color:#10B981;}
+[data-mode="dark"] .ms-cta p{color:rgba(255,255,255,0.55);}
+[data-mode="dark"] .ms-cta-btn{background:#10B981 !important;color:#fff !important;}
+[data-mode="dark"] .ms-cta-btn:hover{background:#059669 !important;}
+/* Table column sizing */
+#chartTable{table-layout:fixed;width:100%;}
+#chartTable th:nth-child(1),#chartTable td:nth-child(1){width:22%;}
+#chartTable th:nth-child(2),#chartTable td:nth-child(2){width:40%;word-break:break-all;font-family:monospace;font-size:0.82rem;}
+#chartTable th:nth-child(3),#chartTable td:nth-child(3){width:20%;}
+#chartTable th:nth-child(4),#chartTable td:nth-child(4){width:18%;}
+</style>
+<div class="ms-cta">
+  <div class="ms-cta-badge">
+    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+    Free Prevention
   </div>
+  <h3>Stop BYOVD attacks.<br><em>Free for up to 100 endpoints.</em></h3>
+  <p>Turn this driver list into enforceable block policies with MagicSword, threat-driven application control.</p>
+  <a class="ms-cta-btn" href="https://www.magicsword.io/plan?utm_source=loldrivers&utm_medium=website&utm_campaign=free_prevention&utm_content=homepage_cta">
+    Start Blocking for Free
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+  </a>
 </div>
 
 {{< /column >}}

--- a/loldrivers.io/layouts/shortcodes/blockbanner.html
+++ b/loldrivers.io/layouts/shortcodes/blockbanner.html
@@ -1,0 +1,31 @@
+{{- $name := .Get 0 -}}
+<style>
+.ms-block-banner{background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:28px 32px;margin:24px 0;text-align:center;position:relative;overflow:hidden;}
+.ms-block-banner::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,#10B981,transparent);}
+.ms-bb-shield{display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:10px;background:rgba(16,185,129,0.08);border:1px solid rgba(16,185,129,0.15);margin-bottom:10px;}
+.ms-bb-shield svg{stroke:#059669;}
+.ms-block-banner h4{margin:0 0 6px;font-size:1.15rem;font-weight:800;color:#111;line-height:1.4;}
+.ms-block-banner h4 strong{color:#059669;}
+.ms-block-banner p{margin:0 auto 18px;max-width:480px;font-size:0.9rem;color:#6b7280;line-height:1.5;}
+.ms-bb-btn{display:inline-flex;align-items:center;gap:8px;padding:12px 28px;background:#111 !important;color:#fff !important;border-radius:8px;font-weight:800;font-size:0.95rem;text-decoration:none !important;transition:background 0.15s,transform 0.1s;}
+.ms-bb-btn:hover{background:#333 !important;color:#fff !important;text-decoration:none !important;transform:translateY(-1px);}
+.ms-bb-btn:active{transform:translateY(0);}
+[data-mode="dark"] .ms-block-banner{background:#08080A;border-color:rgba(255,255,255,0.06);}
+[data-mode="dark"] .ms-bb-shield svg{stroke:#10B981;}
+[data-mode="dark"] .ms-block-banner h4{color:#fff;}
+[data-mode="dark"] .ms-block-banner h4 strong{color:#10B981;}
+[data-mode="dark"] .ms-block-banner p{color:rgba(255,255,255,0.55);}
+[data-mode="dark"] .ms-bb-btn{background:#10B981 !important;color:#fff !important;}
+[data-mode="dark"] .ms-bb-btn:hover{background:#059669 !important;}
+</style>
+<div class="ms-block-banner">
+  <div class="ms-bb-shield">
+    <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+  </div>
+  <h4>Block <strong>{{ $name }}</strong> across your endpoints</h4>
+  <p>Add this driver to your block policy in minutes with MagicSword, threat-driven application control. Free for up to 100 endpoints.</p>
+  <a class="ms-bb-btn" href="https://www.magicsword.io/plan?utm_source=loldrivers&utm_medium=website&utm_campaign=free_prevention&utm_content=driver_block_banner" target="_blank" rel="noopener">
+    Start Blocking for Free
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+  </a>
+</div>


### PR DESCRIPTION
## Summary
<img width="1320" height="336" alt="image" src="https://github.com/user-attachments/assets/6bb6db63-f8d0-4d94-8ff4-f02d02f5a4a6" />

- Replace "Premium" nav link with "Free Prevention" linking to MagicSword plan page with UTM tracking
- Redesign homepage CTA banner: centered layout, light/dark mode support, threat-driven messaging
- Add `blockbanner` Hugo shortcode for driver pages with matching design system
- Update driver template (`driver.md.j2`) to use the new blockbanner shortcode instead of the old red "Block" button
- All links use UTM parameters (`utm_source=loldrivers`) for attribution

## Key messaging
- "Stop BYOVD attacks. Free for up to 100 endpoints."
- "Threat-driven application control" positioning
- Platform-neutral (no WDAC-specific language)

## Files changed
- `bin/jinja2_templates/driver.md.j2` — template uses `blockbanner` shortcode
- `loldrivers.io/config/_default/menus/menu.en.toml` — nav menu update
- `loldrivers.io/content/_index.md` — homepage CTA redesign + table column fixes
- `loldrivers.io/layouts/shortcodes/blockbanner.html` — new shortcode (light/dark mode)
