### PR TITLE
Tweak security metrics card display

### DIFF
--- a/loldrivers.io/layouts/shortcodes/metrics.html
+++ b/loldrivers.io/layouts/shortcodes/metrics.html
@@ -26,8 +26,8 @@
 <div class="lol-metrics">
   <div class="lol-metric-card mc-blue">
     <p class="lol-metric-label">Drivers Tracked</p>
-    <p class="lol-metric-num">{{ $m.total_drivers }}</p>
-    <p class="lol-metric-sub">{{ $m.total_samples }} total samples</p>
+    <p class="lol-metric-num">{{ $m.total_samples }}</p>
+    <p class="lol-metric-sub">{{ $m.total_drivers }} unique drivers</p>
   </div>
   <div class="lol-metric-card mc-red">
     <p class="lol-metric-label">Load Despite HVCI</p>
@@ -36,12 +36,12 @@
   </div>
   <div class="lol-metric-card mc-green">
     <p class="lol-metric-label">In MS Blocklist</p>
-    <p class="lol-metric-num">{{ $m.overlap_count }}</p>
-    <p class="lol-metric-sub">Microsoft coverage ends here</p>
+    <p class="lol-metric-num">{{ $m.overlap_count }}<span class="lol-metric-pct">{{ $m.overlap_pct }}%</span></p>
+    <p class="lol-metric-sub">{{ $m.overlap_count }} of {{ $m.total_samples }} samples in MS blocklist</p>
   </div>
   <div class="lol-metric-card mc-purple">
     <p class="lol-metric-label">LOLDrivers Exclusive</p>
-    <p class="lol-metric-num">{{ $m.loldrivers_exclusive_count }}</p>
+    <p class="lol-metric-num">{{ $m.loldrivers_exclusive_count }}<span class="lol-metric-pct" style="color:#10B981">{{ $m.loldrivers_exclusive_pct }}%</span></p>
     <p class="lol-metric-sub">{{ $m.loldrivers_exclusive_count }} samples not covered by Microsoft</p>
   </div>
 </div>


### PR DESCRIPTION

<img width="881" height="582" alt="image" src="https://github.com/user-attachments/assets/2a8662ba-f58a-4f3a-932b-a9332f6d06a1" />

## Summary
Follow-up to #305 — adjusts the 4 security metric cards per feedback:

- **Drivers Tracked**: total samples (2041) is now the bold hero number; unique driver count (536) shown as subtitle
- **In MS Blocklist**: added percentage badge (28.4%) and descriptive sub text ("572 of 2041 samples in MS blocklist")
- **LOLDrivers Exclusive**: added green percentage badge (71.6%) for at-a-glance coverage gap visibility

## Test plan
- [x] Built locally with Hugo 0.111.3 (matches CI) — 550 pages, no errors
- [x] Verify rendered cards on preview deploy