### PR TITLE
Add 8 vulnerable drivers: ipctype, portwell, ppa_x64, TBT_Force, BiosToolCommonDriver, SparkIO, UDDB2B6, XLHA

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -59,3 +59,4 @@ drivers/622cca8e67e9056955e0aeb55716a68f.bin filter=lfs diff=lfs merge=lfs -text
 drivers/3b24f7363ffb33d1ced37a99da67c7ad.bin filter=lfs diff=lfs merge=lfs -text
 drivers/d4320487bf3021f2f2afcfc43d652a69.bin filter=lfs diff=lfs merge=lfs -text
 drivers/ec7f14be325648533fc04aff9da8635f.bin filter=lfs diff=lfs merge=lfs -text
+drivers/7ee002414a5fa3650d418ebde92e528d.bin filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -51,3 +51,11 @@ drivers/cbf2368a99800ef253c66082dbf3d05b.bin filter=lfs diff=lfs merge=lfs -text
 drivers/e4704b728eb6daeeb780688786303c4f.bin filter=lfs diff=lfs merge=lfs -text
 drivers/f1284aeb27c65ee78c05e57445d1fa41.bin filter=lfs diff=lfs merge=lfs -text
 drivers/cb7bc352e0a7531faec48de1dbd8a9a1.bin filter=lfs diff=lfs merge=lfs -text
+drivers/c8f6cd1c989f364f126e6855f1178704.bin filter=lfs diff=lfs merge=lfs -text
+drivers/a93b28348e04109cc186b985c9308295.bin filter=lfs diff=lfs merge=lfs -text
+drivers/9851c3d7aee98aa0d712c50e9ca20eb9.bin filter=lfs diff=lfs merge=lfs -text
+drivers/a4de3d1854ba9b8e77b2324c52887a2c.bin filter=lfs diff=lfs merge=lfs -text
+drivers/622cca8e67e9056955e0aeb55716a68f.bin filter=lfs diff=lfs merge=lfs -text
+drivers/3b24f7363ffb33d1ced37a99da67c7ad.bin filter=lfs diff=lfs merge=lfs -text
+drivers/d4320487bf3021f2f2afcfc43d652a69.bin filter=lfs diff=lfs merge=lfs -text
+drivers/ec7f14be325648533fc04aff9da8635f.bin filter=lfs diff=lfs merge=lfs -text

--- a/drivers/3b24f7363ffb33d1ced37a99da67c7ad.bin
+++ b/drivers/3b24f7363ffb33d1ced37a99da67c7ad.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a40ee54b975ec19b40dcc0b75f86fd403c829b043a20ac67b7345a6b967c4b3
+size 22128

--- a/drivers/622cca8e67e9056955e0aeb55716a68f.bin
+++ b/drivers/622cca8e67e9056955e0aeb55716a68f.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:177227f68cc28ee7726381b95f7d2215da35be3750157ebcb7e113201059026c
+size 48352

--- a/drivers/7ee002414a5fa3650d418ebde92e528d.bin
+++ b/drivers/7ee002414a5fa3650d418ebde92e528d.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04cc7df4077e36199b04afa39204c8f568f7f66f045e73010fb9b7685324442f
+size 16904

--- a/drivers/9851c3d7aee98aa0d712c50e9ca20eb9.bin
+++ b/drivers/9851c3d7aee98aa0d712c50e9ca20eb9.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:988960e31a258ea71cf93a7791ae8c91c8cefb6ad8a50cdbd1b07f73b524aa61
+size 15560

--- a/drivers/a4de3d1854ba9b8e77b2324c52887a2c.bin
+++ b/drivers/a4de3d1854ba9b8e77b2324c52887a2c.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c776f34c6042d943baec3c13d7154a245aae8dd95e1933211fd19352c770676
+size 15400

--- a/drivers/a93b28348e04109cc186b985c9308295.bin
+++ b/drivers/a93b28348e04109cc186b985c9308295.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f0b16ed90b8c15bf52a7c32699dbe0dbcd38fc02ed2ddb4e1ba35487177b6c5
+size 16848

--- a/drivers/c8f6cd1c989f364f126e6855f1178704.bin
+++ b/drivers/c8f6cd1c989f364f126e6855f1178704.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e2acce10d704c8b511c8b6211a2be5d8e4ade91ebcbda2ac10018e4c0ae99fb
+size 14096

--- a/drivers/d4320487bf3021f2f2afcfc43d652a69.bin
+++ b/drivers/d4320487bf3021f2f2afcfc43d652a69.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9af0b89c5c54eb66e5a660b61aee7c1a25b1c92e20a310d8b16552abcf90c0b5
+size 51392

--- a/drivers/ec7f14be325648533fc04aff9da8635f.bin
+++ b/drivers/ec7f14be325648533fc04aff9da8635f.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11c9cbc39b6e028f2e8f9e7f83b47ae83ca73961ecfebb2f7213f9478f5446d5
+size 22168

--- a/yaml/2a9193cc-4e7e-4c8d-9cb4-040723e81841.yaml
+++ b/yaml/2a9193cc-4e7e-4c8d-9cb4-040723e81841.yaml
@@ -1,0 +1,146 @@
+Id: 2a9193cc-4e7e-4c8d-9cb4-040723e81841
+Tags:
+- SparkIO.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-04-17'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create SparkIO binPath=C:\windows\temp\SparkIO.sys type=kernel &&
+    sc.exe start SparkIO
+  Description: SparkIO.sys is a WHQL-signed kernel driver from Clevo Co. (Taiwan ODM)
+    that ships with Control Center 3.0 and Flexicharger utilities on Clevo-chassis
+    laptops (XMG, Eluktronics, EVOO, Origin PC, System76, Sager, and others). CVE-2022-37415
+    (CVSS 7.8) documents an out-of-bounds write vulnerability. The driver exposes
+    arbitrary physical memory read via MmMapIoSpace, unrestricted I/O port read/write,
+    arbitrary PCI configuration space read/write, and SMBus/I2C read/write. The device
+    is created with IoCreateDevice (no DACL) and IRP_MJ_CREATE returns STATUS_SUCCESS
+    unconditionally with zero caller validation. A public PoC exists by alfarom256.
+  Usecase: Elevate privileges
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/322
+- https://nvd.nist.gov/vuln/detail/CVE-2022-37415
+- https://gist.github.com/alfarom256/220cb75816ca2b5556e7fc8d8d2803a0
+Detection: []
+Acknowledgement:
+  Person: Patrick Saif
+  Handle: '@weezerOSINT'
+KnownVulnerableSamples:
+- Filename: SparkIO.sys
+  MD5: 3b24f7363ffb33d1ced37a99da67c7ad
+  SHA1: 8d45a2d269fc7c6503c04daac0e736ff64edc880
+  SHA256: 5a40ee54b975ec19b40dcc0b75f86fd403c829b043a20ac67b7345a6b967c4b3
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: ''
+  Description: ''
+  Product: ''
+  ProductVersion: ''
+  FileVersion: ''
+  MachineType: AMD64
+  OriginalFilename: ''
+  Authentihash:
+    MD5: 532647c3548d81ebc47f586d10db5cde
+    SHA1: 9100f3ddd25ca50d3a2e89889ab68c4ebbbc4862
+    SHA256: 89e09de9723da81eb3f50ed98a97321a789122d746ef41d6e94ec68111d09907
+  RichPEHeaderHash:
+    MD5: 681a4fef9b8ef8d29d3c05cff67fbaad
+    SHA1: 42617f2a3ef1c4a095387abffcc67cb148ab9ff2
+    SHA256: f9efc7e04e1a1cde0c0ec4007e690283826891ab80dfbd968676ba428d470a18
+  Sections:
+    .text:
+      Entropy: 5.851186515516994
+      Virtual Size: '0x580'
+    .rdata:
+      Entropy: 3.7652998691469417
+      Virtual Size: '0x49c'
+    .data:
+      Entropy: 2.591917186688699
+      Virtual Size: '0x20'
+    .pdata:
+      Entropy: 3.6881022360397258
+      Virtual Size: '0x174'
+    PAGE:
+      Entropy: 6.389187647738722
+      Virtual Size: '0x166e'
+    INIT:
+      Entropy: 5.50704408720018
+      Virtual Size: '0x476'
+    .reloc:
+      Entropy: 2.9086949695628426
+      Virtual Size: '0x14'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2018-11-26 02:59:29'
+  InternalName: ''
+  Copyright: ''
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - KeAcquireSpinLockRaiseToDpc
+  - KeReleaseSpinLock
+  - MmMapIoSpace
+  - MmUnmapIoSpace
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - KeInitializeSpinLock
+  - IoDeleteSymbolicLink
+  - ZwClose
+  - ZwUnmapViewOfSection
+  - MmGetSystemRoutineAddress
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - DbgPrint
+  - HalSetBusDataByOffset
+  - HalGetBusDataByOffset
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2018-09-20 19:45:06'
+      ValidTo: '2019-09-20 19:45:06'
+      Signature: 180e211f245e9f356516359d002cb33904c7c9b883a39af9d000d7feee231f0c68bc272d4e9818533c6dd00a732df28966757d7c84db825265e3b453ccd9e620af2d714ea7aaf1019b7666098ed84df68cbdc52180b76bcef050c13e57a3125e05a576e11221316e763219b50353920b15f0bfd58474381f0d3fc4439dea7b3de5aa7287948b34909c689aa98df140c25ed2f0b7059e84a99c68c2cd69f42af3a2c9776df0eb5f08f3bf62ecd920144b0a6511a9201f00d2bee8774cc00863ba36827c01d8849a69cb06ae35ec50976412beaada0ff49a0bb11acb1465e80a206b0b846b3049548c400cd37cd1d1f1cb3dc1e040f6f26c53adf284153000c33b
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 330000006d9da53e87009d334900000000006d
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 492f0445b9066f46587442aaa5cd8e2f
+        SHA1: 0cbb75cf1d4b8a17871dbadf9f16551e370bfd4f
+        SHA256: 630b559341170d2934b0106cc099d2fff38d3add906676c2d1cb22379a028984
+        SHA384: eb0c7790e4d35dfd6e4f9802d7ab34b0f47e62d987ffac00f7bfc8a90bf8eac0940f00bb8239b23e0cce27c6a2fe727b
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      ValidFrom: '2012-04-18 23:48:38'
+      ValidTo: '2027-04-18 23:58:38'
+      Signature: 5a8a67daccd5fd0d264177bf0a4678b4b3de12692b7723c2652f015fd203f461ba509d2e8c3972f36c3e6ab11e766decb7f382dcccbbc56970287366173f54ebee011648c446d91b80ae813a8d0f796d68b09eea2d3f39d3ca387ebd5e7c086e19dcc6c2f438336861e2524783e1000156d2bacb878205310a418b4ee77f5f5fed5fd3392d45eba213bffd1ec298417161165fc80a70257c59693124e471e70abb0417f79f721ec9d2bb1abe3d02fe090cb243b4591a99539396215fe0d6b72601429536ac27fdbef48577683d18bdf4be98882211865216f345ec0397107087a37043713cdbc98603170cf5735bc67de15c64edd7c548d7ed32e2d1aad3cfa7f6574e61f977eb67f288b3de00da038fd08a34373e1dd862b8d2b1f3e12f8b723b81967c6ffcec667672601b24f2a0896d5b6d002eef28dd868705c2b4b9e5be64c22af24a155c98e2c42785ff52e3627e0fb2020bd766c70ab2d33d200414503259830a7d9bed5a38120152ba2f5e20728e4af1fde771028c3be107bec973f4dd47d8b4efb4a4b330b9893e76cab90098567eabea8ab8a5d038ab6977130b142fe9aa411ff7babd3a2b348aee0aab63e663f788248e200d2b3b9de3c24952ac9f1f0e393b5dd46e506ae67d523aaa7c3315290d265e0158a74ea93d7a846f743f609fe4324f3600af6d71d33ea646655f8174f1fec171da4ca0415a82ddf11f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 610baac1000000000009
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: a569061297e8e824767dbc3184a69bea
+        SHA1: adbb26a587a8f44b4fccaecb306f980d1c55a150
+        SHA256: cec1afd0e310c55c1dcc601ab8e172917706aa32fb5eaf826813547fdf02dd46
+        SHA384: e947cac936803f5683196e4ff1b259096073395d0b908522ddce90d57597c9f7b57f7ddcdbe021ba863d843c340da8ba
+    Signer:
+    - SerialNumber: 330000006d9da53e87009d334900000000006d
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      Version: 1
+  LoadsDespiteHVCI: 'TRUE'
+  Imphash: 157872f202de597049db345f25c2774f

--- a/yaml/2d301a46-ceb6-477c-8a51-463a6ded3524.yaml
+++ b/yaml/2d301a46-ceb6-477c-8a51-463a6ded3524.yaml
@@ -1,0 +1,243 @@
+Id: 2d301a46-ceb6-477c-8a51-463a6ded3524
+Tags:
+- BiosToolCommonDriver.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-04-17'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create BiosToolCommonDriver binPath=C:\windows\temp\BiosToolCommonDriver.sys
+    type=kernel && sc.exe start BiosToolCommonDriver
+  Description: BiosToolCommonDriver.sys is an AMD RPMC (Replay Protected Monotonic
+    Counter) field fusing utility driver that exposes 18 IOCTLs including arbitrary
+    physical memory read/write via MmMapIoSpace, unrestricted port I/O, PCI configuration
+    space read/write, MSR read/write (wrmsr/rdmsr), SPI flash read, CPUID execution,
+    virtual-to-physical address translation via MmGetPhysicalAddress, and contiguous
+    memory allocation. WHQL Microsoft-signed and also AMD Sectigo dual-signed. Ships
+    inside Razer Blade 16 BIOS update packages and ASUS firmware config bundles. PDB
+    path confirms AMD internal build origin.
+  Usecase: Elevate privileges
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/321
+Detection: []
+Acknowledgement:
+  Person: Patrick Saif
+  Handle: '@weezerOSINT'
+KnownVulnerableSamples:
+- Filename: BiosToolCommonDriver.sys
+  MD5: 622cca8e67e9056955e0aeb55716a68f
+  SHA1: d4c584732fa9abd7d7eb83e169686764c500f2e0
+  SHA256: 177227f68cc28ee7726381b95f7d2215da35be3750157ebcb7e113201059026c
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: Advanced Micro Devices
+  Description: the AMD driver to access CPU registers
+  Product: AMD Field Fusing
+  ProductVersion: 1.1.3.0
+  FileVersion: 1.1.3.0
+  MachineType: AMD64
+  OriginalFilename: ''
+  Authentihash:
+    MD5: be3cf8458143f2e2f47481043a18e6f5
+    SHA1: 129f2f059513ae62d0f63e3644cbfa7b671b938b
+    SHA256: 14deaf22605904971fe757778cec9e46a0fd59a1895491760740404843929481
+  RichPEHeaderHash:
+    MD5: b6de948480c7ea3b6ad83a0f8e3c3e89
+    SHA1: 62a6a791154f84d42c78bbc01181daa6c1faf27e
+    SHA256: 52fb8ab5dba36942fbb2d80b644aadd755f6ab2143a1471ce8e7dce41b539f59
+  Sections:
+    .text:
+      Entropy: 5.663196139144487
+      Virtual Size: '0x2ba9'
+    .rdata:
+      Entropy: 4.456837946896162
+      Virtual Size: '0x964'
+    .data:
+      Entropy: 2.0076655699548906
+      Virtual Size: '0x238'
+    .pdata:
+      Entropy: 4.2301068403747975
+      Virtual Size: '0x324'
+    PAGE:
+      Entropy: 6.246124236805516
+      Virtual Size: '0x1b94'
+    INIT:
+      Entropy: 5.150810900004228
+      Virtual Size: '0x632'
+    .rsrc:
+      Entropy: 3.270504549595088
+      Virtual Size: '0x320'
+    .reloc:
+      Entropy: 3.444998860709685
+      Virtual Size: '0x2c'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2023-10-07 02:01:23'
+  InternalName: ''
+  Copyright: "Copyright \xA9 Advanced Micro Devices 2017"
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - RtlVerifyVersionInfo
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - KeDelayExecutionThread
+  - VerSetConditionMask
+  - MmUnmapIoSpace
+  - MmAllocateContiguousMemory
+  - MmFreeContiguousMemory
+  - MmGetPhysicalAddress
+  - __chkstk
+  - DbgPrintEx
+  - MmMapIoSpace
+  - RtlInitUnicodeString
+  - MmGetSystemRoutineAddress
+  - ZwClose
+  - ZwSetSecurityObject
+  - IoDeviceObjectType
+  - IoCreateDevice
+  - ObOpenObjectByPointer
+  - RtlGetDaclSecurityDescriptor
+  - RtlGetGroupSecurityDescriptor
+  - RtlGetOwnerSecurityDescriptor
+  - RtlGetSaclSecurityDescriptor
+  - ExFreePoolWithTag
+  - SeCaptureSecurityDescriptor
+  - _snwprintf
+  - RtlLengthSecurityDescriptor
+  - SeExports
+  - RtlCreateSecurityDescriptor
+  - _wcsnicmp
+  - ExAllocatePoolWithTag
+  - wcschr
+  - RtlAbsoluteToSelfRelativeSD
+  - RtlAddAccessAllowedAce
+  - RtlLengthSid
+  - IoIsWdmVersionAvailable
+  - RtlSetDaclSecurityDescriptor
+  - ZwOpenKey
+  - ZwSetValueKey
+  - ZwQueryValueKey
+  - ZwCreateKey
+  - RtlFreeUnicodeString
+  - HalSetBusDataByOffset
+  - HalGetBusDataByOffset
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=California, L=Santa Clara, O=Advanced Micro Devices Inc.,
+        CN=Advanced Micro Devices Inc.
+      ValidFrom: '2021-05-11 00:00:00'
+      ValidTo: '2024-05-10 23:59:59'
+      Signature: 8444e268ff381c9148985f408e5cc1453a560c9dd94d2a6cfa01dd7f2adc8af633053d2c79027db4f185f477b0d5db8b362b37dbd0d258823831ace7058baf3feb80a9eb2de9dd886bcf390fae9b586fc833e63db5c6a07019f35a9fce6899502852737b32d25ea7832c3786df0642d21622e56c0b0171e96f9520d07f73950376ff555bcf9c8a55bf4f86c088b58e2cb625a0ef4680ed7281f09a40c7be9f69cba77a6967030e39b2cfa46692698ced9e5347dd7056b476545c3442f934cb2c30cb986afabd29a9a9e2eb28c5bd6ee47dabf5ef587f850ea49b124eb868aac68de949616d08f875192b93388549c7327a3ef085e287d5a743810c151b250c64
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 535091e6cab13af393b51ead0825f627
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: f2f60243e26dcdf4729d28b1beb55f01
+        SHA1: a23ac91136dd79d77b93b12c813e0c6669ed9f4d
+        SHA256: 192ee517f8ae928808632422a6461613d65ee324fa58d2f099a27a3d0da9ca6b
+        SHA384: beb93a1ff1715564a418ecb07cee42465dbf9c76cc703e7088bdafb2099b003afa0c335bcd15d318dcb2bf8519c199da
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Trusted Root
+        G4
+      ValidFrom: '2022-08-01 00:00:00'
+      ValidTo: '2031-11-09 23:59:59'
+      Signature: 70a0bf435c55e7385fa0a3741b3db616d7f7bf5707bd9aaca1872cec855ea91abb22f8871a695422eda488776dbd1a14f4134a7a2f2db738eff4ff80b9f8a1f7f272de24bc5203c84ed02adefa2d56cff9f4f7ac307a9a8bb25ed4cfd143449b4321eb9672a148b499cb9d4fa7060313772744d4e77fe859a8f0bf2f0ba6e9f2343cecf703c787a8d24c401935466a6954b0b8a1568eeca4d53de8b1dcfd1cd8f4775a5c548c6fefa1503dfc760968849f6fcadb208d35601c0203cb20b0ac58a00e4063c59822c1b259f5556bcf27ab6c76ce6f232df47e716a236b22ff12b8542d277ed83ad9f0b68796fd5bd15cac18c34d9f73b701a99f57aa5e28e2b994
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 0e9b188ef9d02de7efdb50e20840185a
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 21a266bd49f2778b24d13d95641ea6ac
+        SHA1: 21319f341fdf06bf6a104427afa8b7823b1ea7f3
+        SHA256: e933dc68ee65abd1f9b1aa6738eff60a6895d3d8cc4accf0c69069aa3decd757
+        SHA384: 11533efd6b326a4e065a936de300fe0586a479f93d569d2403bd62c7ad35f1b2199daee3adb510f429c4fc97b4b024e3
+    - Subject: C=GB, ST=Greater Manchester, L=Salford, O=Sectigo Limited, CN=Sectigo
+        RSA Code Signing CA
+      ValidFrom: '2018-11-02 00:00:00'
+      ValidTo: '2030-12-31 23:59:59'
+      Signature: 4d6350ed47344a61a4dbde6a2a8c9bf100001e1d627b3ad732c2f6b3e063b3fb6100889a1b6d1007044fbeb8ea897822eb0f46ecf3465e40468912f40b775a9c2a413afcd6f4ebe7f7159533c3a18328b7de2fe494f78533832d4a4048bf9ac24f4ab18f24f4b38137d3b764b0a6236a596852425fff04ebe174657908f5a993de6b71409996ba78f1b9c8e2c30816b1ab635ac815806d745e4a757ea5b8c36cb5cfdf4a79875cc7404d6335f630d3cfb50a0e0b047fa04baebba3a5d08400933e535d34a50035696cbe9f2025100d19fb509061be398f7a8e4df69f0e1efe075112668326194895ce4ac9c17ff33a059bf96fdf887fc0239ed21e437a4531c19c4da9f059b25919e86a8d290402777c4b4bcd70be3ab2555a783ebcbb6f0310257715348af936cc4392e4ba4ff1629328255729fb5119c7a125406a8457c6b29db1bc1c0ada7c677e7d2ee9284c187ec47b3141719a4b29ec0b3d5750d2caddfd9e0551e54478dd01deb175980d5424fdf04ee3e2f883bd72bacb3d3aeef05e1792686dc861f9a6f12a0a0ba5b9f49eee983205859eebf98329d3c62c7dbd3a772e8b3742a06a82ed3b4aaa9410a4e10df817c5b65a79331892e3b575f8a1e98e0a251ee41ef19f5a8723ff9fa4519efb398011cddbb5c4a7a8806fe553d4e0e3a2c2d25b1afa32262d6a57701c3ca4582ea3f35b4b07dc3259f387a71a6d58
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 1da248306f9b2618d082e0967d33d36a
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: c1eabfb5994258ad955adb7c2df165e6
+        SHA1: fa33b3c00cebc469b269220d9eab26926c9b8ad8
+        SHA256: 70dffac37eb787b2198816982c7d44f541d2e39a7dac069d37b367dc9f354b32
+        SHA384: 20adc5b59cb532e215f01ba09a9c745898c206555613512fea7c295ccfd17ced4fe2c5bc3274ca8a270fc68799b8343c
+    - Subject: C=US, ST=New Jersey, L=Jersey City, O=The USERTRUST Network, CN=USERTrust
+        RSA Certification Authority
+      ValidFrom: '2015-07-22 21:03:49'
+      ValidTo: '2025-07-22 21:03:49'
+      Signature: 6b22933c3d395471646b0ef2e43c3011c5204a4b860f92f1ff33793ad9e498a70e40a022807e61b2e0a719cf2695312a65d46a4f3186eac0c62ec5648c3d4859cd0b2f743d9426131042d49798275e3c76d278691d1a64e7057275e0eb6640439f8f0c46ff9760a6c867ad10089b62a6e9be3a8ad3074d9f729325bc0611e02c90383e671cfd19d79e90ce3dc2e0e761acc0e504f51e99540c910d01567137ae27d49e4322a5c927cd4de571123924a5415687ffbc55140f25ca89eec797e5d213ff3d7e1aa08f3fc82cd7a370d0c760c0fcd83e51e797c63e3bedcf78be8acae3c4f2a7a7ed9eae08028fa052db721ed53bc34d9f8efa9b70c7f8e3bf6c3f929be4373eec6a8c29f9c1a2bf8b3e1a6966fb1c634f2601c902c43ed2ffc343a81bfd99fad4bca5b9e2932f3b01c5d1f43a2f68c3e064b75a955e46cc078369bb3c05925673357345984e7cd812a5b742e9a263f642601870d13b6f31c087c7e671e1f34616e9f5b872b3e96d1f622649a3498bdd68c78b6856f7defcfa8724b80381178fe5f1676a1daed374f78ca55db30b8e422996ce49c4777e667c01171a6c1424c3b0177705d81a40b7866bd8e47b40ac7edf4e6f24f92080828c33e7e5fa29d89dda8b705d2bc91d824c0b67cb84419ee7067e1183442d8a19eef47f9add791c37191e9f3f8c29ba0d5c1086376c48cd455dcd70bcbcd14d5dd8c5b876
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 3300000044b73ffcef5acfa27a000000000044
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: a2d2ae7554f77f6e9ffb0b1a9b700ac4
+        SHA1: 9f69ff166f5dc446578a45d7d69482373755e141
+        SHA256: ad394b7e5cb9ccf6429762405f9840b648e38e8faf2de376f1aa375c6729abb7
+        SHA384: eda103bac2997f31d778637ce8d1fa1263485a9d6a77d6e381bad8312e6bbec020ce5036e16ca96087e50f6ab200944a
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 RSA4096 SHA256 TimeStamping
+        CA
+      ValidFrom: '2022-03-23 00:00:00'
+      ValidTo: '2037-03-22 23:59:59'
+      Signature: 7d598ec093b66f98a94422017e66d6d82142e1b0182e104d13cf3053cebf18fbc7505de24b29fb708a0daa2969fc69c1cf1d07e93e60c8d80be55c5bd76d87fa842025343167cdb612966fc4504c621d0c0882a816bda956cf15738d012225ce95693f4777fb727414d7ffab4f8a2c7aab85cd435fed60b6aa4f91669e2c9ee08aace5fd8cbc6426876c92bd9d7cd0700a7cefa8bc754fba5af7a910b25de9ff285489f0d58a717665daccf072a323fac0278244ae99271bab241e26c1b7de2aebf69eb1799981a35686ab0a45c9dfc48da0e798fbfba69d72afc4c7c1c16a71d9c6138009c4b69fcd878724bb4fa349b9776691f1729ce94b0252a7377e9353ac3b1d08490f94cd397addff256399272c3d3f6ba7f166c341cd4fb6409b212140d0b71324cddc1d783ae49eade5347192d7266be43873aba6014fbd3f3b78ad4cadfbc4957bed0a5f33398741787a38e99ce1dd23fd1d28d3c7f9e8f1985ffb2bd87ef2469d752c1e272c26db6f157b1e198b36b893d4e6f2179959ca70f037bf9800df20164f27fb606716a166badd55c03a2986b098a02bed9541b73ad5159831b462090f0abd81d913febfa4d1f357d9bc04fa82de32df0489f000cd5dc2f9d0237f000be4760226d9f0657642a6298709472be67f1aa4850ffc9896f655542b1f80fac0f20e2be5d6fba92f44154ae7130e1ddb37381aa12bf6edd67cfc
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 073637b724547cd847acfd28662a5e5b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: e4b8ad9932ff9205f580cf8fb2afbb86
+        SHA1: 5301f7044d78bf94dd2b6e4871083a17fdba1dcc
+        SHA256: c3d01499a5d1d2f71e0f44e78fbfa4b8aadb43dd4f226401e0c1d7a6d53357fa
+        SHA384: 84b5f399da5a4f4387269adfd951ef7d2197c29552ed2d2e449060664c3825d6bdb2acc3e563d999e54652f7384f445e
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Timestamp 2023
+      ValidFrom: '2023-07-14 00:00:00'
+      ValidTo: '2034-10-13 23:59:59'
+      Signature: 811ad6dea0a9b59817bc708d4f8a3c689cd825ffcb2ce4cdea5d2292ec8c2202a9b8cf80a8d9e7e3c5ed26828a712f18dd4eb6de6cd7e1609c2beded3d488eb86bba7c5dbdc26137684977a3eb90aa12d72785f38e1e92dac240389f5dc8a02e2578259d2a057a842998b657798fdb26562bb0f3a7bd370cd898764f56b952c2b69d38a981e76d415c8c69d1b92bc4c67bcf9cfa78e2931a76a26975d350e44412be200d9ea944d0f8e54977085a21c5b4cf98951a54bab9bcc16919bacf16f28337346eb04126ddde5a974f338dd48d777d7545a1a558266a0345ded950b5508caf56bd4cc5e146c528d3ade7430070decc989e198903ead49137ef4d52f3c96021c45647edda114b8c32c388e658e2b6db3ef95fb042d68fe31791d1aac055e386bfac272c41d09a334aa836d4b972967e977938485fcac2dc3d32df75d636675a89f8f6a7c7e54f353c00bdbe9c2a6c7901dcda44e63ade383b075e3958f47c733155a08011cb140c7eaebcfea4eb7965aa68d622ca3beb9a8235572816cb69f2329ab2d2d83ab8b146866bba17fdc4776c156caeabaf733ae84946b7d57fccb638c0d8ec1cf5b6a1b8432cdf4e4c7d1e6870c0770ad402e05c60bb28ff38e5525ad6ac1722234ef4ecd317fb506bff07771f71974441c9b846d36c327c582f674765e51b73b699f96b2c0646ef411ef0f05fe0dbd9ad908044af8010418a
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 0544aff3949d0839a6bfdb3f5fe56116
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: 7630cbd02cc6732394e9fdfe99d0d8f8
+        SHA1: bc1890d694f9d392c4cbae6a174e35d70e7ec8b1
+        SHA256: 594a02de632b3a08ed6644c36994025e57f35bc8e7bd16cec5d347883390d1d8
+        SHA384: 31d9fb75262762d17046f31e5c54509f58a295d505e411019544000b64f607b44b3346b708fa50d48f199dba56f0c0b1
+    Signer:
+    - SerialNumber: 535091e6cab13af393b51ead0825f627
+      Issuer: C=GB, ST=Greater Manchester, L=Salford, O=Sectigo Limited, CN=Sectigo
+        RSA Code Signing CA
+      Version: 1
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: e3c915c62d33052b715b0a50dfa2d89d

--- a/yaml/408964b3-1799-425b-92bf-465c72a272d1.yaml
+++ b/yaml/408964b3-1799-425b-92bf-465c72a272d1.yaml
@@ -1,0 +1,154 @@
+Id: 408964b3-1799-425b-92bf-465c72a272d1
+Tags:
+- TBT_Force_Power_Control_Access64.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-04-17'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create TBT_Force_Power_Control_Access64 binPath=C:\windows\temp\TBT_Force_Power_Control_Access64.sys
+    type=kernel && sc.exe start TBT_Force_Power_Control_Access64
+  Description: TBT_Force_Power_Control_Access64.sys is a Thunderbolt force power control
+    driver from Wistron Corporation that exposes physical memory read/write via MmMapIoSpace.
+    Wistron is a major Taiwan-based OEM/ODM. Another Wistron driver (WiRwaDrv.sys)
+    is already tracked in LOLDrivers. The driver is available in the KeServiceDescriptorTable/vulnerable-drivers
+    repository.
+  Usecase: Elevate privileges
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/316
+- https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+Detection: []
+Acknowledgement:
+  Person: ''
+  Handle: '@rainbowdynamix, @DbgPrint'
+KnownVulnerableSamples:
+- Filename: TBT_Force_Power_Control_Access64.sys
+  MD5: a4de3d1854ba9b8e77b2324c52887a2c
+  SHA1: 8a7e3d57f841e2f70453de312ab3b3710c5f7255
+  SHA256: 4c776f34c6042d943baec3c13d7154a245aae8dd95e1933211fd19352c770676
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: ''
+  Description: ''
+  Product: ''
+  ProductVersion: ''
+  FileVersion: ''
+  MachineType: AMD64
+  OriginalFilename: ''
+  Authentihash:
+    MD5: 8244400588a570fbdcc256f5be828537
+    SHA1: 96e15eb936c049ac87d0df9b052ae7d81c8ba9a4
+    SHA256: f1768c07fb9554099980845b42ef3e545734ed98cee7be89d546351e7dbaac44
+  RichPEHeaderHash:
+    MD5: 501b9a0c68a7c9c565a4d76cb6f67f8d
+    SHA1: 542fc0119a9c81791ee7b6651ab5c967990b4945
+    SHA256: 18666117fda7dde8ec20ccc551656f4087a434b8a5efaef91077a3bed93d2b39
+  Sections:
+    .text:
+      Entropy: 6.282727083008546
+      Virtual Size: '0x18c4'
+    .rdata:
+      Entropy: 4.419901607650017
+      Virtual Size: '0x1b4'
+    .data:
+      Entropy: 1.2688008894139502
+      Virtual Size: '0x198'
+    .pdata:
+      Entropy: 3.814811746146139
+      Virtual Size: '0x108'
+    INIT:
+      Entropy: 5.034962631326141
+      Virtual Size: '0x28a'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2013-04-11 20:03:11'
+  InternalName: ''
+  Copyright: ''
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - MmFreeContiguousMemory
+  - MmUnmapIoSpace
+  - MmGetPhysicalAddress
+  - MmMapIoSpace
+  - IoDeleteDevice
+  - IoCreateSymbolicLink
+  - IoCreateDevice
+  - MmAllocateContiguousMemory
+  - KeBugCheckEx
+  - RtlInitUnicodeString
+  - IofCompleteRequest
+  - IoDeleteSymbolicLink
+  - HalSetBusDataByOffset
+  - HalGetBusDataByOffset
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=TW, ST=Taiwan, L=Taipei, O=Wistron Corporation, OU=Digital ID Class
+        3 , Microsoft Software Validation v2, OU=OS Certification Dept., CN=Wistron
+        Corporation
+      ValidFrom: '2012-03-16 00:00:00'
+      ValidTo: '2015-03-16 23:59:59'
+      Signature: c26cf2a80d12cbbd367ac79004b16ead094998318f91b5f0b24e24901723b6ec774562b4e90c4faefd332372fd448a74c54145b19b7587c29f540518701de6f0f77fe743949429f293bcabc8e5ade6312b5261d30354510a468663b06bf74fadb2be455c68e24291bab882ae19b1da343122cbfc0a57c1f901043dd94081f48b5e4527db24c1bb6aa4579bc3a01f3533721337474a587b8611640b30ae4cc53467b51d1ec3e72ba0b3f609df795a26a7051198e58cf10cf2328370d47f4decf0a06bdd0ecb02b273e7ed7a7f01bf50134c100994bafba61eb5c033855ec9d2466426922ffd36ac83323d9d224aa15646c8f5d287b0cd76833fe2837a35493979
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 397eabd0a3fccd492184ef60ab31c8b8
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 8384171634276b77f5d1f927983156df
+        SHA1: 14d5bbddcea1e088ce6c6c64b13c95afd9652fca
+        SHA256: 651023d5a56088eef928285bf1d3ed1207dbce6466e2cbb056e95a8233c9353e
+        SHA384: 308187bdee3ff6a7969fec553ba65c9fc1f62527a7c878b130f69f96e58bb554952d1ee0a8d7abf7358eb2148369bfb0
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=(c) 2006 VeriSign,
+        Inc. , For authorized use only, CN=VeriSign Class 3 Public Primary Certification
+        Authority , G5
+      ValidFrom: '2011-02-22 19:25:17'
+      ValidTo: '2021-02-22 19:35:17'
+      Signature: 812a82168c34672be503eb347b8ca2a3508af45586f11e8c8eae7dee0319ce72951848ad6211fd20fd3f4706015ae2e06f8c152c4e3c6a506c0b36a3cf7a0d9c42bc5cf819d560e369e6e22341678c6883762b8f93a32ab57fbe59fba9c9b2268fcaa2f3821b983e919527978661ee5b5d076bcd86a8e26580a8e215e2b2be23056aba0cf347934daca48c077939c061123a050d89a3ec9f578984fbecca7c47661491d8b60f195de6b84aacbc47c8714396e63220a5dc7786fd3ce38b71db7b9b03fcb71d3264eb1652a043a3fa2ead59924e7cc7f233424838513a7c38c71b242228401e1a461f17db18f7f027356cb863d9cdb9645d2ba55eefc629b4f2c7f821cc04ba57fd01b6abc667f9e7d3997ff4f522fa72f5fdff3a1c423aa1f98018a5ee8d1cd4669e4501feaaeefffb178f30f7f1cd29c59decb5d549003d85b8cbbb933a276a49c030ae66c9f723283276f9a48356c848ce5a96aaa0cc0cc47fb48e97af6de35427c39f86c0d6e473089705dbd054625e0348c2d59f7fa7668cd09db04fd4d3985f4b7ac97fb22952d01280c70f54b61e67cdc6a06c110384d34875e72afeb03b6e0a3aa66b769905a3f177686133144706fc537f52bd92145c4a246a678caf8d90aad0f679211b93267cc3ce1ebd883892ae45c6196a4950b305f8ae59378a6a250394b1598150e8ba8380b72335f476b9671d5918ad208d94
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 611993e400000000001c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 78a717e082dcc1cda3458d917e677d14
+        SHA1: 4a872e0e51f9b304469cd1dedb496ee9b8b983a4
+        SHA256: 317fa1d234ebc49040ebc5e8746f8997471496051b185a91bdd9dfbb23fab5f8
+        SHA384: b71052da4eb9157c8c1a5d7f55df19d69b9128598b72fcca608e5b7cc7d64c43c5504b9c86355a6dc22ee40c88cc385c
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=Terms of use
+        at https://www.verisign.com/rpa (c)10, CN=VeriSign Class 3 Code Signing 2010
+        CA
+      ValidFrom: '2010-02-08 00:00:00'
+      ValidTo: '2020-02-07 23:59:59'
+      Signature: 5622e634a4c461cb48b901ad56a8640fd98c91c4bbcc0ce5ad7aa0227fdf47384a2d6cd17f711a7cec70a9b1f04fe40f0c53fa155efe749849248581261c911447b04c638cbba134d4c645e80d85267303d0a98c646ddc7192e645056015595139fc58146bfed4a4ed796b080c4172e737220609be23e93f449a1ee9619dccb1905cfc3dd28dac423d6536d4b43d40288f9b10cf2326cc4b20cb901f5d8c4c34ca3cd8e537d66fa520bd34eb26d9ae0de7c59af7a1b42191336f86e858bb257c740e58fe751b633fce317c9b8f1b969ec55376845b9cad91faaced93ba5dc82153c2825363af120d5087111b3d5452968a2c9c3d921a089a052ec793a54891d3
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 5200e5aa2556fc1a86ed96c9d44b33c7
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: b30c31a572b0409383ed3fbe17e56e81
+        SHA1: 4843a82ed3b1f2bfbee9671960e1940c942f688d
+        SHA256: 03cda47a6e654ed85d932714fc09ce4874600eda29ec6628cfbaeb155cab78c9
+        SHA384: bbda8407c4f9fc4e54d772f1c7fb9d30bc97e1f97ecd51c443063d1fa0644e266328781776cd5c44896c457c75f4d7da
+    Signer:
+    - SerialNumber: 397eabd0a3fccd492184ef60ab31c8b8
+      Issuer: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=Terms of use at
+        https://www.verisign.com/rpa (c)10, CN=VeriSign Class 3 Code Signing 2010
+        CA
+      Version: 1
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: 08dd07f0f6dab7cc028ea9013f5f0884

--- a/yaml/509edc55-1881-4fac-8640-b9c516396505.yaml
+++ b/yaml/509edc55-1881-4fac-8640-b9c516396505.yaml
@@ -1,0 +1,192 @@
+Id: 509edc55-1881-4fac-8640-b9c516396505
+Tags:
+- ipctype.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-04-17'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create ipctype binPath=C:\windows\temp\ipctype.sys type=kernel &&
+    sc.exe start ipctype
+  Description: ipctype.sys is a kernel driver from Digital Electronics Corporation
+    that exposes physical memory read/write via MmMapIoSpace. The driver is available
+    in the KeServiceDescriptorTable/vulnerable-drivers repository.
+  Usecase: Elevate privileges
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/313
+- https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+Detection: []
+Acknowledgement:
+  Person: ''
+  Handle: '@rainbowdynamix, @DbgPrint'
+KnownVulnerableSamples:
+- Filename: ipctype.sys
+  MD5: c8f6cd1c989f364f126e6855f1178704
+  SHA1: 96611a3d59ea7df9453e194fb7c19d0f944bcefc
+  SHA256: 8e2acce10d704c8b511c8b6211a2be5d8e4ade91ebcbda2ac10018e4c0ae99fb
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: Digital Electronics Corporation
+  Description: IPCType Device Driver for 64bit
+  Product: IPCType Device Driver for 64bit
+  ProductVersion: 1.0.2.0
+  FileVersion: 1.0.2.0
+  MachineType: AMD64
+  OriginalFilename: ipctype.sys
+  Authentihash:
+    MD5: f41029188382165844562f7051585447
+    SHA1: 5fe6c6cde2dc32666efc70a4008d9f987ddf4a63
+    SHA256: 073ea5ba764b889b611816a73efab36882b5158641084b7431799b62d0ecc45d
+  RichPEHeaderHash:
+    MD5: ae583efa641b5b3adcd20b1b1f8a468c
+    SHA1: 26b53309451f6cb17ebcd2e6adaf2ff420605f24
+    SHA256: e5fc90cce8f3fbf1937764ed5b2b36b9d7346be931e177172ef52aaa225183f6
+  Sections:
+    .text:
+      Entropy: 5.784527713326412
+      Virtual Size: '0x4e8'
+    .rdata:
+      Entropy: 4.236261861892203
+      Virtual Size: '0x18c'
+    .data:
+      Entropy: 0.5035334969292564
+      Virtual Size: '0x118'
+    .pdata:
+      Entropy: 3.182334194023545
+      Virtual Size: '0x54'
+    INIT:
+      Entropy: 5.128335442157753
+      Virtual Size: '0x2ca'
+    .rsrc:
+      Entropy: 3.2990311935554653
+      Virtual Size: '0x3f8'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2013-12-18 18:47:22'
+  InternalName: ipctype.sys
+  Copyright: Copyright (C) 2013 Digital Electronics Corporation. All Rights Reserved.
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - MmUnmapLockedPages
+  - ExAllocatePoolWithTag
+  - IoDeleteSymbolicLink
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - IoIs32bitProcess
+  - MmUnmapIoSpace
+  - MmBuildMdlForNonPagedPool
+  - IoFreeMdl
+  - MmMapLockedPagesSpecifyCache
+  - ExFreePool
+  - MmMapIoSpace
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - IoCreateDevice
+  - IoAllocateMdl
+  - KeBugCheckEx
+  - __C_specific_handler
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services CA
+        , G2
+      ValidFrom: '2012-12-21 00:00:00'
+      ValidTo: '2020-12-30 23:59:59'
+      Signature: 03099b8f79ef7f5930aaef68b5fae3091dbb4f82065d375fa6529f168dea1c9209446ef56deb587c30e8f9698d23730b126f47a9ae3911f82ab19bb01ac38eeb599600adce0c4db2d031a6085c2a7afce27a1d574ca86518e979406225966ec7c7376a8321088e41eaddd9573f1d7749872a16065ea6386a2212a35119837eb6
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 7e93ebfb7cc64e59ea4b9a77d406fc3b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: d0785ad36e427c92b19f6826ab1e8020
+        SHA1: 365b7a9c21bd9373e49052c3e7b3e4646ddd4d43
+        SHA256: c2abb7484da91a658548de089d52436175fdb760a1387d225611dc0613a1e2ff
+        SHA384: eab4fe5ef90e0de4a6aa3a27769a5e879f588df5e4785aa4104debd1f81e19ea56d33e3a16e5facf99f68b5d8e3d287b
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services Signer
+        , G4
+      ValidFrom: '2012-10-18 00:00:00'
+      ValidTo: '2020-12-29 23:59:59'
+      Signature: 783bb4912a004cf08f62303778a38427076f18b2de25dca0d49403aa864e259f9a40031cddcee379cb216806dab632b46dbff42c266333e449646d0de6c3670ef705a4356c7c8916c6e9b2dfb2e9dd20c6710fcd9574dcb65cdebd371f4378e678b5cd280420a3aaf14bc48829910e80d111fcdd5c766e4f5e0e4546416e0db0ea389ab13ada097110fc1c79b4807bac69f4fd9cb60c162bf17f5b093d9b5be216ca13816d002e380da8298f2ce1b2f45aa901af159c2c2f491bdb22bbc3fe789451c386b182885df03db451a179332b2e7bb9dc20091371eb6a195bcfe8a530572c89493fb9cf7fc9bf3e226863539abd6974acc51d3c7f92e0c3bc1cd80475
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0ecff438c8febf356e04d86a981b1a50
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: e9d38360b914c8863f6cba3ee58764d3
+        SHA1: 4cba8eae47b6bf76f20b3504b98b8f062694a89b
+        SHA256: 88901d86a4cc1f1bb193d08e1fb63d27452e63f83e228c657ab1a92e4ade3976
+        SHA384: e9f2a75334a9e336c5a4712eadee88d0374b0fdc273262f4e65c9040ad2793067cc076696db5279a478773485e285652
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=(c) 2006 VeriSign,
+        Inc. , For authorized use only, CN=VeriSign Class 3 Public Primary Certification
+        Authority , G5
+      ValidFrom: '2011-02-22 19:25:17'
+      ValidTo: '2021-02-22 19:35:17'
+      Signature: 812a82168c34672be503eb347b8ca2a3508af45586f11e8c8eae7dee0319ce72951848ad6211fd20fd3f4706015ae2e06f8c152c4e3c6a506c0b36a3cf7a0d9c42bc5cf819d560e369e6e22341678c6883762b8f93a32ab57fbe59fba9c9b2268fcaa2f3821b983e919527978661ee5b5d076bcd86a8e26580a8e215e2b2be23056aba0cf347934daca48c077939c061123a050d89a3ec9f578984fbecca7c47661491d8b60f195de6b84aacbc47c8714396e63220a5dc7786fd3ce38b71db7b9b03fcb71d3264eb1652a043a3fa2ead59924e7cc7f233424838513a7c38c71b242228401e1a461f17db18f7f027356cb863d9cdb9645d2ba55eefc629b4f2c7f821cc04ba57fd01b6abc667f9e7d3997ff4f522fa72f5fdff3a1c423aa1f98018a5ee8d1cd4669e4501feaaeefffb178f30f7f1cd29c59decb5d549003d85b8cbbb933a276a49c030ae66c9f723283276f9a48356c848ce5a96aaa0cc0cc47fb48e97af6de35427c39f86c0d6e473089705dbd054625e0348c2d59f7fa7668cd09db04fd4d3985f4b7ac97fb22952d01280c70f54b61e67cdc6a06c110384d34875e72afeb03b6e0a3aa66b769905a3f177686133144706fc537f52bd92145c4a246a678caf8d90aad0f679211b93267cc3ce1ebd883892ae45c6196a4950b305f8ae59378a6a250394b1598150e8ba8380b72335f476b9671d5918ad208d94
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 611993e400000000001c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 78a717e082dcc1cda3458d917e677d14
+        SHA1: 4a872e0e51f9b304469cd1dedb496ee9b8b983a4
+        SHA256: 317fa1d234ebc49040ebc5e8746f8997471496051b185a91bdd9dfbb23fab5f8
+        SHA384: b71052da4eb9157c8c1a5d7f55df19d69b9128598b72fcca608e5b7cc7d64c43c5504b9c86355a6dc22ee40c88cc385c
+    - Subject: C=JP, ST=Osaka, L=Osaka City, O=Digital Electronics Corporation, OU=Digital
+        ID Class 3 , Microsoft Software Validation v2, OU=R&D Division Software Development
+        GR, CN=Digital Electronics Corporation
+      ValidFrom: '2013-06-10 00:00:00'
+      ValidTo: '2014-06-10 23:59:59'
+      Signature: e999cfb6f083deae4f4ec2bc540053ae8c96fc22dbd1d526b2879d2dddfac2c9f455cb3383e12dc347685f60f5ef384bff6005a386505ad54c7db1eab3e0d4b630b1a3931f925cde0eac396c7ea8e1a262c180bf27e2758ad27505926e25d31163433393d0f81a61de6977589bac48c2029e1e52216a6379bd6da356f5c8b620713067aa5db1b95722c0dfde54342ed4f9cdb412715090671ad0781e939027297221abf21006842ea96e38564a52f05eb29d2323a9c69799e806b8bf905a25d650a5bf6dece9b6adbbcec486f79a033a1d420cb68c66e02b1ba53114cf5f3929cf22faa1ac73f6fe740ba62d122f59f80330f9bd07192ddcae56577728cff088
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 5118bc022a1b3c585a10415eb890f6cd
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 129c3fc4428d5b9c20a065c56d45dcd7
+        SHA1: faeb21184ba59c4135f6c801277a4ababcc6277f
+        SHA256: c91b188ac0d331c24c7b28f76b8aeff647558d9ed6dbc84c5f2993eced3ac2a4
+        SHA384: ac10f66201ce9a652b24666891b2acdbaf3b2b2fcaf4582e9a4130766df3723ab6d4718e98623ea48b565be979126a31
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=Terms of use
+        at https://www.verisign.com/rpa (c)10, CN=VeriSign Class 3 Code Signing 2010
+        CA
+      ValidFrom: '2010-02-08 00:00:00'
+      ValidTo: '2020-02-07 23:59:59'
+      Signature: 5622e634a4c461cb48b901ad56a8640fd98c91c4bbcc0ce5ad7aa0227fdf47384a2d6cd17f711a7cec70a9b1f04fe40f0c53fa155efe749849248581261c911447b04c638cbba134d4c645e80d85267303d0a98c646ddc7192e645056015595139fc58146bfed4a4ed796b080c4172e737220609be23e93f449a1ee9619dccb1905cfc3dd28dac423d6536d4b43d40288f9b10cf2326cc4b20cb901f5d8c4c34ca3cd8e537d66fa520bd34eb26d9ae0de7c59af7a1b42191336f86e858bb257c740e58fe751b633fce317c9b8f1b969ec55376845b9cad91faaced93ba5dc82153c2825363af120d5087111b3d5452968a2c9c3d921a089a052ec793a54891d3
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 5200e5aa2556fc1a86ed96c9d44b33c7
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: b30c31a572b0409383ed3fbe17e56e81
+        SHA1: 4843a82ed3b1f2bfbee9671960e1940c942f688d
+        SHA256: 03cda47a6e654ed85d932714fc09ce4874600eda29ec6628cfbaeb155cab78c9
+        SHA384: bbda8407c4f9fc4e54d772f1c7fb9d30bc97e1f97ecd51c443063d1fa0644e266328781776cd5c44896c457c75f4d7da
+    Signer:
+    - SerialNumber: 5118bc022a1b3c585a10415eb890f6cd
+      Issuer: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=Terms of use at
+        https://www.verisign.com/rpa (c)10, CN=VeriSign Class 3 Code Signing 2010
+        CA
+      Version: 1
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: c418dc93b4a3c0a3e13a158f6c2fccd0

--- a/yaml/84f92ac1-1e72-420d-9cc0-65c838b90a4d.yaml
+++ b/yaml/84f92ac1-1e72-420d-9cc0-65c838b90a4d.yaml
@@ -1,0 +1,185 @@
+Id: 84f92ac1-1e72-420d-9cc0-65c838b90a4d
+Tags:
+- portwell.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-04-17'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create portwell binPath=C:\windows\temp\portwell.sys type=kernel
+    && sc.exe start portwell
+  Description: portwell.sys is a kernel driver from Portwell Inc. (Taiwan) that exposes
+    physical memory read/write via MmMapIoSpace. Portwell manufactures embedded computing
+    platforms and industrial PCs. The driver is available in the KeServiceDescriptorTable/vulnerable-drivers
+    repository.
+  Usecase: Elevate privileges
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/314
+- https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+Detection: []
+Acknowledgement:
+  Person: ''
+  Handle: '@rainbowdynamix, @DbgPrint'
+KnownVulnerableSamples:
+- Filename: portwell.sys
+  MD5: a93b28348e04109cc186b985c9308295
+  SHA1: a7b72d8a1751a10643c1cc1c148175ca13bcbebe
+  SHA256: 2f0b16ed90b8c15bf52a7c32699dbe0dbcd38fc02ed2ddb4e1ba35487177b6c5
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: Portwell Inc.
+  Description: kernel mode driver
+  Product: portwell driver
+  ProductVersion: 0.1.0.0
+  FileVersion: 0.1.0.0
+  MachineType: AMD64
+  OriginalFilename: portwell.sys
+  Authentihash:
+    MD5: 94b8f3169c7e3644e9f8d8a8aa8ac94f
+    SHA1: d7246621a438764a98f3d66ce0e393cfceb500d7
+    SHA256: 2c451270999882f56418f1dbe35fc833bb51a9b08ae590a7e407790883537647
+  RichPEHeaderHash:
+    MD5: 24a77833640f64294aed94183558d9b6
+    SHA1: 4bbea4d5a5d44c54e385de1cd61a314b81dca7ce
+    SHA256: 056a884d66338e9bd4c0e5deaa8562f0bc5482301e8bafa60f8ddd99d6df6a3f
+  Sections:
+    .text:
+      Entropy: 5.499964588959135
+      Virtual Size: '0x1275'
+    .rdata:
+      Entropy: 3.9676541818047224
+      Virtual Size: '0x1c0'
+    .data:
+      Entropy: 0.5096713223407059
+      Virtual Size: '0x114'
+    .pdata:
+      Entropy: 3.522050329628502
+      Virtual Size: '0x144'
+    INIT:
+      Entropy: 5.01007564635598
+      Virtual Size: '0x26a'
+    .rsrc:
+      Entropy: 3.1894587294556045
+      Virtual Size: '0x3a8'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2011-02-15 19:07:46'
+  InternalName: portwell.sys
+  Copyright: Copyright (C) 2010 Portwell All rights reserved.
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - MmUnmapIoSpace
+  - MmMapIoSpace
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - RtlAssert
+  - DbgPrint
+  - KeBugCheckEx
+  - RtlInitUnicodeString
+  - IoCreateDevice
+  - IoDeleteSymbolicLink
+  - __C_specific_handler
+  - HalSetBusDataByOffset
+  - HalGetBusDataByOffset
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=PL, O=Unizeto Technologies S.A., OU=Certum Certification Authority,
+        CN=Certum Time,Stamping Authority
+      ValidFrom: '2009-03-03 12:58:15'
+      ValidTo: '2024-03-03 12:58:15'
+      Signature: aa8b1ba2ec8545eb388b0a4d78cf78895310da575a5b075b270cc9d9b9c40a2a67acbf07ab35c1b40e6f794c7bbf13bffa76d56eaecda114995ff2048114579104e78b9345ae87f2b9e35ae87a35917c3a560e59b7c70da6351bcd9cd0e6553afe1b3948c75f9a2196fd1cb27352c4fef163b352afe424e5bb6790674245b676ae13e722b707cb964601e8be3d0d0de7207e46401389962f54ca345313277fecef66c4b108f73222c214a97f56f931eed42fad79213d1133f7d3aee8cbbc5bcf16f68b684f0d9cf46cb82858e3489695d424925794703c6bda3ae8ce9bd23a2b13e0fd8200577f0ddc56d0a945bcd92b9217a7166d256ff3673da7bee7609f2a
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 047a55
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: bf6920398aa3daa5672341db9f6a0325
+        SHA1: d3a5167a88dc5a1c6b32ae1ef06a89322e3848ed
+        SHA256: f0af053cfa33afd3cf0bfb01ec5e6e4c033205fbae439c0c4bcd2a6c5a1acc53
+        SHA384: e51925eb4526890b7b9bac7689af88ecc1f15cdf01852a15c589c7ec71fc1ec7c5442a6f1b733cdd3a85c3511d4ea3bb
+    - Subject: C=BE, O=GlobalSign nv,sa, OU=Primary Object Publishing CA, CN=GlobalSign
+        Primary Object Publishing CA
+      ValidFrom: '1999-01-28 13:00:00'
+      ValidTo: '2017-01-27 12:00:00'
+      Signature: b578a6a27c04b77fc97f7d6abc71fa293060c2f4621efe7f431e9b6ee2b21f730b85765b7df54e49062fd4fab79140efed6f8d8e138354c52a023d0aa4dc990b7abd772fcc40c18ff3c48c4e72ba107ce6ff642bc7ce6ca7fcd79a7c8e468d01834d423bdb9c3f9f326157d717b0b33666f0b3fd446f8137b1944ea7562589f58ad66d116262795c42900218d39c23fc08e86445b92d7e805b4eafc38a299283781f914134af85c5fd07994e2c5cfec7fd17bb2525314d72b5b5294b489a376f13c7114e4a451e7e2f319cabe852afd6679734885f0e276a6652d15ac7ac302c2038dd2bff3aebce104582a27b1ba12073569b2a93e60451066c1bdc2f899493
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 040000000001239e0facb3
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 5ccf05e4dec10d9d6fe15d8778325272
+        SHA1: 79f0a648bd7f1184f86bff43ae47c9ecc3ed3cec
+        SHA256: 33ea31b892ba274a4aefe545de45c42c218b6dff78146655cdea892545c2cccc
+        SHA384: 1350ebc11fd20f5f141bc545786506e6a154be054da7a6e603cb276a6d60a24f2a4016ecc2f5cabd1088e1905f60aabf
+    - Subject: C=TW, ST=Taiwan, L=New Taipei City, O=Portwell Inc., OU=Portwell Inc.,
+        CN=Portwell Inc.
+      ValidFrom: '2011-02-15 06:43:38'
+      ValidTo: '2012-02-12 01:39:43'
+      Signature: 26acf616ec6e68d1cd186d1f8434ee0b3f513d4a9c7d2c9418e9699bb48a11a70cfe2673d4f73701605c33ea243099671c72b271c6921f95e4171ca97102ede2217eecc5f87f80bd2b2ed78cddc3fbe18db85d0be9d4d8e84e887cf62503dc72a0ecdd5e88b4f6d8b600bc7e1633dd94584f48c6b90f44fa6ecac5a31c6a3fbd4d3938202760a978123af87b06056b4465e6c4f2c3e3bbde5b0ea79b71f346f8ce78a87c744d312cdea45346183650d13e6acdc7abc576d8c017c19957c44b8d711f206ec736c2ccd4ae388fb270a9709fb3601b4dc44bf8c05b679fabb40d82e4abf72405285a81036b87b9491f9c6ad5a062b199363dec3487a633a653c2b1
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0100000000012e283e7105
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: a97e8ebbf78752b744864129f574b4b7
+        SHA1: 8da79a14692714778f59de099d7b4cd6b03102e2
+        SHA256: c579b2c527dbaa5be5415d20f4dd9919365e334470ac70a242ca853bdbb5ec55
+        SHA384: 4f9a78a7e15cc17cf1dfd72782d0dd2822be345f93d07e87505f09f623a89c13c9c1c370dfa0750dbc574abb03670a3d
+    - Subject: C=BE, O=GlobalSign nv,sa, OU=ObjectSign CA, CN=GlobalSign ObjectSign
+        CA
+      ValidFrom: '2004-01-22 10:00:00'
+      ValidTo: '2017-01-27 10:00:00'
+      Signature: 1e6af36df48ea922fe7008652ea15dab3330dd6c78fa4beaadc58dec107a6ac55897396b92f391e20ca7281cd15d768e8b077c136fadc43643b3c1bc3159cf1838d8a33bceffca6758bfe0f1ac613ea23b1ebc025b41ac446bf526f3ed5ea865f6ca65a63fcaf577eba5862a582956f8be161040e9d2fc572c636137662539202e0703a036032594bd7ceb7ed3a3c2c57616753092b9ff7641352168d10e5e5c8ec30360e68040fcc05da2546e6e9267a7811287a2a32bdbb74dffe4d5c7e505e6d5f1aefccd661821f33e47c9e59542612c9d2680b20fa83d0ec9a778df6e748c2c46f672e93c646b2855c44b6433cb78541338f0d57106d43e0d0a350ee0b3
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 040000000001239e0faf24
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 7dd2351a85d3665eeb6720a21f4f7dee
+        SHA1: 77838c4d7f36958a581841d28f481d61ce0696ed
+        SHA256: 846725f4b0193468c1079d6127e9e6e420fc6ed66019ed02d732ba644decad57
+        SHA384: aaa45fe704bc66bb1842a2123c6e45e016dfbc7ba2ce07d7d2ee0b5d488a39c68bc6db582cb45d51f5fa52e60be8efd6
+    - Subject: C=BE, O=GlobalSign nv,sa, OU=Root CA, CN=GlobalSign Root CA
+      ValidFrom: '2006-05-23 17:00:51'
+      ValidTo: '2016-05-23 17:10:51'
+      Signature: 13c56c5e077f3c57ff9b315f3fbd955425c679f92c31034d64694b56d95b976f7cf3f0d024657538639813701613f7a701f1c623e085866c0bf080945a75e87ce41e92b473bfc1b3a7b00bd31884cbcc09a35c9c4f3eb03a9c2d1bc404ef9737966fe5ecbaac6ab3d4e23cdf8b25e7acbc624531dda40a72e41bf8784301ccba3914de5d90aed85acf5eca46815133d5a60e5867d3d8665888169beeb11acaad91138421da9a6e20efda007428bac95ff34d5dc3da25692554ea44bcc39b29331cd63c961f8781c553d72a2733d42e197c08586ddb4e1999a9ea5ff39a9d8c513a5a5cbd2fa908359b54a7db351a521633343aa380046afdb4838cad90cf0c3a6596ec334e1826b849bbeb8192ff134d324b23c733e7b6716b15f69c80e6bcb76cbe41d5033a7133150050743b0e5df996aaed903eab134c809926bc38a5eb0236891db620be83ab10f8199ed76379d4aeb12f6136f94a4ba833c70e7241f9f1b1907eae46efde397b75a0411459041d42bc4788b8130e05fa1df0808dff70c677d84bdc460e231a72d5bfdefeaaae69583cfc5c46e4d5819a8b6e6559771a32a590a6b6649364fd0753c9a0de28ad2a6cc638d181ce98f54019e92c1743a4265fd3443053e41d02baa40a2f16dd7a60275242bbad98372897e4b8d27911e3108c48d5305d0a0c52def588ea8d1a2d67c9f4801484b7850cd16628a5c66f2461
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 610b7f6b000000000019
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 4798d55be7663a75649cda4dedc686ef
+        SHA1: 0f1ab2937b245d9466ea6f9bf056a5942e3989cf
+        SHA256: ef14ea05bb066ee9f4188196dd69cd769b283ac4d7555db52f5e76922d3456e1
+        SHA384: 6e7450a139856aeda6fa6284ff89b3752a9b646e096b4d33dd7e8e727742a2111481531581c0aa2cda0338e22cfdbad3
+    Signer:
+    - SerialNumber: 0100000000012e283e7105
+      Issuer: C=BE, O=GlobalSign nv,sa, OU=ObjectSign CA, CN=GlobalSign ObjectSign
+        CA
+      Version: 1
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: 3e7652a1d28db44c532a007ef80fa618

--- a/yaml/886af494-4087-48c9-b48f-53e638d6f62e.yaml
+++ b/yaml/886af494-4087-48c9-b48f-53e638d6f62e.yaml
@@ -1,0 +1,181 @@
+Id: 886af494-4087-48c9-b48f-53e638d6f62e
+Tags:
+- UDDB2B6.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-04-17'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create UDDB2B6 binPath=C:\windows\temp\UDDB2B6.sys type=kernel &&
+    sc.exe start UDDB2B6
+  Description: UDDB2B6.sys is a TechPowerUp kernel driver (GPU-Z variant) that exposes
+    I/O port read/write, MSR read/write, MmMapIoSpace map/unmap/read/write, and PCI
+    configuration space read/write. TechPowerUp has a history of vulnerable kernel
+    drivers including GPU-Z.sys (CVE-2019-7245, CVE-2025-5324) and ThrottleStop.sys
+    (CVE-2025-7771). The driver is available in the KeServiceDescriptorTable/vulnerable-drivers
+    repository.
+  Usecase: Elevate privileges
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/323
+- https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+Detection: []
+Acknowledgement:
+  Person: ''
+  Handle: '@rainbowdynamix, @DbgPrint'
+KnownVulnerableSamples:
+- Filename: UDDB2B6.sys
+  MD5: d4320487bf3021f2f2afcfc43d652a69
+  SHA1: f94503fea3fa7c526a70187444affd7f0e0e8926
+  SHA256: 9af0b89c5c54eb66e5a660b61aee7c1a25b1c92e20a310d8b16552abcf90c0b5
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: ''
+  Description: Low-Level Driver
+  Product: Low-Level Driver
+  ProductVersion: 5.0.0.0
+  FileVersion: 5.0.0.0
+  MachineType: AMD64
+  OriginalFilename: ''
+  Authentihash:
+    MD5: 7871902bebb585e4618ba59e9c48bf71
+    SHA1: f36d42ef53bc86c5345ddc9d2a28093fd713822b
+    SHA256: 9786d12616feaf1302c308b816d3582969f4510208aedffac92225bbb78efc35
+  RichPEHeaderHash:
+    MD5: b37ad1d85b91c021ea12bff0b0376eee
+    SHA1: 3d6e11dd7d2b8086a4fac748992854a729c981f6
+    SHA256: 11c623eec508e3fa87222632ece31a0c0e6b4f8b0d21b22715ec9f265c56a44d
+  Sections:
+    .text:
+      Entropy: 6.20794196283954
+      Virtual Size: '0x12e9'
+    .rdata:
+      Entropy: 4.235911121601372
+      Virtual Size: '0xca4'
+    .data:
+      Entropy: 2.066104072827117
+      Virtual Size: '0x220'
+    .pdata:
+      Entropy: 4.135029038437317
+      Virtual Size: '0x294'
+    PAGE:
+      Entropy: 6.240571596154161
+      Virtual Size: '0x1987'
+    INIT:
+      Entropy: 4.9460502571462355
+      Virtual Size: '0x66c'
+    .rsrc:
+      Entropy: 3.166293837059211
+      Virtual Size: '0x2b0'
+    .reloc:
+      Entropy: 3.7563283859124614
+      Virtual Size: '0x30'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2024-02-12 02:47:29'
+  InternalName: ''
+  Copyright: Copyright 2004-2024 (c). All rights reserved.
+  Imports:
+  - HAL.dll
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - HalGetBusDataByOffset
+  - HalSetBusDataByOffset
+  - _vsnwprintf
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - RtlCopyUnicodeString
+  - IoDeleteSymbolicLink
+  - IoRegisterShutdownNotification
+  - ExAllocatePoolWithTag
+  - IoUnregisterShutdownNotification
+  - ExFreePoolWithTag
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - wcsrchr
+  - __C_specific_handler
+  - MmBuildMdlForNonPagedPool
+  - IoAllocateMdl
+  - MmMapIoSpace
+  - MmUnmapIoSpace
+  - PsGetCurrentProcessId
+  - IoFreeMdl
+  - MmUnmapLockedPages
+  - MmMapLockedPagesSpecifyCache
+  - MmGetSystemRoutineAddress
+  - RtlFreeUnicodeString
+  - IoCreateDevice
+  - ZwClose
+  - ObOpenObjectByPointer
+  - ZwSetSecurityObject
+  - IoDeviceObjectType
+  - _snwprintf
+  - RtlLengthSecurityDescriptor
+  - SeCaptureSecurityDescriptor
+  - RtlCreateSecurityDescriptor
+  - RtlSetDaclSecurityDescriptor
+  - RtlAbsoluteToSelfRelativeSD
+  - IoIsWdmVersionAvailable
+  - SeExports
+  - wcschr
+  - _wcsnicmp
+  - RtlLengthSid
+  - RtlAddAccessAllowedAce
+  - RtlGetSaclSecurityDescriptor
+  - RtlGetDaclSecurityDescriptor
+  - RtlGetGroupSecurityDescriptor
+  - RtlGetOwnerSecurityDescriptor
+  - ZwOpenKey
+  - ZwCreateKey
+  - ZwQueryValueKey
+  - ZwSetValueKey
+  - KeBugCheckEx
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Spokane, O=TechPowerUp LLC, serialNumber=604
+        057 982, CN=TechPowerUp LLC, BUSINESS_CATEGORY=Private Organization, JURISDICTION_OF_INCORPORATION_SP=Washington,
+        JURISDICTION_OF_INCORPORATION_C=US
+      ValidFrom: '2022-06-24 13:22:08'
+      ValidTo: '2025-04-14 20:06:58'
+      Signature: c59737c97e8486c0a7fc3d2a096b1d16734edb2e1ece05c9716478b6b8a4cd5976140e8efe19e8f790fa191e623f616945f68b8e147911fd94bc0a2c2a09e7e63fdd43680372d79d7e4970c0912d29a43f95dfc1e0b50cb1cf5e8e7d7f0648e38f2661c82fa02c8b74752ac12c97424fde8700a6fd8c8dfe501d029bb8a0cf4a063b0e0f733bec2d046e4966702acfe0d939b628723e0ceea458a6866aa4332dff03369ed46a1ace8fa40a32b77f66f0775dd61378077d3a83b3a95564f85194ec731b62990b844873ef30b2a0f9098b552f58431e9b39e08720b46114201f9535f33e78844202c553a2d79a06d60c0c98966623b0a78c3214ab7d04ba922580f6b50c72c2f251a2a36e0048b4b04b50493ce019a3696ad5750d73036ebe12704ecde47af92fc3ed1afee6dd1b02671991932c3289d194c66c2abe801675abb973a36abdb2ab5e97907a6e9ab16a0a3c5be5f935f7c380d0a3da42fd12cf1931a5954cf04e1b83ab4730507c774d55d9491014dc088a21350fd380cc2d84b2e5fc27d6f7855614be8772917dede4d724e64aabc2f3fe8d10d71f281b9a0ac5028219ecd92cdc77b31c946a282cd1039285c6dbcfa5f70681423194904d1888807009489125284d5c12f5f32ee0282607fef79e2ce39db5173c9a7165ec24020a6b4586d0003fce184dacfc2dbc61fd0d0f0e4d0da13bb381618b4540632ae5f1
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 115bbe9e1c286827af66e7a01390c206
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 60e408e2390af7c32b78b980eebef3dc
+        SHA1: ca42b365c64a60c58de315e23b522b3e69dfcf85
+        SHA256: 06990ff9bd8df35bf3deff4b89e9448895469ca675a68d726b02cc307d57eadd
+        SHA384: 25a302eef819bcc3db04b9dcff01ec2c38cb536a73f87a782f79df50178efaa0cb7ec579fe84a446f55f6c05e52ad987
+    - Subject: C=US, ST=Texas, L=Houston, O=SSL Corp, CN=SSL.com EV Code Signing Intermediate
+        CA RSA R3
+      ValidFrom: '2019-03-26 17:44:23'
+      ValidTo: '2034-03-22 17:44:23'
+      Signature: 728ffa81488291e26083255b7b8f2f940f8358ce8824fa99424e2d4e3789f89fb11eae744079f9decbf7ff2c25105298408f5438ff5dd12aa95ae6b702bbc87fee2ad3ff7fcc363c5529435d364996265d70e7f22b0567474c99581908f6b1c64f60d2fc38be02ac25d1880da52ce1ddd37d57cf6ac31960d26daa5d7b44e85a5b83dbc81b360a7e0af50a523678e29afb1354cc9cc947bf624e35af3ee1ba0fc993eed520b796b7507652357a9da13b2664371fcebc037bc461815289cc7bfe5a051a47aee412ca8e54e35a9fb0c18af2f95f4668b9afc7d93e84d12b2512383dbb9a01eadfcc66a8b6c51f6a9347b0ce069284ad43836a86395c4ce2024b7873ae4b28e6a4f8616980ccff34e8b02f6402490d8d2e1f7deba186050fed5e7034e5180200eb63be75266da71c905707ae99a58e37d2a7c3586ca5f4e7522235a75bbb6eeb48db9a72deaa5a6249099e902b120fc83adbaf68739dd9e379ca98f9681deae6582ea9186ccd993a9acd267044e666989c251e196ac7d8f3e7ffa63577fbf57dbb8c82c76f7d5432bbea990b39e82051152f89e32ae1c520f37a784e3daf176292548d278c9037dce329e84293b6f83b2b0b9950b8e434069823eeeadfb554bbaedbf1eadd72f945edb1da433b80fc6f6cdfdc916db8a5d4ef75cd654c642c59df132e021b4bfa0493c0bb371d1fb220d34f33af16a11cc0aaa888
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 424b6a53cec766141c2a63b1a51c4104
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: db3494d2a0da480f9a2dc03978395f8a
+        SHA1: 9cb274c1f98981dbdbe1a7630a9071458784c80d
+        SHA256: 49b229a10f850de5b85110a0e0f59c48dd12b116c9ad236a3f16c5bdfbc968d5
+        SHA384: 2012fa0acaa171e7e953cfad3301af5dc2947a64428d9fdc7bcd47afe88ab85fa580e0ed6d0f61e9629d46accc3b48ec
+    Signer:
+    - SerialNumber: 115bbe9e1c286827af66e7a01390c206
+      Issuer: C=US, ST=Texas, L=Houston, O=SSL Corp, CN=SSL.com EV Code Signing Intermediate
+        CA RSA R3
+      Version: 1
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: fbcbcd6272f1203182652eacc64bca75

--- a/yaml/bd06e043-0f69-4212-be93-d069bf0de848.yaml
+++ b/yaml/bd06e043-0f69-4212-be93-d069bf0de848.yaml
@@ -1,0 +1,186 @@
+Id: bd06e043-0f69-4212-be93-d069bf0de848
+Tags:
+- AsrCDDrv.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-04-17'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create AsrCDDrv binPath=C:\windows\temp\AsrCDDrv.sys type=kernel
+    && sc.exe start AsrCDDrv
+  Description: AsrCDDrv.sys is a kernel driver from ASRock Incorporation that exposes
+    control register read/write (cr0, cr2, cr3, cr4, cr8), arbitrary MSR read/write,
+    arbitrary physical memory read/write via MmMapIoSpace, contiguous memory allocation/free
+    via MmAllocateContiguousMemorySpecifyCache, and I/O port read/write (8/16/32-bit).
+    The driver is available in the KeServiceDescriptorTable/vulnerable-drivers repository.
+  Usecase: Elevate privileges
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/326
+- https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+Detection: []
+Acknowledgement:
+  Person: ''
+  Handle: '@rainbowdynamix, @DbgPrint'
+KnownVulnerableSamples:
+- Filename: AsrCDDrv.sys
+  MD5: 7ee002414a5fa3650d418ebde92e528d
+  SHA1: 554c4784bafef107fc64c170c073af85b8e8b85a
+  SHA256: 04cc7df4077e36199b04afa39204c8f568f7f66f045e73010fb9b7685324442f
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: ASRock Incorporation
+  Description: ASRock Setup Driver
+  Product: ASRock Setup utility
+  ProductVersion: 1.00.00.0000
+  FileVersion: '1.00.00.0000 built by: WinDDK'
+  MachineType: AMD64
+  OriginalFilename: AsrCDDrv.sys
+  Authentihash:
+    MD5: 7ff3d0c2e1fc70b8ab22c7632f12a116
+    SHA1: f0378e4b642a435804a8bc9c4f2560d5a19eb2a7
+    SHA256: 550ce92e71808dc6b7fc5cba903c57f761816d35b2e76b4230cb6de6c540fce6
+  RichPEHeaderHash:
+    MD5: e17528a6924e362a582d295d8b9f454d
+    SHA1: 6b9c4cc51c6ed9e9d47186162eaed54e68f15157
+    SHA256: 086cf6d5b93f22feaf67adc52dcf88d69fd9d7cf1b244bba1cd9e22e4bb9baca
+  Sections:
+    .text:
+      Entropy: 6.3166868559763385
+      Virtual Size: '0x14fa'
+    .rdata:
+      Entropy: 4.7312172898131415
+      Virtual Size: '0x1bc'
+    .data:
+      Entropy: 0.4697909271189269
+      Virtual Size: '0x130'
+    .pdata:
+      Entropy: 3.558429299887632
+      Virtual Size: '0xd8'
+    INIT:
+      Entropy: 5.328065922243454
+      Virtual Size: '0x3ae'
+    .rsrc:
+      Entropy: 3.2877257875824744
+      Virtual Size: '0x3b8'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2010-12-13 20:34:49'
+  InternalName: AsrCDDrv.sys
+  Copyright: ASRock Incorporation, all rights reserved
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - MmUnmapIoSpace
+  - MmGetPhysicalAddress
+  - MmMapIoSpace
+  - MmFreeContiguousMemorySpecifyCache
+  - IoCreateSymbolicLink
+  - IoCreateDevice
+  - MmAllocateContiguousMemorySpecifyCache
+  - KeBugCheckEx
+  - IofCompleteRequest
+  - IoDeleteSymbolicLink
+  - KeStallExecutionProcessor
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=VeriSign, Inc., CN=VeriSign Time Stamping Services Signer ,
+        G2
+      ValidFrom: '2007-06-15 00:00:00'
+      ValidTo: '2012-06-14 23:59:59'
+      Signature: 50c54bc82480dfe40d24c2de1ab1a102a1a6822d0c831581370a820e2cb05a1761b5d805fe88dbf19191b3561a40a6eb92be3839b07536743a984fe437ba9989ca95421db0b9c7a08d57e0fad5640442354e01d133a217c84daa27c7f2e1864c02384d8378c6fc53e0ebe00687dda4969e5e0c98e2a5bebf8285c360e1dfad28d8c7a54b64dac71b5bbdac3908d53822a1338b2f8a9aebbc07213f44410907b5651c24bc48d34480eba1cfc902b414cf54c716a3805cf9793e5d727d88179e2c43a2ca53ce7d3df62a3ab84f9400a56d0a835df95e53f418b3570f70c3fbf5ad95a00e17dec4168060c90f2b6e8604f1ebf47827d105c5ee345b5eb94932f233
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 3825d7faf861af9ef490e726b5d65ad5
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: d6c7684e9aaa508cf268335f83afe040
+        SHA1: 18066d20ad92409c567cdfde745279ff71c75226
+        SHA256: a612fb22ce8be6dab75e47c98508f98496583e79c9c97b936a8caee9ea9f3fff
+        SHA384: 35c249d6ad0261a6229b2a727067ac6ba32a5d24b30b9249051f748c7735fbe2ec2ef26a702c50df1790fbe32a65aee7
+    - Subject: C=US, O=VeriSign, Inc., CN=VeriSign Time Stamping Services CA
+      ValidFrom: '2003-12-04 00:00:00'
+      ValidTo: '2013-12-03 23:59:59'
+      Signature: 4a6bf9ea58c2441c318979992b96bf82ac01d61c4ccdb08a586edf0829a35ec8ca9313e704520def47272f0038b0e4c9934e9ad4226215f73f37214f703180f18b3887b3e8e89700fecf55964e24d2a9274e7aaeb76141f32acee7c9d95eddbb2b853eb59db5d9e157ffbeb4c57ef5cf0c9ef097fe2bd33b521b1b3827f73f4a
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 47bf1995df8d524643f7db6d480d31a4
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 518d2ea8a21e879c942d504824ac211c
+        SHA1: 21ce87d827077e61abddf2beba69fde5432ea031
+        SHA256: 1ec3b4f02e03930a470020e0e48d24b84678bb558f46182888d870541f5e25c7
+        SHA384: 53e346bbde23779a5d116cc9d86fdd71c97b1f1b343439f8a11aa1d3c87af63864bb8488a5aeb2d0c26a6a1e0b15f03f
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=Terms of use
+        at https://www.verisign.com/rpa (c)04, CN=VeriSign Class 3 Code Signing 2004
+        CA
+      ValidFrom: '2004-07-16 00:00:00'
+      ValidTo: '2014-07-15 23:59:59'
+      Signature: ae3a17b84a7b55fa6455ec40a4ed494190999c89bcaf2e1dca7823f91c190f7feb68bc32d98838dedc3fd389b43fb18296f1a45abaed2e26d3de7c016e000a00a4069211480940f91c1879672324e0bbd5e150ae1bf50edde02e81cd80a36c524f9175558aba22f2d2ea4175882f63557d1e545a9559cad93481c05f5ef67ab5
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 4191a15a3978dfcf496566381d4c75c2
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 41011f8d0e7c7a6408334ca387914c61
+        SHA1: c7fc1727f5b75a6421a1f95c73bbdb23580c48e5
+        SHA256: 88dd3952638ee82738c03168e6fd863fe4eab1059ee5e2926ad8cb587c255dc0
+        SHA384: a00aa5ed457c41e37967882644d63366bae014f03a986576d8514164d7027acf7d0b5e03d764db2558f60db148954459
+    - Subject: C=TW, ST=TAIWAN, L=Taipei, O=ASROCK Incorporation, OU=Digital ID Class
+        3 , Microsoft Software Validation v2, CN=ASROCK Incorporation
+      ValidFrom: '2008-03-20 00:00:00'
+      ValidTo: '2011-04-04 23:59:59'
+      Signature: 179fbf5dd400138d3d484517a6375dd973c3679b73725ec83b4b9fd6fc7b064b619c47f7127e039e62d2dbea7aae89f4a54974ec94f22b62d9a289dd2c5384726f59991a09e672281308cf85d62c11c33251a319d2d017606594597e0a9ad63760309819db18ff72b3aed4c8da0d9b9811a1efa1ff05874e803a8ff73df738b7949382f045a19d68c1baae7cc5b1b7a2c07b5a911ce59a5ab03976564c0ca80e663e7b872d5713c2814d06036d22632716bc7e7be1244e9838ec543c7c157dd27d40800bc907bd4a428754465dcf738738b096f1b1054bf989a94f2129a67d369931517b5f4701cffb5264ef481bc0fce0a7345496a17aecdc875782b2b93f00
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 5958ecc30dd6f80e6e7ba7ee62cca802
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 94dd40fb7f02f41e5d6c615a8843a724
+        SHA1: c7185b172a9d61dc30f2e9f40878d010fd38774b
+        SHA256: ea6a2d5c3ed62615c1f9fc5d4a151a20fbca985a6bcd71bec5c570ec8e05c316
+        SHA384: 66f8fb4b317b88fd1b3a28e7652b37ef64f2f26a35de7371160863f1fd8e38abc166c58a3c1cf0f1ddc89fdaa02fb64a
+    - Subject: C=US, O=VeriSign, Inc., OU=Class 3 Public Primary Certification Authority
+      ValidFrom: '2006-05-23 17:01:29'
+      ValidTo: '2016-05-23 17:11:29'
+      Signature: 01e446b33b457f7513877e5f43de468ecb8abdb64741bccccc7491d8ce395195a4a6b547c0efd2da7b8f5711f4328c7ccd3fee42da04214af7c843884a6f5cca14fc4bd19f4cbdd4556ecc02be0da6888f8609baa425bde8b0f0fa8b714e67b0cb82a8d78e55f737ebf03e88efe4e08afd1c6e2e61414875b4b02c1d28d8490fd715f02473253ccc880cde284c6554fe5eae8cea19ad2c51b29b3a47f53c80350117e24987d6544afb4bab07bcbf7d79cfbf35005cbb9ecffc82891b39a05197b6dec0b307ff449644c0342a195cabeef03bec294eb513c537857e75d5b4d60d066eb5d26c237167eaf1718eaf4e74aa0cf9ecbf4c58fa5e909b6d39cb86883f8b1ca81632d5fe6db9f1f8b3ead791f6364778c0272a15c768d6f4c5fc4f4ec8673f102d409ff11ec96148e7a703fc31730cf04688fe56da492995ef09daa3e5beef60ecd954a0599c28bd54ef66157f874c84dba60e95672e517b3439b641c28c846826dc240209e7818e0a972defeea7b998a60f818dc710b5e1ed982f486f53854964789bec5dac970b5526c3efba8dc8d1a52f5a7f936b611a339b18b8a26210de24ea76e12f43ebecdd7c12342489da2855aee5754e312b6763b6a8d7ab730a03cec5ea593fc7eb2a45aea8625b2f009939abb45f73c308ec80118f470e8f2a1343e191066255bbffba3da9a93d260faeca7d628b155589d694344dd665
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 610c120600000000001b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 53c41bc1164e09e0cd1617a5bf913efd
+        SHA1: 93c03aac8951d494ecd5696b1c08658541b18727
+        SHA256: 40bddadac24dc61ca4fb5cab2a2bc5d876bc36808311039a7a3e1a4066f7489b
+        SHA384: f51d4e75ba638f7314cd59b8d6d45f3b34d35ce6986e9d205cd6f333e8e8d8e9c91f636e6bc84731b6661673f40963d8
+    Signer:
+    - SerialNumber: 5958ecc30dd6f80e6e7ba7ee62cca802
+      Issuer: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=Terms of use at
+        https://www.verisign.com/rpa (c)04, CN=VeriSign Class 3 Code Signing 2004
+        CA
+      Version: 1
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: 57c7a5afa78ef66662909df8a27a1455

--- a/yaml/d0de6c54-2dd8-4e32-a2a7-c6c26dcd2a0f.yaml
+++ b/yaml/d0de6c54-2dd8-4e32-a2a7-c6c26dcd2a0f.yaml
@@ -1,0 +1,195 @@
+Id: d0de6c54-2dd8-4e32-a2a7-c6c26dcd2a0f
+Tags:
+- XLHA.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-04-17'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create XLHA binPath=C:\windows\temp\XLHA.sys type=kernel && sc.exe
+    start XLHA
+  Description: XLHA.sys is a kernel driver from LG Electronics Inc. that exposes physical
+    memory read/write via MmMapIoSpace and MSR read. Two other LG LHA.sys variants
+    are already tracked in LOLDrivers. The driver is available in the KeServiceDescriptorTable/vulnerable-drivers
+    repository.
+  Usecase: Elevate privileges
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/324
+- https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+Detection: []
+Acknowledgement:
+  Person: ''
+  Handle: '@rainbowdynamix, @DbgPrint'
+KnownVulnerableSamples:
+- Filename: XLHA.sys
+  MD5: ec7f14be325648533fc04aff9da8635f
+  SHA1: 086e5aab557be8fc970cb11b17d948f8a11978d8
+  SHA256: 11c9cbc39b6e028f2e8f9e7f83b47ae83ca73961ecfebb2f7213f9478f5446d5
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: LG Electronics Inc.
+  Description: XLHA
+  Product: "Microsoft\xAE Windows\xAE Operating System"
+  ProductVersion: 6.1.7600.16385
+  FileVersion: '6.1.7600.16385 built by: WinDDK'
+  MachineType: AMD64
+  OriginalFilename: XLHA.sys
+  Authentihash:
+    MD5: 2d9afb49cfc1bad59a7f65cfdea6cf9c
+    SHA1: 6826c2bcdcfe39f096bd70b52ebe4c24c2a8e208
+    SHA256: c0166630f8a9453c118c650f9bdaaa1bb6014b4a3d759d90b8268268797133a0
+  RichPEHeaderHash:
+    MD5: 30c853790d43b4458084956d9d579d85
+    SHA1: f3ae411539a96e483f7abe861a274004470e2c6f
+    SHA256: 102020b25facf0be74f4f0fe654d19ef01334cf6a3431c43aaed5c85c009f02f
+  Sections:
+    .text:
+      Entropy: 6.4068564679293685
+      Virtual Size: '0x236e'
+    .rdata:
+      Entropy: 4.598961116862971
+      Virtual Size: '0x25c'
+    .data:
+      Entropy: 0.41395709433809735
+      Virtual Size: '0x161'
+    .pdata:
+      Entropy: 3.8305271148391036
+      Virtual Size: '0x120'
+    INIT:
+      Entropy: 5.082764435526367
+      Virtual Size: '0x33c'
+    .rsrc:
+      Entropy: 3.4325228322463297
+      Virtual Size: '0x388'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2015-12-28 20:05:35'
+  InternalName: XLHA.sys
+  Copyright: ultrabios@hotmail.com
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ExFreePoolWithTag
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - KeReleaseSpinLock
+  - MmUnmapIoSpace
+  - MmFreeNonCachedMemory
+  - MmGetPhysicalAddress
+  - MmMapIoSpace
+  - IoDeleteSymbolicLink
+  - IoCreateSymbolicLink
+  - MmAllocateNonCachedMemory
+  - IoCreateDevice
+  - KeAcquireSpinLockRaiseToDpc
+  - DbgPrint
+  - IoWMIQueryAllData
+  - MmGetSystemRoutineAddress
+  - KeBugCheckEx
+  - IofCompleteRequest
+  - ExAllocatePoolWithTag
+  - KeStallExecutionProcessor
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services CA
+        , G2
+      ValidFrom: '2012-12-21 00:00:00'
+      ValidTo: '2020-12-30 23:59:59'
+      Signature: 03099b8f79ef7f5930aaef68b5fae3091dbb4f82065d375fa6529f168dea1c9209446ef56deb587c30e8f9698d23730b126f47a9ae3911f82ab19bb01ac38eeb599600adce0c4db2d031a6085c2a7afce27a1d574ca86518e979406225966ec7c7376a8321088e41eaddd9573f1d7749872a16065ea6386a2212a35119837eb6
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 7e93ebfb7cc64e59ea4b9a77d406fc3b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: d0785ad36e427c92b19f6826ab1e8020
+        SHA1: 365b7a9c21bd9373e49052c3e7b3e4646ddd4d43
+        SHA256: c2abb7484da91a658548de089d52436175fdb760a1387d225611dc0613a1e2ff
+        SHA384: eab4fe5ef90e0de4a6aa3a27769a5e879f588df5e4785aa4104debd1f81e19ea56d33e3a16e5facf99f68b5d8e3d287b
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services Signer
+        , G4
+      ValidFrom: '2012-10-18 00:00:00'
+      ValidTo: '2020-12-29 23:59:59'
+      Signature: 783bb4912a004cf08f62303778a38427076f18b2de25dca0d49403aa864e259f9a40031cddcee379cb216806dab632b46dbff42c266333e449646d0de6c3670ef705a4356c7c8916c6e9b2dfb2e9dd20c6710fcd9574dcb65cdebd371f4378e678b5cd280420a3aaf14bc48829910e80d111fcdd5c766e4f5e0e4546416e0db0ea389ab13ada097110fc1c79b4807bac69f4fd9cb60c162bf17f5b093d9b5be216ca13816d002e380da8298f2ce1b2f45aa901af159c2c2f491bdb22bbc3fe789451c386b182885df03db451a179332b2e7bb9dc20091371eb6a195bcfe8a530572c89493fb9cf7fc9bf3e226863539abd6974acc51d3c7f92e0c3bc1cd80475
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0ecff438c8febf356e04d86a981b1a50
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: e9d38360b914c8863f6cba3ee58764d3
+        SHA1: 4cba8eae47b6bf76f20b3504b98b8f062694a89b
+        SHA256: 88901d86a4cc1f1bb193d08e1fb63d27452e63f83e228c657ab1a92e4ade3976
+        SHA384: e9f2a75334a9e336c5a4712eadee88d0374b0fdc273262f4e65c9040ad2793067cc076696db5279a478773485e285652
+    - Subject: "C=KR, ST=\uACBD\uAE30\uB3C4 \uD3C9\uD0DD\uC2DC, L=\uACBD\uAE30\uB3C4\
+        \ \uD3C9\uD0DD\uC2DC, O=LG Electronics Inc., CN=LG Electronics Inc."
+      ValidFrom: '2014-07-30 00:00:00'
+      ValidTo: '2017-09-27 23:59:59'
+      Signature: e5240868f932855b412fcfb55a2d2e6a117e180f2c1ace813e5d234bce408b042a504dbade9c7586a4d54149845acde53075e86e0d739e4a3d1c891834beb37785f0c08c043488dc70c3290e652f0a24836354692556ad87b4eceb24d91348a7becbb7854185e8fc135c01577c182b600d76865a11382f89ccc2ca73d56c4a15a6d43f57c2dcd007639aaab4902b1b0c06242ad6e138c7499a3fb6aa3483454aac67a5ba6cadb29cbeb453921b3f1f9d54dd7660305846e376c5811e0b9d129a0fe079a00cd0e20c90934042bf320b952a75a9e3080c1b35b2213a406e3f2255f45cf0d9933e16b78a222f7e62b554d1f210a520f1ca97680a5d8530573d2780
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 4bad88265909f29eb7827157954a75a5
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 52a4b746528c06f501945b65a62947e0
+        SHA1: d6ceebc8b2b42593ba455288596ac537ada0a97c
+        SHA256: ac5e2ff118ef7840f833e2aa3cc53389a85e092cb732cba8f3f48e45735af79e
+        SHA384: 17d54ba5865642ef456642143388a0831789f8430ecb4786d8258b259e9d7c4609121ccc893c0c9753367bbb32e677c6
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=(c) 2006 VeriSign,
+        Inc. , For authorized use only, CN=VeriSign Class 3 Public Primary Certification
+        Authority , G5
+      ValidFrom: '2011-02-22 19:25:17'
+      ValidTo: '2021-02-22 19:35:17'
+      Signature: 812a82168c34672be503eb347b8ca2a3508af45586f11e8c8eae7dee0319ce72951848ad6211fd20fd3f4706015ae2e06f8c152c4e3c6a506c0b36a3cf7a0d9c42bc5cf819d560e369e6e22341678c6883762b8f93a32ab57fbe59fba9c9b2268fcaa2f3821b983e919527978661ee5b5d076bcd86a8e26580a8e215e2b2be23056aba0cf347934daca48c077939c061123a050d89a3ec9f578984fbecca7c47661491d8b60f195de6b84aacbc47c8714396e63220a5dc7786fd3ce38b71db7b9b03fcb71d3264eb1652a043a3fa2ead59924e7cc7f233424838513a7c38c71b242228401e1a461f17db18f7f027356cb863d9cdb9645d2ba55eefc629b4f2c7f821cc04ba57fd01b6abc667f9e7d3997ff4f522fa72f5fdff3a1c423aa1f98018a5ee8d1cd4669e4501feaaeefffb178f30f7f1cd29c59decb5d549003d85b8cbbb933a276a49c030ae66c9f723283276f9a48356c848ce5a96aaa0cc0cc47fb48e97af6de35427c39f86c0d6e473089705dbd054625e0348c2d59f7fa7668cd09db04fd4d3985f4b7ac97fb22952d01280c70f54b61e67cdc6a06c110384d34875e72afeb03b6e0a3aa66b769905a3f177686133144706fc537f52bd92145c4a246a678caf8d90aad0f679211b93267cc3ce1ebd883892ae45c6196a4950b305f8ae59378a6a250394b1598150e8ba8380b72335f476b9671d5918ad208d94
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 611993e400000000001c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 78a717e082dcc1cda3458d917e677d14
+        SHA1: 4a872e0e51f9b304469cd1dedb496ee9b8b983a4
+        SHA256: 317fa1d234ebc49040ebc5e8746f8997471496051b185a91bdd9dfbb23fab5f8
+        SHA384: b71052da4eb9157c8c1a5d7f55df19d69b9128598b72fcca608e5b7cc7d64c43c5504b9c86355a6dc22ee40c88cc385c
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=Terms of use
+        at https://www.verisign.com/rpa (c)10, CN=VeriSign Class 3 Code Signing 2010
+        CA
+      ValidFrom: '2010-02-08 00:00:00'
+      ValidTo: '2020-02-07 23:59:59'
+      Signature: 5622e634a4c461cb48b901ad56a8640fd98c91c4bbcc0ce5ad7aa0227fdf47384a2d6cd17f711a7cec70a9b1f04fe40f0c53fa155efe749849248581261c911447b04c638cbba134d4c645e80d85267303d0a98c646ddc7192e645056015595139fc58146bfed4a4ed796b080c4172e737220609be23e93f449a1ee9619dccb1905cfc3dd28dac423d6536d4b43d40288f9b10cf2326cc4b20cb901f5d8c4c34ca3cd8e537d66fa520bd34eb26d9ae0de7c59af7a1b42191336f86e858bb257c740e58fe751b633fce317c9b8f1b969ec55376845b9cad91faaced93ba5dc82153c2825363af120d5087111b3d5452968a2c9c3d921a089a052ec793a54891d3
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 5200e5aa2556fc1a86ed96c9d44b33c7
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: b30c31a572b0409383ed3fbe17e56e81
+        SHA1: 4843a82ed3b1f2bfbee9671960e1940c942f688d
+        SHA256: 03cda47a6e654ed85d932714fc09ce4874600eda29ec6628cfbaeb155cab78c9
+        SHA384: bbda8407c4f9fc4e54d772f1c7fb9d30bc97e1f97ecd51c443063d1fa0644e266328781776cd5c44896c457c75f4d7da
+    Signer:
+    - SerialNumber: 4bad88265909f29eb7827157954a75a5
+      Issuer: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=Terms of use at
+        https://www.verisign.com/rpa (c)10, CN=VeriSign Class 3 Code Signing 2010
+        CA
+      Version: 1
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: 1dd3b83f2b007f862a1d8de4a1d3303f

--- a/yaml/d6dc9b52-9918-442d-b03a-f1f614aa4cce.yaml
+++ b/yaml/d6dc9b52-9918-442d-b03a-f1f614aa4cce.yaml
@@ -1,0 +1,156 @@
+Id: d6dc9b52-9918-442d-b03a-f1f614aa4cce
+Tags:
+- ppa_x64.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-04-17'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create ppa_x64 binPath=C:\windows\temp\ppa_x64.sys type=kernel &&
+    sc.exe start ppa_x64
+  Description: ppa_x64.sys is a kernel driver by Remko Weijnen that provides physical
+    memory access via the PhysicalMemory section object. The device name PhyMem indicates
+    this is part of the PhyMem driver family, of which several variants are already
+    tracked in LOLDrivers (phymem64.sys, Phymemx64.sys, phymem_ext64.sys). The driver
+    is available in the KeServiceDescriptorTable/vulnerable-drivers repository.
+  Usecase: Elevate privileges
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/315
+- https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+Detection: []
+Acknowledgement:
+  Person: ''
+  Handle: '@rainbowdynamix, @DbgPrint'
+KnownVulnerableSamples:
+- Filename: ppa_x64.sys
+  MD5: 9851c3d7aee98aa0d712c50e9ca20eb9
+  SHA1: 513e8fc423ce2737843053852a0a672c43d2db9e
+  SHA256: 988960e31a258ea71cf93a7791ae8c91c8cefb6ad8a50cdbd1b07f73b524aa61
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: ''
+  Description: ''
+  Product: ''
+  ProductVersion: ''
+  FileVersion: ''
+  MachineType: AMD64
+  OriginalFilename: ''
+  Authentihash:
+    MD5: a7c7afe04a23793de0fe3b0d99cc20bd
+    SHA1: ce465a42be6f19ca8e99c23b78c42b6073c8b673
+    SHA256: 5721c075bfec3ce946b8a96a58551a765be294212eaf27e5ffd6b738baef57d3
+  RichPEHeaderHash:
+    MD5: 1ca376dfca09b19f2421324c4fb8a536
+    SHA1: 27b8b4fa4e7b64527ab469cda082f8d62e8ddd3b
+    SHA256: e437729618db22b65d8932ba76cec6eb1f742c8462dd3f0df1c5b34c958a5555
+  Sections:
+    .text:
+      Entropy: 5.329527770359642
+      Virtual Size: '0xfa4'
+    .rdata:
+      Entropy: 2.9166477083260434
+      Virtual Size: '0x108'
+    .data:
+      Entropy: 4.289734809136851
+      Virtual Size: '0x218'
+    .pdata:
+      Entropy: 3.158092896635105
+      Virtual Size: '0x90'
+    INIT:
+      Entropy: 4.4747991229522235
+      Virtual Size: '0x2aa'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2009-12-29 02:36:19'
+  InternalName: ''
+  Copyright: ''
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - KeWaitForSingleObject
+  - IofCallDriver
+  - IoBuildSynchronousFsdRequest
+  - KeInitializeEvent
+  - IoDeleteDevice
+  - IoCreateSymbolicLink
+  - IoCreateDevice
+  - RtlInitUnicodeString
+  - ExAllocatePool
+  - IofCompleteRequest
+  - ExFreePoolWithTag
+  - IoFreeMdl
+  - MmUnmapLockedPages
+  - MmUnmapIoSpace
+  - MmMapLockedPages
+  - MmBuildMdlForNonPagedPool
+  - IoAllocateMdl
+  - MmMapIoSpace
+  - IoDeleteSymbolicLink
+  - MmMapLockedPagesSpecifyCache
+  - IoGetDeviceObjectPointer
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=NL, ST=Noord Brabant, L='s,Hertogenbosch, O=Remko Weijnen, CN=Remko
+        Weijnen
+      ValidFrom: '2015-06-30 00:00:00'
+      ValidTo: '2018-07-06 12:00:00'
+      Signature: 7b492458bed209ba27f8cd4671fc3af69f9dee6c6c380454a9f83028a20602a759a0b4998bb91a8219bd9741b57ff30837473f495d77a1a111f12dd986f1eb0c7485c0a681553c1df12d2dbc1e18082991350515d30e838b2cd22911c5ab5582a2f9e58759fac9a3feb2d6724529e6fd9a68752a6b38a5e0d4311501eda6e82a3657f0fd031fbb58774933634d472e39513e207cfd1467852f47a56d3b4ee55f5c831cdeb4e7d50c71faff4a250c24ed4e9f0b7073ae6858110c6a297a159c3387eec686370f7e55cba1a8aaf721a26c44fc59a2ab85b98464e7829842f1c23e26fde1af8538b25d9e0eb05a01ba7eb53f92644a393e56fdaa8e24214caea373
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 0f4e02f997b62a18c0983bddeda309ab
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: a8524495a477651182b4bde5e7067ee3
+        SHA1: 421ef2e5d418e5a362fbf80a163bd98a6ff655a4
+        SHA256: 71d19c0f529996809f7cead25d8bf89b4433e5886dc824276c9bcc2cc1c3059c
+        SHA384: fb0da82f5b925a27bae035cc0d2787160a709e66a644accf576c8d2aab86ff901f95896c4fd8c1631cb2ef72e305f530
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert High Assurance
+        EV Root CA
+      ValidFrom: '2011-04-15 19:45:33'
+      ValidTo: '2021-04-15 19:55:33'
+      Signature: 208cc159ed6f9c6b2dc14a3e751d454c41501cbd80ead9b0928b062a133f53169e56396a8a63b6782479f57db8b947a10a96c2f6cbbda2669f06e1acd279090efd3cdcac020c70af3f1bec787ed4eb4b056026d973619121edb06863e09712ab6fa012edd99fd2da273cb3e456f9d1d4810f71bd427ca689dccdd5bd95a2abf193117de8ac3129a85d6670419dfc75c9d5b31a392ad08505508bac91cac493cb71a59da4946f580cfa6e20c40831b5859d7e81f9d23dca5b18856c0a86ec22091ba574344f7f28bc954aab1db698b05d09a477767eefa78e5d84f61824cbd16da6c3a19cc2107580ff9d32fde6cf433a82f7ce8fe1722a9b62b75fed951a395c2f946d48b7015f332fbbdc2d73348904420a1c8b79f9a3fa17effaa11a10dfe0b2c195eb5c0c05973b353e18884ddb6cbf24898dc8bdd89f7b393a24a0d5dfd1f34a1a97f6a66f7a1fb090a9b3ac013991d361b764f13e573803afce7ad2b590f5aedc3999d5b63c97eda6cb16c77d6b2a4c9094e64c54fd1ecd20ecce689c8758e96160beeb0ec9d5197d9fe978bd0eac2175078fa96ee08c6a2a6b9ce3e765bcbc2d3c6ddc04dc67453632af0481bca8006e614c95c55cd48e8e9f2fc13274bdbd11650307cdefb75e0257da86d41a2834af8849b2cfa5dd82566f68aa14e25954feffeaeeefea9270226081e32523c09fcc0f49b235aa58c33ac3d9169410
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 61204db4000000000027
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 8e3ffc222fbcebdbb8b23115ab259be7
+        SHA1: ee20bff28ffe13be731c294c90d6ded5aae0ec0e
+        SHA256: 59826b69bc8c28118c96323b627da59aaca0b142cc5d8bad25a8fcfd399aa821
+        SHA384: f2dab7e56a33298654924501499487f6ba72c7d9477476a186e1ed7a9be031fade0e35ac09eff5e56bbbab95ae5374e7
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+        Code Signing CA
+      ValidFrom: '2013-10-22 12:00:00'
+      ValidTo: '2028-10-22 12:00:00'
+      Signature: 6a0eff7e137c06a54bc02e8cf9536409e2ba58913050eccc9fe1d3a82f4846361829d078285f9856400f1ebabdb13b875cdc5bd8200ded1a164dd51124214bf127699013eb11a101dafdb54e795975bd382a6ac3f68e412b8aa28bd72c5151d99ca0c8e34eba6ca847d24ed1681f8c02573bb3296a8e6a202ab9f2006264bac8e900f9cca4d4ba9a35d8af2c656c167c5821de4a30d0faeb245d06c99d16b7ad4a45d325e20cf040aa5c4dac7ecd0682b976466908d832b682fee3a95834431b8e6767973f6831163638953e87f7c7c3af9d7a7719d9de93b5fd6e2bfc94f93db74c12352c30bee88d9e05709a4813f48cd6e71eac38e7a8f3ad0cb77aec67ed
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 0b7e10903c38490ffa2f679a87a1a7b9
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 7b0fbcf5c5aa55932726e9222f56efe2
+        SHA1: f09486b2b82a88a8b82aa2a12440496c8e53c452
+        SHA256: 0bf095b845b69928b5d7dfd1c42ae4f90feb8dc97f7830598c93e848877021fb
+        SHA384: f2a7644292efe9a7adc26cdeb0aa13980ea792d21845ba696684ac64d7f906839f3ec7625c3a88efefe3a451d961d317
+    Signer:
+    - SerialNumber: 0f4e02f997b62a18c0983bddeda309ab
+      Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+        Code Signing CA
+      Version: 1
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: 8e01c1742ba7ebcbb0d61dd1ca8a6e91


### PR DESCRIPTION
## Summary

Batch of 8 new vulnerable driver entries from issues #313-#324. All binaries downloaded from VT, all YAMLs enriched with the official metadata-extractor (full ImportedFunctions, Imphash, cert chains with TBS hashes).

### New Entries

**ipctype.sys** (Digital Electronics Corp) -- Closes #313
- Physical memory R/W via MmMapIoSpace
- VT: 1/77, 14 submissions

**portwell.sys** (Portwell Inc., Taiwan) -- Closes #314
- Physical memory R/W via MmMapIoSpace
- VT: 1/77, 15 submissions

**ppa_x64.sys** (Remko Weijnen) -- Closes #315
- PhyMem family driver (3 variants already tracked in LOLDrivers)
- VT: 0/77, 16 submissions

**TBT_Force_Power_Control_Access64.sys** (Wistron Corp) -- Closes #316
- Thunderbolt force power control, MmMapIoSpace
- Another Wistron driver (WiRwaDrv.sys) already tracked
- VT: 0/77, 29 submissions

**BiosToolCommonDriver.sys** (AMD Inc.) -- Closes #321
- AMD RPMC field fusing utility, 18 IOCTLs
- PhysMem R/W, Port I/O, PCI Config R/W, MSR R/W, SPI Flash Read, CPUID, VA-to-PA, contiguous alloc
- AMD Sectigo code-signed (NOT WHQL despite issue claiming dual-signed)
- Ships in Razer Blade 16 BIOS update and ASUS firmware packages
- VT: 0/77

**SparkIO.sys** (Clevo Co., Taiwan ODM) -- Closes #322
- **CVE-2022-37415** (CVSS 7.8) with [public PoC](https://gist.github.com/alfarom256/220cb75816ca2b5556e7fc8d8d2803a0)
- **WHQL signed (LoadsDespiteHVCI: TRUE)** -- loads with Memory Integrity enabled
- PhysMem R, Port I/O, PCI Config R/W, SMBus/I2C R/W
- Zero auth -- IRP_MJ_CREATE returns STATUS_SUCCESS unconditionally
- Ships on millions of Clevo-chassis laptops (XMG, Eluktronics, EVOO, Origin PC, System76, Sager)
- Not on LOLDrivers, not on MS blocklist, not on HVCI blocklist
- VT: 0/77, 20 submissions

**UDDB2B6.sys** (TechPowerUp LLC) -- Closes #323
- GPU-Z variant: Port I/O, MSR R/W, MmMapIoSpace map/read/write, PCI R/W
- Same TechPowerUp driver family as GPU-Z.sys (CVE-2019-7245) and ThrottleStop.sys (CVE-2025-7771)
- VT: 0/77, 89 submissions

**XLHA.sys** (LG Electronics Inc.) -- Closes #324
- MmMapIoSpace R/W + MSR Read
- Two other LG LHA.sys variants already tracked
- VT: 0/75


**AsrCDDrv.sys** (ASRock Incorporation) -- Closes #326
- Control register R/W (cr0/cr2/cr3/cr4/cr8), MSR R/W, physical memory R/W, contiguous memory alloc, port I/O
- VT: 0/60, 5 submissions

### Skipped/Closed

- **#312** (AdvCare.sys) -- Closed as duplicate, already merged in PR #300
- **#320** (Alternative TRIXX drivers) -- On hold with PR #292
- **#299** (GoFlyDrv) -- Sparse issue, needs more info from reporter

## Acknowledgement

- [@weezerOSINT](https://x.com/weezerOSINT) (Patrick Saif) -- #321, #322
- [@rainbowdynamix](https://x.com/rainbowdynamix) / [@DbgPrint](https://x.com/DbgPrint) -- #313, #314, #315, #316, #323, #324
