### PR TITLE
Fix misclassified authenticode hashes in 58 driver YAML files

### DIFF
--- a/bin/fix_authenticode_hashes.py
+++ b/bin/fix_authenticode_hashes.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+Cross-references YAML driver files against Microsoft's SiPolicy (VulnerableDriverBlockList)
+to identify hashes that are actually authenticode hashes misclassified as file hashes.
+
+The SiPolicy XML deny rules contain authenticode hashes, not flat file hashes.
+This script finds YAML entries where these hashes were incorrectly stored as SHA256/SHA1
+and moves them to the Authentihash section via targeted text edits (preserving formatting).
+
+Usage:
+    python3 bin/fix_authenticode_hashes.py [--dry-run] [--sipolicy PATH ...]
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+import yaml
+
+
+NS = '{urn:schemas-microsoft-com:sipolicy}'
+
+
+def parse_sipolicy_hashes(xml_paths):
+    """Parse SiPolicy XML files and return a dict of hash -> hash_info."""
+    groups = {}  # prefix -> {sha1: ..., sha256: ..., page_sha1: ..., page_sha256: ...}
+    all_hashes = {}  # lowercase hash -> {type, prefix, friendly_name}
+
+    for xml_path in xml_paths:
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+
+        for deny in root.iter(f'{NS}Deny'):
+            friendly = deny.get('FriendlyName', '')
+            hash_val = deny.get('Hash', '').lower()
+            if not hash_val or not friendly:
+                continue
+
+            if 'Hash Page Sha256' in friendly:
+                hash_type = 'page_sha256'
+                prefix = friendly.replace(' Hash Page Sha256', '')
+            elif 'Hash Page Sha1' in friendly:
+                hash_type = 'page_sha1'
+                prefix = friendly.replace(' Hash Page Sha1', '')
+            elif 'Hash Sha256' in friendly:
+                hash_type = 'sha256'
+                prefix = friendly.replace(' Hash Sha256', '')
+            elif 'Hash Sha1' in friendly:
+                hash_type = 'sha1'
+                prefix = friendly.replace(' Hash Sha1', '')
+            else:
+                all_hashes[hash_val] = {'type': 'unknown', 'friendly': friendly}
+                continue
+
+            if prefix not in groups:
+                groups[prefix] = {}
+            groups[prefix][hash_type] = hash_val
+
+            all_hashes[hash_val] = {
+                'type': hash_type,
+                'prefix': prefix,
+                'friendly': friendly,
+            }
+
+    return all_hashes, groups
+
+
+def apply_text_edit(content, hash_field, hash_val, authentihash, indent):
+    """Apply a targeted text edit: replace hash line and add Authentihash block."""
+    # Find the line with the hash value (case-insensitive match)
+    pattern = re.compile(
+        rf'^({indent}{hash_field}:\s*)[\'"]?{re.escape(hash_val)}[\'"]?\s*$',
+        re.IGNORECASE | re.MULTILINE
+    )
+    match = pattern.search(content)
+    if not match:
+        return content, False
+
+    # Replace the hash value with empty string
+    new_line = f"{indent}{hash_field}: ''"
+    content = content[:match.start()] + new_line + content[match.end():]
+
+    # Now find where to insert the Authentihash block
+    # Look for LoadsDespiteHVCI line that follows this sample's hash
+    # We need to find the LoadsDespiteHVCI line for THIS specific sample
+    hvci_pattern = re.compile(
+        rf'^{indent}LoadsDespiteHVCI:.*$', re.MULTILINE
+    )
+
+    # Search from the position of the hash line we just modified
+    search_start = match.start()
+    hvci_match = hvci_pattern.search(content, search_start)
+    if not hvci_match:
+        return content, False
+
+    # Check if there's already an Authentihash block between our edit and HVCI
+    segment = content[search_start:hvci_match.start()]
+    if 'Authentihash:' in segment:
+        return content, False
+
+    # Build authentihash block
+    auth_sha1 = authentihash['SHA1'] or "''"
+    auth_sha256 = authentihash['SHA256'] or "''"
+    auth_block = f"\n{indent}Authentihash:\n"
+    auth_block += f"{indent}    MD5: ''\n"
+    auth_block += f"{indent}    SHA1: {auth_sha1}\n"
+    auth_block += f"{indent}    SHA256: {auth_sha256}"
+
+    # Insert after the LoadsDespiteHVCI line
+    insert_pos = hvci_match.end()
+    content = content[:insert_pos] + auth_block + content[insert_pos:]
+
+    return content, True
+
+
+def process_yaml_files(yaml_dir, all_hashes, groups, dry_run=False):
+    """Process all YAML files and fix misclassified authenticode hashes."""
+    yaml_files = sorted(glob.glob(os.path.join(yaml_dir, '*.yaml')))
+    modified_files = []
+    total_samples_fixed = 0
+
+    for yaml_file in yaml_files:
+        # Parse YAML to understand structure
+        with open(yaml_file, 'r') as f:
+            data = yaml.safe_load(f)
+
+        if not data or 'KnownVulnerableSamples' not in data:
+            continue
+
+        samples = data['KnownVulnerableSamples']
+        if not samples:
+            continue
+
+        # Identify which samples need fixing
+        fixes = []
+        for sample in samples:
+            existing_auth = sample.get('Authentihash', {})
+            if existing_auth and (existing_auth.get('SHA256') or existing_auth.get('SHA1')):
+                continue
+
+            matched_fields = {}
+            for field in ['SHA256', 'SHA1', 'MD5']:
+                val = sample.get(field, '')
+                if val and val.lower() in all_hashes:
+                    matched_fields[field] = val
+
+            if not matched_fields:
+                continue
+
+            # Find the SiPolicy group
+            first_match = list(matched_fields.values())[0]
+            info = all_hashes.get(first_match.lower())
+            if not info or 'prefix' not in info:
+                continue
+
+            group = groups.get(info['prefix'], {})
+            authentihash = {'MD5': '', 'SHA1': '', 'SHA256': ''}
+
+            if group:
+                if 'sha1' in group:
+                    authentihash['SHA1'] = group['sha1']
+                if 'sha256' in group:
+                    authentihash['SHA256'] = group['sha256']
+
+            for field, val in matched_fields.items():
+                field_info = all_hashes[val.lower()]
+                if field_info['type'] == 'sha256':
+                    authentihash['SHA256'] = val.lower()
+                elif field_info['type'] == 'sha1':
+                    authentihash['SHA1'] = val.lower()
+
+            if not authentihash['SHA256'] and not authentihash['SHA1']:
+                continue
+
+            fixes.append((matched_fields, authentihash))
+
+        if not fixes:
+            continue
+
+        # Read raw file content for text-based edits
+        with open(yaml_file, 'r') as f:
+            content = f.read()
+
+        file_modified = False
+        filename = os.path.basename(yaml_file)
+
+        # Detect indent level for KnownVulnerableSamples entries
+        # Could be "    SHA256:" (4 spaces) or "  SHA256:" (2 spaces)
+        indent_match = re.search(r'^( +)SHA256:', content, re.MULTILINE)
+        indent = indent_match.group(1) if indent_match else '    '
+
+        for matched_fields, authentihash in fixes:
+            for field, val in matched_fields.items():
+                content_new, success = apply_text_edit(
+                    content, field, val, authentihash, indent
+                )
+                if success:
+                    content = content_new
+                    file_modified = True
+                    total_samples_fixed += 1
+                    print(f"  [{filename}] Moved {field}: {val[:16]}... to Authentihash")
+                    if authentihash['SHA256']:
+                        print(f"    Authentihash SHA256: {authentihash['SHA256']}")
+                    if authentihash['SHA1']:
+                        print(f"    Authentihash SHA1:  {authentihash['SHA1']}")
+                    break  # Only one field per sample needs moving
+
+        if file_modified:
+            modified_files.append(yaml_file)
+            if not dry_run:
+                with open(yaml_file, 'w') as f:
+                    f.write(content)
+
+    return modified_files, total_samples_fixed
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Fix authenticode hashes misclassified as file hashes in YAML driver files')
+    parser.add_argument('--yaml-dir', default='yaml/',
+                        help='Directory containing YAML driver files')
+    parser.add_argument('--sipolicy', nargs='+',
+                        default=[
+                            '.context/attachments/SiPolicy_Enforced.xml',
+                            '.context/attachments/SiPolicy_Enforced_Server2016.xml',
+                            '.context/attachments/SiPolicy_Audit.xml',
+                        ],
+                        help='Path(s) to SiPolicy XML files')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Show what would be changed without modifying files')
+    args = parser.parse_args()
+
+    print("Parsing SiPolicy XML files...")
+    for sp in args.sipolicy:
+        if not os.path.exists(sp):
+            print(f"  WARNING: {sp} not found, skipping")
+    sipolicy_paths = [sp for sp in args.sipolicy if os.path.exists(sp)]
+
+    all_hashes, groups = parse_sipolicy_hashes(sipolicy_paths)
+    print(f"  Found {len(all_hashes)} unique deny hashes across {len(groups)} driver groups")
+
+    print(f"\nScanning YAML files in {args.yaml_dir}...")
+    if args.dry_run:
+        print("  (DRY RUN - no files will be modified)\n")
+
+    modified, total_fixed = process_yaml_files(
+        args.yaml_dir, all_hashes, groups, dry_run=args.dry_run)
+
+    print(f"\nSummary:")
+    print(f"  Files modified: {len(modified)}")
+    print(f"  Samples fixed:  {total_fixed}")
+
+    if args.dry_run and modified:
+        print(f"\n  Re-run without --dry-run to apply changes.")
+
+
+if __name__ == '__main__':
+    main()

--- a/yaml/058fb356-e0ff-4f5e-8293-319feb005db2.yaml
+++ b/yaml/058fb356-e0ff-4f5e-8293-319feb005db2.yaml
@@ -30,9 +30,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 0f780b7ada5dd8464d9f2cc537d973f5ac804e9c
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 0f780b7ada5dd8464d9f2cc537d973f5ac804e9c
+        SHA256: 7fd788358585e0b863328475898bb4400ed8d478466d1b7f5cc0252671456cc8
 -   Company: ''
     Date: ''
     Description: ''
@@ -43,6 +47,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: ea360a9f23bb7cf67f08b88e6a185a699f0c5410
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 0f780b7ada5dd8464d9f2cc537d973f5ac804e9c
+        SHA256: 7fd788358585e0b863328475898bb4400ed8d478466d1b7f5cc0252671456cc8

--- a/yaml/067589f2-4f29-4dc4-bd50-a2e2ee57b25f.yaml
+++ b/yaml/067589f2-4f29-4dc4-bd50-a2e2ee57b25f.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 3e9b62d2ea2be50a2da670746c4dbe807db9601980af3a1014bcd72d0248d84c
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 39f934078a060bad2d58b5dba8f8884903d697a7
+        SHA256: 3e9b62d2ea2be50a2da670746c4dbe807db9601980af3a1014bcd72d0248d84c

--- a/yaml/0d0d204b-f6ce-4ce4-8d76-1724a1676c3f.yaml
+++ b/yaml/0d0d204b-f6ce-4ce4-8d76-1724a1676c3f.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 49ed27460730b62403c1d2e4930573121ab0c86c442854bc0a62415ca445a810
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 69d6b4032f1456506382885eba5b396f1c36841b
+        SHA256: 49ed27460730b62403c1d2e4930573121ab0c86c442854bc0a62415ca445a810

--- a/yaml/0f6c3a28-4d04-474b-a098-37383f984686.yaml
+++ b/yaml/0f6c3a28-4d04-474b-a098-37383f984686.yaml
@@ -31,7 +31,11 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 8fb149fc476cf5bf18dc575334edad7caf210996
+    SHA1: ''
     SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 8fb149fc476cf5bf18dc575334edad7caf210996
+        SHA256: 40a8fd2d1de93611ac88f29352476fbe0c2607b1d973dab8923ff0811f92f659

--- a/yaml/1068f5cc-65dd-4fd0-b3d8-1d982b37405f.yaml
+++ b/yaml/1068f5cc-65dd-4fd0-b3d8-1d982b37405f.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 01779ee53f999464465ed690d823d160f73f10e7
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 01779ee53f999464465ed690d823d160f73f10e7
+        SHA256: ''

--- a/yaml/13b2424a-d337-4bc7-ad1d-2049c79906b4.yaml
+++ b/yaml/13b2424a-d337-4bc7-ad1d-2049c79906b4.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 36875562e747136313ec5db58174e5fab870997a054ca8d3987d181599c7db6a
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 560d8869d48a71e59601b76240e9a6cffb068c9c
+        SHA256: 36875562e747136313ec5db58174e5fab870997a054ca8d3987d181599c7db6a

--- a/yaml/19003e00-d42d-4cbe-91f3-756451bdd7da.yaml
+++ b/yaml/19003e00-d42d-4cbe-91f3-756451bdd7da.yaml
@@ -40,9 +40,13 @@ KnownVulnerableSamples:
   Product: ''
   ProductVersion: ''
   Publisher: ''
-  SHA1: 0b6ec2aedc518849a1c61a70b1f9fb068ede2bc3
+  SHA1: ''
   Signature: []
   LoadsDespiteHVCI: 'FALSE'
+  Authentihash:
+      MD5: ''
+      SHA1: 0b6ec2aedc518849a1c61a70b1f9fb068ede2bc3
+      SHA256: 399effe75d32bdab6fa0a6bffe02dbf0a59219d940b654837c3be1c0bd02e9aa
 - Company: ''
   Date: ''
   Description: ''
@@ -53,9 +57,13 @@ KnownVulnerableSamples:
   Product: ''
   ProductVersion: ''
   Publisher: ''
-  SHA1: 461882bd59887617cadc1c7b2b22d0a45458c070
+  SHA1: ''
   Signature: []
   LoadsDespiteHVCI: 'FALSE'
+  Authentihash:
+      MD5: ''
+      SHA1: 0b6ec2aedc518849a1c61a70b1f9fb068ede2bc3
+      SHA256: 399effe75d32bdab6fa0a6bffe02dbf0a59219d940b654837c3be1c0bd02e9aa
 - Company: ''
   Date: ''
   Description: ''
@@ -66,9 +74,13 @@ KnownVulnerableSamples:
   Product: ''
   ProductVersion: ''
   Publisher: ''
-  SHA1: a7948a4e9a3a1a9ed0e4e41350e422464d8313cd
+  SHA1: ''
   Signature: []
   LoadsDespiteHVCI: 'FALSE'
+  Authentihash:
+      MD5: ''
+      SHA1: a7948a4e9a3a1a9ed0e4e41350e422464d8313cd
+      SHA256: 7aaf2aa194b936e48bc90f01ee854768c8383c0be50cfb41b346666aec0cf853
 - Company: ''
   Date: ''
   Description: ''
@@ -79,9 +91,13 @@ KnownVulnerableSamples:
   Product: ''
   ProductVersion: ''
   Publisher: ''
-  SHA1: f3cce7e79ab5bd055f311bb3ac44a838779270b6
+  SHA1: ''
   Signature: []
   LoadsDespiteHVCI: 'FALSE'
+  Authentihash:
+      MD5: ''
+      SHA1: a7948a4e9a3a1a9ed0e4e41350e422464d8313cd
+      SHA256: 7aaf2aa194b936e48bc90f01ee854768c8383c0be50cfb41b346666aec0cf853
 - Company: ''
   Date: ''
   Description: ''
@@ -94,10 +110,14 @@ KnownVulnerableSamples:
   ProductVersion: ''
   Publisher: ''
   SHA1: ''
-  SHA256: 399EFFE75D32BDAB6FA0A6BFFE02DBF0A59219D940B654837C3BE1C0BD02E9AA
+  SHA256: ''
   Signature:
   - ''
   LoadsDespiteHVCI: 'FALSE'
+  Authentihash:
+      MD5: ''
+      SHA1: 0b6ec2aedc518849a1c61a70b1f9fb068ede2bc3
+      SHA256: 399effe75d32bdab6fa0a6bffe02dbf0a59219d940b654837c3be1c0bd02e9aa
 - Company: ''
   Date: ''
   Description: ''
@@ -110,10 +130,14 @@ KnownVulnerableSamples:
   ProductVersion: ''
   Publisher: ''
   SHA1: ''
-  SHA256: 27CD05527FEB020084A4A76579C125458571DA8843CDFC3733211760A11DA970
+  SHA256: ''
   Signature:
   - ''
   LoadsDespiteHVCI: 'FALSE'
+  Authentihash:
+      MD5: ''
+      SHA1: 0b6ec2aedc518849a1c61a70b1f9fb068ede2bc3
+      SHA256: 399effe75d32bdab6fa0a6bffe02dbf0a59219d940b654837c3be1c0bd02e9aa
 - Company: ''
   Date: ''
   Description: ''
@@ -126,10 +150,14 @@ KnownVulnerableSamples:
   ProductVersion: ''
   Publisher: ''
   SHA1: ''
-  SHA256: 7AAF2AA194B936E48BC90F01EE854768C8383C0BE50CFB41B346666AEC0CF853
+  SHA256: ''
   Signature:
   - ''
   LoadsDespiteHVCI: 'FALSE'
+  Authentihash:
+      MD5: ''
+      SHA1: a7948a4e9a3a1a9ed0e4e41350e422464d8313cd
+      SHA256: 7aaf2aa194b936e48bc90f01ee854768c8383c0be50cfb41b346666aec0cf853
 - Company: ''
   Date: ''
   Description: ''
@@ -142,10 +170,14 @@ KnownVulnerableSamples:
   ProductVersion: ''
   Publisher: ''
   SHA1: ''
-  SHA256: 727E8BA66A8FF07BDC778EACB463B65F2D7167A6616CA2F259EA32571CACF8AF
+  SHA256: ''
   Signature:
   - ''
   LoadsDespiteHVCI: 'FALSE'
+  Authentihash:
+      MD5: ''
+      SHA1: a7948a4e9a3a1a9ed0e4e41350e422464d8313cd
+      SHA256: 7aaf2aa194b936e48bc90f01ee854768c8383c0be50cfb41b346666aec0cf853
 - Authentihash:
     MD5: 8faa23dd62881edd4c9a04f51649c212
     SHA1: 0b6ec2aedc518849a1c61a70b1f9fb068ede2bc3

--- a/yaml/193df066-c27c-4343-a4eb-ad2ac417a4cc.yaml
+++ b/yaml/193df066-c27c-4343-a4eb-ad2ac417a4cc.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: fd33fb2735cc5ef466a54807d3436622407287e325276fcd3ed1290c98bd0533
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 7a43be821832e9bf55b1b781ae468179d0e4f56e
+        SHA256: fd33fb2735cc5ef466a54807d3436622407287e325276fcd3ed1290c98bd0533

--- a/yaml/1d4f7a3a-786b-4a74-b34f-14d44343de9e.yaml
+++ b/yaml/1d4f7a3a-786b-4a74-b34f-14d44343de9e.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: d7bc7306cb489fe4c285bbeddc6d1a09e814ef55cf30bd5b8daf87a52396f102
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: ec7947ad1919c8f60bc973b96da4132a1ea396e0
+        SHA256: d7bc7306cb489fe4c285bbeddc6d1a09e814ef55cf30bd5b8daf87a52396f102

--- a/yaml/1ed9d02f-17cf-43dd-9645-a54452468a5e.yaml
+++ b/yaml/1ed9d02f-17cf-43dd-9645-a54452468a5e.yaml
@@ -31,9 +31,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: b242b0332b9c9e8e17ec27ef10d75503d20d97b6
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: b242b0332b9c9e8e17ec27ef10d75503d20d97b6
+        SHA256: ''
 -   Company: ''
     Date: ''
     Description: ''
@@ -44,6 +48,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: a65fabaf64aa1934314aae23f25cdf215cbaa4b6
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: a65fabaf64aa1934314aae23f25cdf215cbaa4b6
+        SHA256: ''

--- a/yaml/204eccdf-99ca-4f2a-a325-8ebe34fd29a1.yaml
+++ b/yaml/204eccdf-99ca-4f2a-a325-8ebe34fd29a1.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 221dfbc74bbb255b0879360ccc71a74b756b2e0f16e9386b38a9ce9d4e2e34f9
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 3debe170b5a113407f9e86ee6ed9ae00c3d82c9f
+        SHA256: 221dfbc74bbb255b0879360ccc71a74b756b2e0f16e9386b38a9ce9d4e2e34f9

--- a/yaml/2cc3dd4f-8a1e-4f1f-9871-0a14815949b4.yaml
+++ b/yaml/2cc3dd4f-8a1e-4f1f-9871-0a14815949b4.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: bc2f3850c7b858340d7ed27b90e63b036881fd6c
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: bc2f3850c7b858340d7ed27b90e63b036881fd6c
+        SHA256: f08ebddc11aefcb46082c239f8d97ceea247d846e22c4bcdd72af75c1cbc6b0b

--- a/yaml/2cfede23-67f4-4af7-830f-c95ba30a43ae.yaml
+++ b/yaml/2cfede23-67f4-4af7-830f-c95ba30a43ae.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 0c74d09da7baf7c05360346e4c3512d0cd433d59
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 0c74d09da7baf7c05360346e4c3512d0cd433d59
+        SHA256: ''

--- a/yaml/30d6c39c-1d93-4101-8dd3-322ff0ab7fb3.yaml
+++ b/yaml/30d6c39c-1d93-4101-8dd3-322ff0ab7fb3.yaml
@@ -30,9 +30,13 @@ KnownVulnerableSamples:
   Product: ''
   ProductVersion: ''
   Publisher: ''
-  SHA256: f8886a9c759e0426e08d55e410b02c5b05af3c287b15970175e4874316ffaf13
+  SHA256: ''
   Signature: []
   LoadsDespiteHVCI: 'FALSE'
+  Authentihash:
+      MD5: ''
+      SHA1: b04ecc8dd0d52fe4552d2c4d693d67fae20c460f
+      SHA256: f8886a9c759e0426e08d55e410b02c5b05af3c287b15970175e4874316ffaf13
 - Authentihash:
     MD5: e6afe5e6540dab647a06673be116690b
     SHA1: b04ecc8dd0d52fe4552d2c4d693d67fae20c460f

--- a/yaml/31a962ce-43ef-410f-873a-7ccc8f00332b.yaml
+++ b/yaml/31a962ce-43ef-410f-873a-7ccc8f00332b.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 4cff6e53430b81ecc4fae453e59a0353bcfe73dd5780abfc35f299c16a97998e
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 0ce54b617de11c24670064960b736ef9c47a5f15
+        SHA256: 4cff6e53430b81ecc4fae453e59a0353bcfe73dd5780abfc35f299c16a97998e

--- a/yaml/354a9fcf-acf1-4151-94d2-af88116f605c.yaml
+++ b/yaml/354a9fcf-acf1-4151-94d2-af88116f605c.yaml
@@ -30,9 +30,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: a7d827a41b2c4b7638495cd1d77926f1ba902978
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 877c6c36a155109888fe1f9797b93cb30b4957ef
+        SHA256: 4e19d4ce649c28dd947424483796beace3656284fb0379d97dddd320aa602bbc
 -   Company: ''
     Date: ''
     Description: ''
@@ -43,6 +47,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 877c6c36a155109888fe1f9797b93cb30b4957ef
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 877c6c36a155109888fe1f9797b93cb30b4957ef
+        SHA256: 4e19d4ce649c28dd947424483796beace3656284fb0379d97dddd320aa602bbc

--- a/yaml/3fb743b8-d3ed-4873-9c95-e212720dde21.yaml
+++ b/yaml/3fb743b8-d3ed-4873-9c95-e212720dde21.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 0fd2df82341bf5ebb8a53682e60d08978100c01acb0bed7b6ce2876ada80f670
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: cec5447d0529f97c4bf4a012ea58aab07139ffe0
+        SHA256: 0fd2df82341bf5ebb8a53682e60d08978100c01acb0bed7b6ce2876ada80f670

--- a/yaml/404f6db5-6be8-44a9-9898-badd56f96721.yaml
+++ b/yaml/404f6db5-6be8-44a9-9898-badd56f96721.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: cc383ad11e9d06047a1558ed343f389492da3ac2b84b71462aee502a2fa616c8
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 3c20bb896fd16b5c698185fb176e820a448997b3
+        SHA256: cc383ad11e9d06047a1558ed343f389492da3ac2b84b71462aee502a2fa616c8

--- a/yaml/4137ecf0-05e7-463a-94da-47b7259d4433.yaml
+++ b/yaml/4137ecf0-05e7-463a-94da-47b7259d4433.yaml
@@ -30,9 +30,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: faa870b0cb15c9ac2b9bba5d0470bd501ccd4326
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: faa870b0cb15c9ac2b9bba5d0470bd501ccd4326
+        SHA256: b430d3a0bdb837a5d6625d3b1cef07abd1953f969869ff6cf7ba398ae605431a
 -   Company: ''
     Date: ''
     Description: ''
@@ -43,9 +47,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: aca8e53483b40a06dfdee81bb364b1622f9156fe
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: aca8e53483b40a06dfdee81bb364b1622f9156fe
+        SHA256: b430d3a0bdb837a5d6625d3b1cef07abd1953f969869ff6cf7ba398ae605431a
 -   Company: ''
     Date: ''
     Description: ''
@@ -56,6 +64,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 05ac1c64ca16ab0517fe85d4499d08199e63df26
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 05ac1c64ca16ab0517fe85d4499d08199e63df26
+        SHA256: b430d3a0bdb837a5d6625d3b1cef07abd1953f969869ff6cf7ba398ae605431a

--- a/yaml/457f8b21-202a-4a3d-a18d-b4aaded9ef02.yaml
+++ b/yaml/457f8b21-202a-4a3d-a18d-b4aaded9ef02.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: f18e669127c041431cde8f2d03b15cfc20696056
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: f18e669127c041431cde8f2d03b15cfc20696056
+        SHA256: ''

--- a/yaml/45f2c348-bf17-40ab-8306-ef14231cc996.yaml
+++ b/yaml/45f2c348-bf17-40ab-8306-ef14231cc996.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: f1c8c3926d0370459a1b7f0cf3d17b22ff9d0c7f
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: f1c8c3926d0370459a1b7f0cf3d17b22ff9d0c7f
+        SHA256: ''

--- a/yaml/4b047bb8-c605-4664-baed-25bb70e864a1.yaml
+++ b/yaml/4b047bb8-c605-4664-baed-25bb70e864a1.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: d5562fb90b0b3deb633ab335bcbd82ce10953466a428b3f27cb5b226b453eaf3
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 1236573a309c4edb52e050e53e73188183c23e7e
+        SHA256: d5562fb90b0b3deb633ab335bcbd82ce10953466a428b3f27cb5b226b453eaf3

--- a/yaml/4f93e19c-4600-4e2e-943f-a986875fd7d2.yaml
+++ b/yaml/4f93e19c-4600-4e2e-943f-a986875fd7d2.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: ae79e760c739d6214c1e314728a78a6cb6060cce206fde2440a69735d639a0a2
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: fd081f7a372b939db8523e222d118b87450d3d19
+        SHA256: ae79e760c739d6214c1e314728a78a6cb6060cce206fde2440a69735d639a0a2

--- a/yaml/578d4909-c2ba-4363-b6e3-98fb62d5e55c.yaml
+++ b/yaml/578d4909-c2ba-4363-b6e3-98fb62d5e55c.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 0ebaef662b14410c198395b13347e1d175334ec67919709ad37d65eba013adff
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 150f5dae8716b09a64cac96862f5e2506a71e771
+        SHA256: 0ebaef662b14410c198395b13347e1d175334ec67919709ad37d65eba013adff

--- a/yaml/579a0516-1177-45ce-ad9e-45f53b28dcdc.yaml
+++ b/yaml/579a0516-1177-45ce-ad9e-45f53b28dcdc.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 84df20b1d9d87e305c92e5ffae21b10b325609d59d835a954dbd8750ef5dabf4
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: fd8a340cd071bc98e6eeac9bbd4ac8a78688bc17
+        SHA256: 84df20b1d9d87e305c92e5ffae21b10b325609d59d835a954dbd8750ef5dabf4

--- a/yaml/5d3f0b7d-7413-48e6-8d9c-7fc0bb5a66ee.yaml
+++ b/yaml/5d3f0b7d-7413-48e6-8d9c-7fc0bb5a66ee.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: c60fcff9c8e5243bbb22ec94618b9dcb02c59bb49b90c04d7d6ab3ebbd58dc3a
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: aa937f73a8afcda98e868f4aeeb0eb81a4150075
+        SHA256: c60fcff9c8e5243bbb22ec94618b9dcb02c59bb49b90c04d7d6ab3ebbd58dc3a

--- a/yaml/65660363-0080-4432-abd9-64368dac0283.yaml
+++ b/yaml/65660363-0080-4432-abd9-64368dac0283.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 146d77e80ca70ea5cb17bfc9a5cea92334f809cbdc87a51c2d10b8579a4b9c88
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 1cf3b0a2a0b47477a840adc2b520401e18af16d6
+        SHA256: 146d77e80ca70ea5cb17bfc9a5cea92334f809cbdc87a51c2d10b8579a4b9c88

--- a/yaml/69b924ab-2e4a-4eae-8091-4151c238136e.yaml
+++ b/yaml/69b924ab-2e4a-4eae-8091-4151c238136e.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: a3e507e713f11901017fc328186ae98e23de7cea5594687480229f77d45848d8
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 1f7804d9185b1910c43bd4104d58b96994ff8e49
+        SHA256: a3e507e713f11901017fc328186ae98e23de7cea5594687480229f77d45848d8

--- a/yaml/6a7d882b-3d9d-4334-be5f-2e29c6bf9ff8.yaml
+++ b/yaml/6a7d882b-3d9d-4334-be5f-2e29c6bf9ff8.yaml
@@ -30,9 +30,13 @@ KnownVulnerableSamples:
   Product: ''
   ProductVersion: ''
   Publisher: ''
-  SHA256: 72b99147839bcfb062d29014ec09fe20a8f261748b5925b00171ef3cb849a4c1
+  SHA256: ''
   Signature: []
   LoadsDespiteHVCI: 'FALSE'
+  Authentihash:
+      MD5: ''
+      SHA1: 83660d245fe618ecafe4900ac1e2ad0292c2da2a
+      SHA256: 72b99147839bcfb062d29014ec09fe20a8f261748b5925b00171ef3cb849a4c1
 - Authentihash:
     MD5: 038cbc948ff5ba06ac0b54ca31401fe4
     SHA1: 83660d245fe618ecafe4900ac1e2ad0292c2da2a

--- a/yaml/7196366e-04f0-4aaf-9184-ed0a0d21a75f.yaml
+++ b/yaml/7196366e-04f0-4aaf-9184-ed0a0d21a75f.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: be03e9541f56ac6ed1e81407dcd7cc85c0ffc538c3c2c2c8a9c747edbcf13100
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 738cf0afb7ecdf35a92667c8802d512a0caf353c
+        SHA256: be03e9541f56ac6ed1e81407dcd7cc85c0ffc538c3c2c2c8a9c747edbcf13100

--- a/yaml/7437388f-821e-421f-a3c1-62ce2c725a6a.yaml
+++ b/yaml/7437388f-821e-421f-a3c1-62ce2c725a6a.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 5b9623da9ba8e5c80c49473f40ffe7ad315dcadffc3230afdc9d9226d60a715a
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 8a50e81d6e6c45410bf13f95b1a67cada8c82221
+        SHA256: 5b9623da9ba8e5c80c49473f40ffe7ad315dcadffc3230afdc9d9226d60a715a

--- a/yaml/75a933b4-82d8-4eb8-8ed5-a0a2178630a3.yaml
+++ b/yaml/75a933b4-82d8-4eb8-8ed5-a0a2178630a3.yaml
@@ -30,9 +30,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 8cc8974a05e81678e3d28acfe434e7804abd019c
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 8cc8974a05e81678e3d28acfe434e7804abd019c
+        SHA256: 97b976f7e7e5df7af0781bbbb33cb5f3f7a59efdd07995253b31de8123352a67
 -   Company: ''
     Date: ''
     Description: ''
@@ -43,6 +47,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 282bb241bda5c4c1b8eb9bf56d018896649ca0e1
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 8cc8974a05e81678e3d28acfe434e7804abd019c
+        SHA256: 97b976f7e7e5df7af0781bbbb33cb5f3f7a59efdd07995253b31de8123352a67

--- a/yaml/86b520f6-cc90-4488-b343-168cad88010d.yaml
+++ b/yaml/86b520f6-cc90-4488-b343-168cad88010d.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 3ae56ab63230d6d9552360845b4a37b5801cc5ea
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 3ae56ab63230d6d9552360845b4a37b5801cc5ea
+        SHA256: 44a0599defea351314663582dbc61069b3a095a4ddad571bb17dd0d8b21e7ff2

--- a/yaml/8c2fa9d1-b2b1-4ba1-bad9-60c44c2c20eb.yaml
+++ b/yaml/8c2fa9d1-b2b1-4ba1-bad9-60c44c2c20eb.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 258359a7fa3d975620c9810dab3a6493972876a024135feaf3ac8482179b2e79
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: d85c6097a2279301222b6a06b93296ace669a76d
+        SHA256: 258359a7fa3d975620c9810dab3a6493972876a024135feaf3ac8482179b2e79

--- a/yaml/8d14d798-338f-471e-bacb-6d9371c0f529.yaml
+++ b/yaml/8d14d798-338f-471e-bacb-6d9371c0f529.yaml
@@ -30,9 +30,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 485c0b9710a196c7177b99ee95e5ddb35b26ddd1
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 485c0b9710a196c7177b99ee95e5ddb35b26ddd1
+        SHA256: 96ee751f7c38731e97773e07e0f13f4dd361af9aaa1d30b41652c2e6efc3fb3e
 -   Company: ''
     Date: ''
     Description: ''
@@ -43,9 +47,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 50e2bc41f0186fdce970b80e2a2cb296353af586
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 485c0b9710a196c7177b99ee95e5ddb35b26ddd1
+        SHA256: 96ee751f7c38731e97773e07e0f13f4dd361af9aaa1d30b41652c2e6efc3fb3e
 -   Company: ''
     Date: ''
     Description: ''
@@ -56,9 +64,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: e3c1dd569aa4758552566b0213ee4d1fe6382c4b
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: e3c1dd569aa4758552566b0213ee4d1fe6382c4b
+        SHA256: fe4270a61dbed978c28b2915fcc2826d011148dcb7533fa8bd072ddce5944cef
 -   Company: ''
     Date: ''
     Description: ''
@@ -69,6 +81,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: e09b5e80805b8fe853ea27d8773e31bff262e3f7
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: e3c1dd569aa4758552566b0213ee4d1fe6382c4b
+        SHA256: fe4270a61dbed978c28b2915fcc2826d011148dcb7533fa8bd072ddce5944cef

--- a/yaml/90e8600a-9b5c-4153-bb06-1d8fbe0ef232.yaml
+++ b/yaml/90e8600a-9b5c-4153-bb06-1d8fbe0ef232.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 455bc98ba32adab8b47d2d89bdbadca4910f91c182ab2fc3211ba07d3784537b
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 61258963d900c2a39408ef4b51f69f405f55e407
+        SHA256: 455bc98ba32adab8b47d2d89bdbadca4910f91c182ab2fc3211ba07d3784537b

--- a/yaml/920e3326-e5dc-446a-9993-6ec05266e0e0.yaml
+++ b/yaml/920e3326-e5dc-446a-9993-6ec05266e0e0.yaml
@@ -30,9 +30,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: d569d4bab86e70efbcdfdac9d822139d6f477b7c
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: d569d4bab86e70efbcdfdac9d822139d6f477b7c
+        SHA256: c1b41d6b91448e2409bb2f4fbf4aeb952adf373d0decc9d052277b89ba401407
 -   Company: ''
     Date: ''
     Description: ''
@@ -43,9 +47,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 80fa962bdfb76dfcb9e5d13efc38bb3d392f2e77
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 55ab7e27412eca433d76513edc7e6e03bcdd7eda
+        SHA256: c1b41d6b91448e2409bb2f4fbf4aeb952adf373d0decc9d052277b89ba401407
 -   Company: ''
     Date: ''
     Description: ''
@@ -56,9 +64,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 5a7dd0da0aee0bdedc14c1b7831b9ce9178a0346
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 5a7dd0da0aee0bdedc14c1b7831b9ce9178a0346
+        SHA256: c1b41d6b91448e2409bb2f4fbf4aeb952adf373d0decc9d052277b89ba401407
 -   Company: ''
     Date: ''
     Description: ''
@@ -69,9 +81,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 1acc7a486b52c5ee6619dbdc3b4210b5f48b936f
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 55ab7e27412eca433d76513edc7e6e03bcdd7eda
+        SHA256: c1b41d6b91448e2409bb2f4fbf4aeb952adf373d0decc9d052277b89ba401407
 -   Company: ''
     Date: ''
     Description: ''
@@ -82,9 +98,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 55ab7e27412eca433d76513edc7e6e03bcdd7eda
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 55ab7e27412eca433d76513edc7e6e03bcdd7eda
+        SHA256: c1b41d6b91448e2409bb2f4fbf4aeb952adf373d0decc9d052277b89ba401407
 -   Company: ''
     Date: ''
     Description: ''
@@ -95,6 +115,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 1e7c241b9a9ea79061b50fb19b3d141dee175c27
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 55ab7e27412eca433d76513edc7e6e03bcdd7eda
+        SHA256: c1b41d6b91448e2409bb2f4fbf4aeb952adf373d0decc9d052277b89ba401407

--- a/yaml/974de971-1f78-47b9-8049-6c34f294acd5.yaml
+++ b/yaml/974de971-1f78-47b9-8049-6c34f294acd5.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 37dde6bd8a7a36111c3ac57e0ac20bbb93ce3374d0852bcacc9a2c8c8c30079e
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 73857acdd7d7c9235f3e18c503a27e7c88c5fcb0
+        SHA256: 37dde6bd8a7a36111c3ac57e0ac20bbb93ce3374d0852bcacc9a2c8c8c30079e

--- a/yaml/99668140-a8f6-48f8-86d1-cf3bf693600c.yaml
+++ b/yaml/99668140-a8f6-48f8-86d1-cf3bf693600c.yaml
@@ -30,9 +30,13 @@ KnownVulnerableSamples:
   Product: ''
   ProductVersion: ''
   Publisher: ''
-  SHA256: 9d58f640c7295952b71bdcb456cae37213baccdcd3032c1e3aeb54e79081f395
+  SHA256: ''
   Signature: []
   LoadsDespiteHVCI: 'FALSE'
+  Authentihash:
+      MD5: ''
+      SHA1: 67650bc9cdf0716bc7b5664723c38fc5327ec662
+      SHA256: 9d58f640c7295952b71bdcb456cae37213baccdcd3032c1e3aeb54e79081f395
 - Company: ''
   Date: ''
   Description: ''
@@ -43,9 +47,13 @@ KnownVulnerableSamples:
   Product: ''
   ProductVersion: ''
   Publisher: ''
-  SHA256: 4a9093e8dbcb867e1b97a0a67ce99a8511900658f5201c34ffb8035881f2dbbe
+  SHA256: ''
   Signature: []
   LoadsDespiteHVCI: 'FALSE'
+  Authentihash:
+      MD5: ''
+      SHA1: 67650bc9cdf0716bc7b5664723c38fc5327ec662
+      SHA256: 4a9093e8dbcb867e1b97a0a67ce99a8511900658f5201c34ffb8035881f2dbbe
 - Authentihash:
     MD5: d490f971f9503765a947997d7c54a4c7
     SHA1: 67650bc9cdf0716bc7b5664723c38fc5327ec662

--- a/yaml/a1d35b93-e97f-4ddd-a465-2405e804e754.yaml
+++ b/yaml/a1d35b93-e97f-4ddd-a465-2405e804e754.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: dfaefd06b680f9ea837e7815fc1cc7d1f4cc375641ac850667ab20739f46ad22
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 03f0dd3124ec3a4bb6d30865a488f54e74ded699
+        SHA256: dfaefd06b680f9ea837e7815fc1cc7d1f4cc375641ac850667ab20739f46ad22

--- a/yaml/a5792a63-ba77-44ac-bd4a-134b24b01033.yaml
+++ b/yaml/a5792a63-ba77-44ac-bd4a-134b24b01033.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 64f9e664bc6d4b8f5f68616dd50ae819c3e60452efd5e589d6604b9356841b57
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: f50b475d5fd1ed4f866bf43342676e449f779c67
+        SHA256: 64f9e664bc6d4b8f5f68616dd50ae819c3e60452efd5e589d6604b9356841b57

--- a/yaml/ad693146-4adf-4407-bb20-f2505e34c226.yaml
+++ b/yaml/ad693146-4adf-4407-bb20-f2505e34c226.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 3a95cc82173032b82a0ffc7d2e438df64c13bc16b4574214c9fe3be37250925e
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: f3e60b7b9c53315d6158f82596919209a00e1cda
+        SHA256: 3a95cc82173032b82a0ffc7d2e438df64c13bc16b4574214c9fe3be37250925e

--- a/yaml/adfb015a-f453-4b9e-a247-50f146209eb0.yaml
+++ b/yaml/adfb015a-f453-4b9e-a247-50f146209eb0.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 708016fbe22c813a251098f8f992b177b476bd1bbc48c2ed4a122ff74910a965
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 969a945c93f54fcbf17548903131d4b86042df7b
+        SHA256: 708016fbe22c813a251098f8f992b177b476bd1bbc48c2ed4a122ff74910a965

--- a/yaml/b45a3fdf-592a-4cd9-81e2-8fe03d554cad.yaml
+++ b/yaml/b45a3fdf-592a-4cd9-81e2-8fe03d554cad.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 4941c4298f4560fc1e59d0f16f84bab5c060793700b82be2fd7c63735f1657a8
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 82f8d4ba137fa4b0da20e8cd1968a7aaea803dbc
+        SHA256: 4941c4298f4560fc1e59d0f16f84bab5c060793700b82be2fd7c63735f1657a8

--- a/yaml/b7ec29c6-e151-4a9f-a293-e61f04ee6489.yaml
+++ b/yaml/b7ec29c6-e151-4a9f-a293-e61f04ee6489.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: d25904fbf907e19f366d54962ff543d9f53b8fdfd2416c8b9796b6a8dd430e26
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 2a506e2512c9083419b7741b4499e012cdc60204
+        SHA256: d25904fbf907e19f366d54962ff543d9f53b8fdfd2416c8b9796b6a8dd430e26

--- a/yaml/be4843ef-a2a8-4a0d-91c6-42e165800bb0.yaml
+++ b/yaml/be4843ef-a2a8-4a0d-91c6-42e165800bb0.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 0de4247e72d378713bcf22d5c5d3874d079203bb4364e25f67a90d5570bdcce8
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 0d523e8b0b96675ac2e5ac0d56c367564b260545
+        SHA256: 0de4247e72d378713bcf22d5c5d3874d079203bb4364e25f67a90d5570bdcce8

--- a/yaml/c0645f0f-9b97-4fe9-811e-2e45c250c9ef.yaml
+++ b/yaml/c0645f0f-9b97-4fe9-811e-2e45c250c9ef.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: fcdfe570e6dc6e768ef75138033d9961f78045adca53beb6fdb520f6417e0df1
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: c4fe0cbb8da5bf1e02ec6d7a0f97d740955ddd97
+        SHA256: fcdfe570e6dc6e768ef75138033d9961f78045adca53beb6fdb520f6417e0df1

--- a/yaml/c1ece07b-e92a-4050-95ee-90e03aa82120.yaml
+++ b/yaml/c1ece07b-e92a-4050-95ee-90e03aa82120.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 8111085022bda87e5f6aa4c195e743cc6dd6a3a6d41add475d267dc6b105a69f
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 00b4fdc0f7f28ddecd5b4e5880a71e7f08b5f825
+        SHA256: 8111085022bda87e5f6aa4c195e743cc6dd6a3a6d41add475d267dc6b105a69f

--- a/yaml/c2e70ee6-2f13-4d43-ad5a-c2bf033cc457.yaml
+++ b/yaml/c2e70ee6-2f13-4d43-ad5a-c2bf033cc457.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 823da894b2c73ffcd39e77366b6f1abf0ae9604d9b20140a54e6d55053aadeba
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: e343aa3981393778f32df94efac90fe35d6933a9
+        SHA256: 823da894b2c73ffcd39e77366b6f1abf0ae9604d9b20140a54e6d55053aadeba

--- a/yaml/cacc48e6-6ed8-431c-abee-88ee6c2dc3c1.yaml
+++ b/yaml/cacc48e6-6ed8-431c-abee-88ee6c2dc3c1.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: cb9890d4e303a4c03095d7bc176c42dee1b47d8aa58e2f442ec1514c8f9e3cec
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 8f0b99b53eb921547afecf1f12b3299818c4e5d1
+        SHA256: cb9890d4e303a4c03095d7bc176c42dee1b47d8aa58e2f442ec1514c8f9e3cec

--- a/yaml/d05a0a6c-c037-4647-99ac-c41593190223.yaml
+++ b/yaml/d05a0a6c-c037-4647-99ac-c41593190223.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: cb57f3a7fe9e1f8e63332c563b0a319b26c944be839eabc03e9a3277756ba612
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 002223fddc5658ea22b7a8979984a9b54f63b316
+        SHA256: cb57f3a7fe9e1f8e63332c563b0a319b26c944be839eabc03e9a3277756ba612

--- a/yaml/d1441172-cc15-4a96-b782-f440bfb681e1.yaml
+++ b/yaml/d1441172-cc15-4a96-b782-f440bfb681e1.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: dec8a933dba04463ed9bb7d53338ff87f2c23cfb79e0e988449fc631252c9dcc
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 4bbb9709d5f916fe78eaa15431f622761efc496f
+        SHA256: dec8a933dba04463ed9bb7d53338ff87f2c23cfb79e0e988449fc631252c9dcc

--- a/yaml/d5118882-6cdd-4b06-8bf4-e9818f16137e.yaml
+++ b/yaml/d5118882-6cdd-4b06-8bf4-e9818f16137e.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 7d8937c18d6e11a0952e53970a0934cf0e65515637ac24d6ca52ccf4b93d385f
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 295e590d49df717c489c5c824e9c6896a14248bb
+        SHA256: 7d8937c18d6e11a0952e53970a0934cf0e65515637ac24d6ca52ccf4b93d385f

--- a/yaml/ddbd60c3-0611-4a59-894d-aec84203906f.yaml
+++ b/yaml/ddbd60c3-0611-4a59-894d-aec84203906f.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 4b8c0445075f09aeef542ab1c86e5de6b06e91a3
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 4b8c0445075f09aeef542ab1c86e5de6b06e91a3
+        SHA256: 0988d366572a57b3015d875b60704517d05115580678e8f2e126f771eda28f7b

--- a/yaml/e6338692-90e0-41b1-9481-a47e0df144ad.yaml
+++ b/yaml/e6338692-90e0-41b1-9481-a47e0df144ad.yaml
@@ -30,9 +30,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 08596732304351b311970ff96b21f451f23b1e25
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 08596732304351b311970ff96b21f451f23b1e25
+        SHA256: 7b7e0e1453e733050b586a6fac91883dbb85ae0775c84c4ceb967cfc9b4efd10
 -   Company: ''
     Date: ''
     Description: ''
@@ -43,9 +47,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 7838fb56fdab816bc1900a4720eea2fc9972ef7a
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 08596732304351b311970ff96b21f451f23b1e25
+        SHA256: 7b7e0e1453e733050b586a6fac91883dbb85ae0775c84c4ceb967cfc9b4efd10
 -   Company: ''
     Date: ''
     Description: ''
@@ -56,9 +64,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: 4789b910023a667bee70ff1f1a8f369cffb10fe8
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 4789b910023a667bee70ff1f1a8f369cffb10fe8
+        SHA256: 7fb0f6fc5bdd22d53f8532cb19da666a77a66ffb1cf3919a2e22b66c13b415b7
 -   Company: ''
     Date: ''
     Description: ''
@@ -69,6 +81,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA1: eeff4ec4ebc12c6acd2c930dc2eaaf877cfec7ec
+    SHA1: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 4789b910023a667bee70ff1f1a8f369cffb10fe8
+        SHA256: 7fb0f6fc5bdd22d53f8532cb19da666a77a66ffb1cf3919a2e22b66c13b415b7

--- a/yaml/e71f0866-e317-44d4-a456-d6f0c555aa73.yaml
+++ b/yaml/e71f0866-e317-44d4-a456-d6f0c555aa73.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 15c53eb3a0ea44bbd2901a45a6ebeae29bb123f9c1115c38dfb2cdbec0642229
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 8403a17ae001fef3488c2e641e2be553cd5b478d
+        SHA256: 15c53eb3a0ea44bbd2901a45a6ebeae29bb123f9c1115c38dfb2cdbec0642229

--- a/yaml/e9b099f6-8a12-46f0-a540-40e88cf0ce17.yaml
+++ b/yaml/e9b099f6-8a12-46f0-a540-40e88cf0ce17.yaml
@@ -30,6 +30,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: 3390919bb28d5c36cc348f9ef23be5fa49bfd81263eb7740826e4437cbe904cd
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 83767982b3a5f70615a386f4d6638f20509f3560
+        SHA256: 3390919bb28d5c36cc348f9ef23be5fa49bfd81263eb7740826e4437cbe904cd

--- a/yaml/f93e88c2-d0e8-4347-869f-efa568955e9d.yaml
+++ b/yaml/f93e88c2-d0e8-4347-869f-efa568955e9d.yaml
@@ -31,9 +31,13 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: fafa1bb36f0ac34b762a10e9f327dcab2152a6d0b16a19697362d49a31e7f566
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: dc38cc55b84a1a7c0846fb5509b43b4ff97a9be6
+        SHA256: fafa1bb36f0ac34b762a10e9f327dcab2152a6d0b16a19697362d49a31e7f566
 -   Company: ''
     Date: ''
     Description: ''
@@ -44,6 +48,10 @@ KnownVulnerableSamples:
     Product: ''
     ProductVersion: ''
     Publisher: ''
-    SHA256: de6bf572d39e2611773e7a01f0388f84fb25da6cba2f1f8b9b36ffba467de6fa
+    SHA256: ''
     Signature: []
     LoadsDespiteHVCI: 'FALSE'
+    Authentihash:
+        MD5: ''
+        SHA1: 22c5e127e7e7c567d8624607a6f8f5809deacb55
+        SHA256: de6bf572d39e2611773e7a01f0388f84fb25da6cba2f1f8b9b36ffba467de6fa


### PR DESCRIPTION
## Summary
- Cross-referenced all driver YAML files against Microsoft's SiPolicy (VulnerableDriverBlockList) XML to identify hashes incorrectly stored as file hashes that are actually **authenticode hashes**
- Fixed **84 samples across 58 files** by moving misclassified SHA256/SHA1 values to the `Authentihash` section and pairing them with corresponding hash values from SiPolicy deny rule groups
- Includes a reusable script (`bin/fix_authenticode_hashes.py`) that parses SiPolicy XML and cross-references against YAML files
- This supersedes and expands on the manual fixes in PR #249 (which covered 9 files)

## Context
As reported in #249, hashes (`hash=""`) from the [VulnerableDriverBlockList](https://aka.ms/VulnerableDriverBlockList) are authenticode hashes, not flat file hashes. Many driver entries had these stored in the wrong field (`SHA256`/`SHA1` instead of `Authentihash`), causing hash verification failures and the "unable to verify" warning on 77+ driver pages.