### PR TITLE
feat: HVCI & MS blocklist security metrics on landing page

### DIFF
--- a/bin/blocklist_analysis.py
+++ b/bin/blocklist_analysis.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+Compares LOLDrivers YAML data against the Microsoft Vulnerable Driver Blocklist
+(SiPolicy_Enforced.xml) and computes HVCI bypass metrics.
+
+Produces:
+  1. HVCI metrics — how many samples load despite HVCI
+  2. Overlap — LOLDrivers samples also in the MS blocklist
+  3. Gap — LOLDrivers samples NOT in the MS blocklist
+  4. MS-exclusive — MS blocklist entries not in LOLDrivers
+
+Usage:
+    python3 bin/blocklist_analysis.py [--yaml-dir yaml] [--sipolicy .context/SiPolicy_Enforced.xml]
+"""
+
+import argparse
+import json
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+import yaml
+
+NS = '{urn:schemas-microsoft-com:sipolicy}'
+
+
+def parse_sipolicy(xml_path):
+    """Parse SiPolicy XML and extract deny hashes, signers, and filename rules."""
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    auth_sha256s = set()
+    auth_sha1s = set()
+    hash_deny_count = 0
+    filename_deny_count = 0
+    driver_names = set()
+
+    for deny in root.iter(f'{NS}Deny'):
+        hash_val = deny.get('Hash', '')
+        friendly = deny.get('FriendlyName', '')
+        filename = deny.get('FileName', '')
+
+        # Filename/version-based rule (no hash)
+        if filename and not hash_val:
+            filename_deny_count += 1
+            continue
+
+        if not hash_val:
+            continue
+
+        hash_val = hash_val.lower().strip()
+        hash_deny_count += 1
+
+        # Extract driver name from FriendlyName
+        if '\\' in friendly:
+            name_part = friendly.split('\\')[0].strip()
+            driver_names.add(name_part.lower())
+        elif friendly:
+            name_part = friendly.split(' Hash')[0].strip()
+            if name_part:
+                driver_names.add(name_part.lower())
+
+        # Categorize hash type from FriendlyName
+        if 'Hash Page' in friendly:
+            # Page hashes — skip for matching (LOLDrivers doesn't track these)
+            continue
+        elif 'Hash Sha256' in friendly:
+            auth_sha256s.add(hash_val)
+        elif 'Hash Sha1' in friendly:
+            auth_sha1s.add(hash_val)
+
+    # Count denied signers
+    signer_deny_count = 0
+    for scenario in root.iter(f'{NS}SigningScenario'):
+        for denied in scenario.iter(f'{NS}DeniedSigners'):
+            for _ in denied.iter(f'{NS}DeniedSigner'):
+                signer_deny_count += 1
+
+    return {
+        'auth_sha256s': auth_sha256s,
+        'auth_sha1s': auth_sha1s,
+        'hash_deny_count': hash_deny_count,
+        'filename_deny_count': filename_deny_count,
+        'signer_deny_count': signer_deny_count,
+        'unique_driver_names': driver_names,
+    }
+
+
+def load_loldrivers(yaml_dir):
+    """Load all LOLDrivers YAML files and extract sample data."""
+    samples = []
+    driver_count = 0
+
+    for root_dir, _, files in os.walk(yaml_dir):
+        for fname in sorted(files):
+            if not fname.endswith('.yaml'):
+                continue
+            fpath = os.path.join(root_dir, fname)
+            with open(fpath, 'r') as f:
+                data = yaml.safe_load(f)
+            if not data or 'KnownVulnerableSamples' not in data:
+                continue
+
+            driver_count += 1
+            driver_id = data.get('Id', fname)
+            tags = data.get('Tags', [])
+            category = data.get('Category', '')
+
+            for sample in data['KnownVulnerableSamples']:
+                auth = sample.get('Authentihash', {}) or {}
+                auth_sha256 = (auth.get('SHA256') or '').lower().strip()
+                auth_sha1 = (auth.get('SHA1') or '').lower().strip()
+                flat_sha256 = (sample.get('SHA256') or '').lower().strip()
+                hvci = str(sample.get('LoadsDespiteHVCI', '')).upper().strip()
+                filename = sample.get('Filename') or (tags[0] if tags else '')
+
+                samples.append({
+                    'driver_id': driver_id,
+                    'tags': tags,
+                    'category': category,
+                    'filename': filename,
+                    'auth_sha256': auth_sha256,
+                    'auth_sha1': auth_sha1,
+                    'flat_sha256': flat_sha256,
+                    'hvci': hvci,
+                    'has_authentihash': bool(auth_sha256 or auth_sha1),
+                })
+
+    return samples, driver_count
+
+
+def compute_metrics(samples, sipolicy):
+    """Compute all metrics."""
+    total_samples = len(samples)
+
+    # HVCI metrics
+    hvci_true = sum(1 for s in samples if s['hvci'] == 'TRUE')
+    hvci_false = sum(1 for s in samples if s['hvci'] == 'FALSE')
+    hvci_unknown = total_samples - hvci_true - hvci_false
+
+    # Blocklist comparison
+    matched_samples = []
+    unmatched_samples = []
+    no_authentihash = []
+
+    if sipolicy:
+        for s in samples:
+            if not s['has_authentihash']:
+                no_authentihash.append(s)
+                continue
+
+            in_blocklist = False
+            if s['auth_sha256'] and s['auth_sha256'] in sipolicy['auth_sha256s']:
+                in_blocklist = True
+            elif s['auth_sha1'] and s['auth_sha1'] in sipolicy['auth_sha1s']:
+                in_blocklist = True
+
+            if in_blocklist:
+                matched_samples.append(s)
+            else:
+                unmatched_samples.append(s)
+
+        # MS-exclusive: hashes in blocklist not found in any LOLDrivers sample
+        lol_auth_sha256s = {s['auth_sha256'] for s in samples if s['auth_sha256']}
+        lol_auth_sha1s = {s['auth_sha1'] for s in samples if s['auth_sha1']}
+        ms_exclusive_sha256 = sipolicy['auth_sha256s'] - lol_auth_sha256s
+        ms_exclusive_sha1 = sipolicy['auth_sha1s'] - lol_auth_sha1s
+
+    # Matched drivers (unique driver IDs that have at least one matched sample)
+    matched_driver_ids = {s['driver_id'] for s in matched_samples} if sipolicy else set()
+    unmatched_driver_ids = {s['driver_id'] for s in unmatched_samples} if sipolicy else set()
+    # Drivers with ALL samples unmatched (truly exclusive to LOLDrivers)
+    exclusive_driver_ids = unmatched_driver_ids - matched_driver_ids
+
+    # HVCI + blocklist cross-analysis
+    hvci_bypass_in_blocklist = sum(
+        1 for s in matched_samples if s['hvci'] == 'TRUE'
+    ) if sipolicy else 0
+    hvci_bypass_not_in_blocklist = sum(
+        1 for s in unmatched_samples if s['hvci'] == 'TRUE'
+    ) if sipolicy else 0
+
+    matchable = total_samples - len(no_authentihash) if sipolicy else 0
+
+    return {
+        'total_samples': total_samples,
+        'hvci': {
+            'bypass_count': hvci_true,
+            'blocked_count': hvci_false,
+            'unknown_count': hvci_unknown,
+            'bypass_pct': round(hvci_true / total_samples * 100, 1) if total_samples else 0,
+        },
+        'blocklist': {
+            'ms_auth_sha256_count': len(sipolicy['auth_sha256s']) if sipolicy else 0,
+            'ms_auth_sha1_count': len(sipolicy['auth_sha1s']) if sipolicy else 0,
+            'ms_hash_deny_rules': sipolicy['hash_deny_count'] if sipolicy else 0,
+            'ms_filename_deny_rules': sipolicy['filename_deny_count'] if sipolicy else 0,
+            'ms_signer_deny_count': sipolicy['signer_deny_count'] if sipolicy else 0,
+            'ms_unique_driver_names': len(sipolicy['unique_driver_names']) if sipolicy else 0,
+            'matchable_samples': matchable,
+            'samples_without_authentihash': len(no_authentihash) if sipolicy else 0,
+            'overlap_samples': len(matched_samples) if sipolicy else 0,
+            'overlap_pct': round(len(matched_samples) / matchable * 100, 1) if matchable else 0,
+            'overlap_drivers': len(matched_driver_ids),
+            'loldrivers_exclusive_samples': len(unmatched_samples) if sipolicy else 0,
+            'loldrivers_exclusive_pct': round(len(unmatched_samples) / matchable * 100, 1) if matchable else 0,
+            'loldrivers_exclusive_drivers': len(exclusive_driver_ids),
+            'ms_exclusive_sha256': len(ms_exclusive_sha256) if sipolicy else 0,
+            'ms_exclusive_sha1': len(ms_exclusive_sha1) if sipolicy else 0,
+        },
+        'cross': {
+            'hvci_bypass_in_blocklist': hvci_bypass_in_blocklist,
+            'hvci_bypass_not_in_blocklist': hvci_bypass_not_in_blocklist,
+        },
+    }
+
+
+def print_report(metrics, driver_count):
+    """Print a human-readable report."""
+    total = metrics['total_samples']
+    h = metrics['hvci']
+    b = metrics['blocklist']
+    c = metrics['cross']
+
+    print("=" * 70)
+    print("  LOLDrivers vs Microsoft Vulnerable Driver Blocklist — Analysis")
+    print("=" * 70)
+
+    print(f"\n{'LOLDrivers Overview':}")
+    print(f"  Total drivers (YAML files):        {driver_count}")
+    print(f"  Total samples (hashes):            {total}")
+
+    print(f"\n{'HVCI Bypass Analysis':}")
+    print(f"  Load DESPITE HVCI (bypass):        {h['bypass_count']}  ({h['bypass_pct']}%)")
+    print(f"  Blocked by HVCI:                   {h['blocked_count']}")
+    if h['unknown_count']:
+        print(f"  Unknown/untagged:                  {h['unknown_count']}")
+
+    if b['ms_auth_sha256_count']:
+        print(f"\n{'Microsoft Vulnerable Driver Blocklist':}")
+        print(f"  Unique Authenticode SHA256 hashes: {b['ms_auth_sha256_count']}")
+        print(f"  Unique Authenticode SHA1 hashes:   {b['ms_auth_sha1_count']}")
+        print(f"  Hash-based deny rules:             {b['ms_hash_deny_rules']}")
+        print(f"  Filename-based deny rules:         {b['ms_filename_deny_rules']}")
+        print(f"  Certificate/signer denies:         {b['ms_signer_deny_count']}")
+        print(f"  Unique driver names referenced:    {b['ms_unique_driver_names']}")
+
+        print(f"\n{'Coverage Comparison (Authenticode hash matching)':}")
+        print(f"  LOLDrivers samples with Authentihash: {b['matchable_samples']}")
+        print(f"  Samples WITHOUT Authentihash:         {b['samples_without_authentihash']}")
+        print(f"  ---")
+        print(f"  Overlap (in BOTH):                    {b['overlap_samples']} samples across {b['overlap_drivers']} drivers  ({b['overlap_pct']}%)")
+        print(f"  LOLDrivers exclusive (NOT in MS):     {b['loldrivers_exclusive_samples']} samples across {b['loldrivers_exclusive_drivers']} drivers  ({b['loldrivers_exclusive_pct']}%)")
+        print(f"  MS blocklist exclusive SHA256:         {b['ms_exclusive_sha256']} hashes not in LOLDrivers")
+        print(f"  MS blocklist exclusive SHA1:           {b['ms_exclusive_sha1']} hashes not in LOLDrivers")
+
+        print(f"\n{'HVCI + Blocklist Cross-Analysis':}")
+        print(f"  HVCI bypass AND in MS blocklist:   {c['hvci_bypass_in_blocklist']}")
+        print(f"  HVCI bypass NOT in MS blocklist:   {c['hvci_bypass_not_in_blocklist']}  <-- gap: loads despite HVCI, MS doesn't block")
+
+    print("\n" + "=" * 70)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='LOLDrivers vs Microsoft Driver Blocklist analysis')
+    parser.add_argument('--yaml-dir', default='yaml/',
+                        help='Path to LOLDrivers YAML directory')
+    parser.add_argument('--sipolicy', default='.context/SiPolicy_Enforced.xml',
+                        help='Path to SiPolicy_Enforced.xml')
+    parser.add_argument('--output', default='.context/blocklist_analysis_results.json',
+                        help='Path to write JSON results')
+    args = parser.parse_args()
+
+    # Load LOLDrivers
+    print("Loading LOLDrivers YAML files...")
+    samples, driver_count = load_loldrivers(args.yaml_dir)
+    print(f"  Loaded {len(samples)} samples from {driver_count} drivers")
+
+    # Parse SiPolicy
+    sipolicy = None
+    if os.path.exists(args.sipolicy):
+        print(f"\nParsing SiPolicy XML: {args.sipolicy}")
+        sipolicy = parse_sipolicy(args.sipolicy)
+        print(f"  Found {len(sipolicy['auth_sha256s'])} unique Authenticode SHA256 hashes")
+        print(f"  Found {len(sipolicy['auth_sha1s'])} unique Authenticode SHA1 hashes")
+    else:
+        print(f"\nWARNING: SiPolicy XML not found at {args.sipolicy}")
+        print("  Skipping blocklist comparison (HVCI metrics only)")
+
+    # Compute metrics
+    print("\nComputing metrics...")
+    metrics = compute_metrics(samples, sipolicy)
+
+    # Print report
+    print_report(metrics, driver_count)
+
+    # Write JSON
+    output = {
+        'driver_count': driver_count,
+        **metrics,
+    }
+    # Convert sets to counts for JSON serialization
+    os.makedirs(os.path.dirname(args.output) or '.', exist_ok=True)
+    with open(args.output, 'w') as f:
+        json.dump(output, f, indent=2)
+    print(f"\nResults written to: {args.output}")
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/site.py
+++ b/bin/site.py
@@ -5,9 +5,13 @@ import re
 import os
 import json
 import datetime
+import io
+import zipfile
+import xml.etree.ElementTree as ET
 import jinja2
 import csv
 import pandas as pd
+import requests
 
 
 def write_drivers_csv(drivers, output_dir, VERBOSE):
@@ -71,65 +75,164 @@ def write_drivers_csv(drivers, output_dir, VERBOSE):
     df.to_csv(output_file, quoting=1, index=False)
 
 
-def write_top_products(drivers, output_dir, top_n=5):
-    products_count = {}
+SIPOLICY_NS = '{urn:schemas-microsoft-com:sipolicy}'
+BLOCKLIST_URL = 'https://aka.ms/VulnerableDriverBlockList'
+
+
+def download_sipolicy(cache_dir, sipolicy_override=None):
+    """Download and extract SiPolicy_Enforced.xml from Microsoft's blocklist ZIP."""
+    if sipolicy_override and os.path.exists(sipolicy_override):
+        return sipolicy_override
+
+    cache_path = os.path.join(cache_dir, 'SiPolicy_Enforced.xml')
+    if os.path.exists(cache_path):
+        return cache_path
+
+    try:
+        print("Downloading Microsoft Vulnerable Driver Blocklist...")
+        resp = requests.get(BLOCKLIST_URL, timeout=30)
+        resp.raise_for_status()
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            target = None
+            for name in zf.namelist():
+                if name.endswith('SiPolicy_Enforced.xml') and 'Server2016' not in name:
+                    target = name
+                    break
+            if not target:
+                print("WARNING: SiPolicy_Enforced.xml not found in ZIP")
+                return None
+            os.makedirs(cache_dir, exist_ok=True)
+            with open(cache_path, 'wb') as f:
+                f.write(zf.read(target))
+        print(f"  Saved to {cache_path}")
+        return cache_path
+    except Exception as e:
+        print(f"WARNING: Failed to download blocklist: {e}")
+        return None
+
+
+def parse_sipolicy_hashes(xml_path):
+    """Parse SiPolicy XML and extract deny hashes and signer counts."""
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    auth_sha256s = set()
+    auth_sha1s = set()
+    hash_deny_count = 0
+    filename_deny_count = 0
+
+    for deny in root.iter(f'{SIPOLICY_NS}Deny'):
+        hash_val = deny.get('Hash', '')
+        friendly = deny.get('FriendlyName', '')
+        filename = deny.get('FileName', '')
+
+        if filename and not hash_val:
+            filename_deny_count += 1
+            continue
+        if not hash_val:
+            continue
+
+        hash_val = hash_val.lower().strip()
+        hash_deny_count += 1
+
+        if 'Hash Page' in friendly:
+            continue
+        elif 'Hash Sha256' in friendly:
+            auth_sha256s.add(hash_val)
+        elif 'Hash Sha1' in friendly:
+            auth_sha1s.add(hash_val)
+
+    signer_deny_count = 0
+    for scenario in root.iter(f'{SIPOLICY_NS}SigningScenario'):
+        for denied in scenario.iter(f'{SIPOLICY_NS}DeniedSigners'):
+            for _ in denied.iter(f'{SIPOLICY_NS}DeniedSigner'):
+                signer_deny_count += 1
+
+    return {
+        'auth_sha256s': auth_sha256s,
+        'auth_sha1s': auth_sha1s,
+        'hash_deny_count': hash_deny_count,
+        'filename_deny_count': filename_deny_count,
+        'signer_deny_count': signer_deny_count,
+    }
+
+
+def compute_metrics(drivers, sipolicy_data):
+    """Compute HVCI and blocklist comparison metrics from driver data."""
+    total_drivers = len(drivers)
+    total_samples = 0
+    hvci_true = 0
+    hvci_false = 0
+    matchable = 0
+    overlap = 0
+    no_authentihash = 0
 
     for driver in drivers:
-        for hash_info in driver['KnownVulnerableSamples']:
-            product_name = hash_info.get('Product') or None
+        for sample in driver.get('KnownVulnerableSamples', []):
+            total_samples += 1
+            hvci = str(sample.get('LoadsDespiteHVCI', '')).upper().strip()
+            if hvci == 'TRUE':
+                hvci_true += 1
+            elif hvci == 'FALSE':
+                hvci_false += 1
 
-            if not product_name:
-                continue
+            if sipolicy_data:
+                auth = sample.get('Authentihash', {}) or {}
+                auth_sha256 = (auth.get('SHA256') or '').lower().strip()
+                auth_sha1 = (auth.get('SHA1') or '').lower().strip()
 
-            product_name = product_name.strip().replace(',', '')
-
-            if product_name.lower() == 'n/a' or product_name.isspace():
-                continue
-
-            if product_name not in products_count:
-                products_count[product_name] = 0
-
-            products_count[product_name] += 1
-
-    sorted_products = sorted(products_count.items(), key=lambda x: x[1], reverse=True)[:top_n]
-
-    with open(f"{output_dir}/content/drivers_top_{top_n}_products.csv", "w") as f:
-        writer = csv.writer(f)
-
-        for product, count in sorted_products:
-            for _ in range(count):
-                writer.writerow([count, product])
-
-def write_top_publishers(drivers, output_dir, top_n=5):
-    publishers_count = {}
-
-    for driver in drivers:
-        for hash_info in driver['KnownVulnerableSamples']:
-            publisher_str = hash_info.get('Publisher')  # Use the `get()` method here
-
-            if not publisher_str:
-                continue
-
-            publishers = re.findall(r'\"(.*?)\"|([^,]+)', publisher_str)
-            for publisher_tuple in publishers:
-                publisher = next(filter(None, publisher_tuple)).strip()
-
-                if publisher.lower() == 'n/a' or publisher.isspace() or publisher.lower() == 'ltd.':
+                if not auth_sha256 and not auth_sha1:
+                    no_authentihash += 1
                     continue
 
-                if publisher not in publishers_count:
-                    publishers_count[publisher] = 0
+                matchable += 1
+                if ((auth_sha256 and auth_sha256 in sipolicy_data['auth_sha256s']) or
+                        (auth_sha1 and auth_sha1 in sipolicy_data['auth_sha1s'])):
+                    overlap += 1
 
-                publishers_count[publisher] += 1
+    exclusive = matchable - overlap if sipolicy_data else 0
 
-    sorted_publishers = sorted(publishers_count.items(), key=lambda x: x[1], reverse=True)[:top_n]
+    metrics = {
+        'total_drivers': total_drivers,
+        'total_samples': total_samples,
+        'hvci_bypass_count': hvci_true,
+        'hvci_blocked_count': hvci_false,
+        'hvci_bypass_pct': str(round(hvci_true / total_samples * 100, 1)) if total_samples else '0',
+        'generated_at': datetime.datetime.now().strftime('%Y-%m-%d'),
+    }
 
-    with open(f"{output_dir}/content/drivers_top_{top_n}_publishers.csv", "w") as f:
-        writer = csv.writer(f)
+    if sipolicy_data:
+        metrics.update({
+            'ms_blocklist_hash_count': len(sipolicy_data['auth_sha256s']),
+            'ms_blocklist_signer_count': sipolicy_data['signer_deny_count'],
+            'overlap_count': overlap,
+            'overlap_pct': str(round(overlap / matchable * 100, 1)) if matchable else '0',
+            'loldrivers_exclusive_count': exclusive,
+            'loldrivers_exclusive_pct': str(round(exclusive / matchable * 100, 1)) if matchable else '0',
+            'samples_without_authentihash': no_authentihash,
+        })
+    else:
+        metrics.update({
+            'ms_blocklist_hash_count': 'N/A',
+            'ms_blocklist_signer_count': 'N/A',
+            'overlap_count': 'N/A',
+            'overlap_pct': 'N/A',
+            'loldrivers_exclusive_count': 'N/A',
+            'loldrivers_exclusive_pct': 'N/A',
+            'samples_without_authentihash': 'N/A',
+        })
 
-        for publisher, count in sorted_publishers:
-            for _ in range(count):
-                writer.writerow([count, publisher])
+    return metrics
+
+
+def write_metrics_json(metrics, output_dir):
+    """Write metrics to a Hugo data file."""
+    data_dir = os.path.join(output_dir, 'data')
+    os.makedirs(data_dir, exist_ok=True)
+    output_file = os.path.join(data_dir, 'metrics.json')
+    with open(output_file, 'w') as f:
+        json.dump(metrics, f, indent=2)
+    return output_file
 
 
 def generate_doc_drivers(REPO_PATH, OUTPUT_DIR, TEMPLATE_PATH, messages, VERBOSE):
@@ -187,13 +290,9 @@ def generate_doc_drivers(REPO_PATH, OUTPUT_DIR, TEMPLATE_PATH, messages, VERBOSE
             writer.writerow([link, sha256, driver['Category'].capitalize(), driver['Created']])
     messages.append("site_gen.py wrote drivers table to: {0}".format(OUTPUT_DIR + '/content/drivers_table.csv'))
 
-    # write top 5 publishers
-    write_top_publishers(drivers, OUTPUT_DIR)
-    messages.append("site_gen.py wrote drivers publishers to: {0}".format(OUTPUT_DIR + '/content/drivers_top_n_publishers.csv'))
-
-    # write top 5 products
-    write_top_products(drivers, OUTPUT_DIR)
-    messages.append("site_gen.py wrote drivers products to: {0}".format(OUTPUT_DIR + '/content/drivers_top_n_products.csv'))
+    # write top 5 publishers (kept for backward compatibility but no longer on landing page)
+    # write_top_publishers(drivers, OUTPUT_DIR)
+    # write_top_products(drivers, OUTPUT_DIR)
 
     return drivers, messages
 
@@ -206,6 +305,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--path", required=False, default="yaml", help="path to loldriver yaml folder. Defaults to `yaml`")
     parser.add_argument("-o", "--output", required=False, default="loldrivers.io", help="path to the output directory for the site, defaults to `loldrivers.io`")
     parser.add_argument("-v", "--verbose", required=False, default=False, action='store_true', help="prints verbose output")
+    parser.add_argument("--sipolicy", required=False, default=None, help="path to pre-downloaded SiPolicy_Enforced.xml (otherwise downloads from Microsoft)")
 
     # parse them
     args = parser.parse_args()
@@ -239,6 +339,17 @@ if __name__ == "__main__":
 
     messages = []
     drivers, messages = generate_doc_drivers(REPO_PATH, OUTPUT_DIR, TEMPLATE_PATH, messages, VERBOSE)
+
+    # compute and write blocklist/HVCI metrics
+    sipolicy_xml = download_sipolicy(OUTPUT_DIR, args.sipolicy)
+    if sipolicy_xml:
+        sipolicy_data = parse_sipolicy_hashes(sipolicy_xml)
+        print(f"  SiPolicy: {len(sipolicy_data['auth_sha256s'])} unique SHA256, {len(sipolicy_data['auth_sha1s'])} unique SHA1 authenticode hashes")
+    else:
+        sipolicy_data = None
+    metrics = compute_metrics(drivers, sipolicy_data)
+    metrics_file = write_metrics_json(metrics, OUTPUT_DIR)
+    messages.append(f"site_gen.py wrote metrics to: {metrics_file}")
 
     # print all the messages from generation
     for m in messages:

--- a/loldrivers.io/content/_index.md
+++ b/loldrivers.io/content/_index.md
@@ -7,55 +7,30 @@ title = "LOLDrivers"
   baseChartOn = 4 # number of column the chart(s) and graph should be drawn from # can be overridden directly via shortcode parameter # it's therefore optional
   charts = ["table"]
   title = "Driver List"
-
-[dataset2]
-  fileLink = "content/drivers_top_5_products.csv"
-  colors = ["#ef7f1a", "#627c62", "#11819b", "#4e1154", "#a1c9a2", "#38a9d9", "#f9b34c", "#824da4", "#e0c7c2", "#c2c2a3", "#d6a994", "#f2c057"] # chart colors
-  columnTitles = ["Count", "Name"] # optional if not table will be displayed from dataset
-  baseChartOn = 2 # number of column the chart(s) and graph should be drawn from # can be overridden directly via shortcode parameter # it's therefore optional
-  piechart = true
-  barchart = true
-  title = "Top Products"
-
-
-[dataset3]
-  fileLink = "content/drivers_top_5_publishers.csv"
-  colors = ["#ef7f1a", "#627c62", "#11819b", "#4e1154", "#a1c9a2", "#38a9d9", "#f9b34c", "#824da4", "#e0c7c2", "#c2c2a3", "#d6a994", "#f2c057"] # chart colors
-  columnTitles = ["Count", "Name"] # optional if not table will be displayed from dataset
-  baseChartOn = 2 # number of column the chart(s) and graph should be drawn from # can be overridden directly via shortcode parameter # it's therefore optional
-  piechart = true
-  barchart = true
-  title = "Top Publishers"
 +++
 
-{{< block "grid-3" >}}
+{{< block "grid-2" >}}
 
 {{< column "mt-4">}}
 
-# Living Off The Land Drivers 
-Living Off The Land Drivers is a curated list of Windows drivers used by adversaries to bypass security controls and carry out attacks. The project helps security professionals stay informed and mitigate potential threats. 
+# Living Off The Land Drivers
+Living Off The Land Drivers is a curated list of Windows drivers used by adversaries to bypass security controls and carry out attacks. The project helps security professionals stay informed and mitigate potential threats.
 
 {{< tip  >}}
 Feel free to open a [PR](https://github.com/magicsword-io/LOLDrivers/pulls), raise an [issue](https://github.com/magicsword-io/LOLDrivers/issues/new/choose "Open a Github Issue")(s) or request new driver(s) be added.
 {{< /tip >}}
 
 {{< tip >}}
-You can also get the malicious driver list via **API** using [CSV](api/drivers.csv) or [JSON](api/drivers.json). Sysmon users check out the pre-built [config](https://github.com/magicsword-io/LOLDrivers/blob/main/detections/sysmon/sysmon_config_vulnerable_hashes.xml). There is a [Sigma rule](https://github.com/magicsword-io/LOLDrivers/blob/main/detections/sigma/driver_load_win_vuln_drivers.yml) for SIEMs. If you've found this project valuable, you'll absolutely love our sister projects, [LOLBAS](https://lolbas-project.github.io/#) and [GTFOBins](https://gtfobins.github.io), check them out!  
+You can also get the malicious driver list via **API** using [CSV](api/drivers.csv) or [JSON](api/drivers.json). Sysmon users check out the pre-built [config](https://github.com/magicsword-io/LOLDrivers/blob/main/detections/sysmon/sysmon_config_vulnerable_hashes.xml). There is a [Sigma rule](https://github.com/magicsword-io/LOLDrivers/blob/main/detections/sigma/driver_load_win_vuln_drivers.yml) for SIEMs. If you've found this project valuable, you'll absolutely love our sister projects, [LOLBAS](https://lolbas-project.github.io/#) and [GTFOBins](https://gtfobins.github.io), check them out!
 {{< /tip >}}
 
 {{< /column >}}
 
 {{< column "mt-4">}}
 
-# Top Products
+# Security Metrics
 
-{{% chart "dataset2" "pie" %}}
-
-{{< /column >}}
-
-{{< column "mt-4">}}
-
-{{% chart "dataset3" "bar" %}}
+{{< metrics >}}
 
 {{< /column >}}
 

--- a/loldrivers.io/data/metrics.json
+++ b/loldrivers.io/data/metrics.json
@@ -1,0 +1,15 @@
+{
+  "total_drivers": 524,
+  "total_samples": 2023,
+  "hvci_bypass_count": 422,
+  "hvci_blocked_count": 1552,
+  "hvci_bypass_pct": "20.9",
+  "generated_at": "2026-04-10",
+  "ms_blocklist_hash_count": 501,
+  "ms_blocklist_signer_count": 214,
+  "overlap_count": 572,
+  "overlap_pct": "28.6",
+  "loldrivers_exclusive_count": 1427,
+  "loldrivers_exclusive_pct": "71.4",
+  "samples_without_authentihash": 24
+}

--- a/loldrivers.io/layouts/shortcodes/metrics.html
+++ b/loldrivers.io/layouts/shortcodes/metrics.html
@@ -1,0 +1,51 @@
+{{ $m := .Site.Data.metrics }}
+{{ if $m }}
+<style>
+.lol-metrics{display:grid;grid-template-columns:1fr 1fr;gap:14px;margin:8px 0 0;}
+.lol-metric-card{background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:18px 20px;position:relative;overflow:hidden;}
+.lol-metric-card::before{content:'';position:absolute;top:0;left:0;bottom:0;width:4px;}
+.lol-metric-card.mc-blue::before{background:#2563EB;}
+.lol-metric-card.mc-red::before{background:#EF4444;}
+.lol-metric-card.mc-green::before{background:#10B981;}
+.lol-metric-card.mc-purple::before{background:#7C3AED;}
+.lol-metric-num{font-size:2rem;font-weight:800;line-height:1.1;color:#111;margin:0 0 2px;}
+.lol-metric-label{font-size:0.82rem;font-weight:700;color:#374151;text-transform:uppercase;letter-spacing:0.04em;margin:0 0 4px;}
+.lol-metric-sub{font-size:0.78rem;color:#6b7280;margin:0;line-height:1.3;}
+.lol-metric-pct{font-size:0.85rem;font-weight:600;margin-left:4px;}
+.mc-red .lol-metric-pct{color:#EF4444;}
+.mc-green .lol-metric-pct{color:#10B981;}
+.mc-purple .lol-metric-pct{color:#7C3AED;}
+.lol-metrics-footer{margin-top:10px;font-size:0.72rem;color:#9ca3af;text-align:right;}
+[data-mode="dark"] .lol-metric-card{background:#08080A;border-color:rgba(255,255,255,0.06);}
+[data-mode="dark"] .lol-metric-num{color:#fff;}
+[data-mode="dark"] .lol-metric-label{color:rgba(255,255,255,0.7);}
+[data-mode="dark"] .lol-metric-sub{color:rgba(255,255,255,0.4);}
+[data-mode="dark"] .lol-metrics-footer{color:rgba(255,255,255,0.25);}
+@media(max-width:480px){.lol-metrics{grid-template-columns:1fr;}}
+</style>
+<div class="lol-metrics">
+  <div class="lol-metric-card mc-blue">
+    <p class="lol-metric-label">Drivers Tracked</p>
+    <p class="lol-metric-num">{{ $m.total_drivers }}</p>
+    <p class="lol-metric-sub">{{ $m.total_samples }} total samples</p>
+  </div>
+  <div class="lol-metric-card mc-red">
+    <p class="lol-metric-label">Load Despite HVCI</p>
+    <p class="lol-metric-num">{{ $m.hvci_bypass_count }}<span class="lol-metric-pct">{{ $m.hvci_bypass_pct }}%</span></p>
+    <p class="lol-metric-sub">{{ $m.hvci_bypass_count }} of {{ $m.total_samples }} samples bypass HVCI</p>
+  </div>
+  <div class="lol-metric-card mc-green">
+    <p class="lol-metric-label">In MS Blocklist</p>
+    <p class="lol-metric-num">{{ $m.overlap_count }}</p>
+    <p class="lol-metric-sub">Microsoft coverage ends here</p>
+  </div>
+  <div class="lol-metric-card mc-purple">
+    <p class="lol-metric-label">LOLDrivers Exclusive</p>
+    <p class="lol-metric-num">{{ $m.loldrivers_exclusive_count }}</p>
+    <p class="lol-metric-sub">{{ $m.loldrivers_exclusive_count }} samples not covered by Microsoft</p>
+  </div>
+</div>
+<div class="lol-metrics-footer">Updated {{ $m.generated_at }} &middot; <a href="https://aka.ms/VulnerableDriverBlockList" target="_blank" rel="noopener">MS Blocklist source</a></div>
+{{ else }}
+<p style="color:#6b7280;font-size:0.9rem;">Metrics unavailable — run <code>site.py</code> to generate.</p>
+{{ end }}


### PR DESCRIPTION
## Summary
<img width="1685" height="739" alt="image" src="https://github.com/user-attachments/assets/15c22681-648e-4875-879d-fce6386cd502" />

Replaces the "Top Products" pie chart and "Top Publishers" bar chart on the LOLDrivers landing page with **4 security metric cards** that tell a much more compelling story:

- **Drivers Tracked** — 524 drivers, 2,023 total samples
- **Load Despite HVCI** — 422 samples (20.9%) bypass HVCI protections
- **In MS Blocklist** — 572 samples overlap with Microsoft's Vulnerable Driver Blocklist
- **LOLDrivers Exclusive** — 1,427 samples not covered by Microsoft (where MS coverage ends and LOLDrivers continues)

### How it works

- `bin/site.py` now downloads the [Microsoft Vulnerable Driver Blocklist](https://aka.ms/VulnerableDriverBlockList) at build time
- Parses `SiPolicy_Enforced.xml` and matches Authenticode hashes against LOLDrivers' `Authentihash` fields
- Writes `loldrivers.io/data/metrics.json` which Hugo reads via `site.Data.metrics`
- New `metrics.html` shortcode renders the stat cards (light + dark mode)
- **Auto-updates on every CI build** — new drivers or MS blocklist changes are reflected automatically

Also includes `bin/blocklist_analysis.py` as a standalone script for ad-hoc analysis.

### Screenshot

The 4 metric cards replace the old pie/bar charts in a 2x2 grid layout.

## Test plan

- [x] Run `python bin/site.py --sipolicy .context/SiPolicy_Enforced.xml` and verify `loldrivers.io/data/metrics.json` is generated with correct values
- [x] Run `hugo serve` in `loldrivers.io/` and verify landing page renders 4 stat cards
- [x] Verify dark mode rendering
- [x] Verify CI generates metrics on merge (site.py downloads blocklist automatically)