### PR TITLE
Add signeddrv.sys (WinNotify) — WHQL-signed malicious kernel driver

### DIFF
--- a/yaml/1386e02c-62c9-47b4-b6d4-3182ada18faf.yaml
+++ b/yaml/1386e02c-62c9-47b4-b6d4-3182ada18faf.yaml
@@ -1,0 +1,161 @@
+Id: 1386e02c-62c9-47b4-b6d4-3182ada18faf
+Tags:
+- signeddrv.sys
+Author: Robel Campbell
+Created: '2026-04-18'
+MitreID: T1068
+CVE: []
+Category: malicious
+Verified: 'TRUE'
+Commands:
+  Command: sc.exe create WinNotify binPath=C:\windows\temp\signeddrv.sys type=kernel
+    && sc.exe start WinNotify
+  Description: WHQL-signed malicious kernel driver attributed to Aspect Network (AspectNetwork.net),
+    a pay-to-cheat service targeting Rainbow Six Siege. Exposes an unauthenticated device
+    interface (\\.\WinNotify) with 18 IOCTLs covering kernel address disclosure, cross-process
+    memory read/write, arbitrary kernel memmove, physical memory access, and mouse injection.
+    No access control on the device object. Cert expired 2025-10-08; loads on Windows 10
+    and 11 via timestamp countersignature.
+  Usecase: Kernel memory read/write, KASLR bypass, PPL bypass, EDR/AV tampering
+  Privileges: kernel
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://www.virustotal.com/gui/file/4dc3a03a046c210a7c6cd37db8d6bd34bf3760a612232cc82acf941a9e508e0f
+Acknowledgement:
+  Person: Robel Campbell, Halcyon
+  Handle: '@x0rb3l'
+Detection: []
+KnownVulnerableSamples:
+- Filename: signeddrv.sys
+  MD5: e052ac7d39d07f6657cf049aae0c5b60
+  SHA1: 9582337fdd6165dca71c6ae1c8c0222c6a10de77
+  SHA256: 4dc3a03a046c210a7c6cd37db8d6bd34bf3760a612232cc82acf941a9e508e0f
+  Signature:
+  - Microsoft Windows Hardware Compatibility Publisher
+  Date: '2025-06-19 21:05:50'
+  Publisher: Microsoft Windows Hardware Compatibility Publisher
+  Company: ''
+  Description: ''
+  Product: ''
+  ProductVersion: ''
+  FileVersion: ''
+  MachineType: AMD64
+  OriginalFilename: ''
+  Authentihash:
+    MD5: 26e19d4941322c86f3bdba7639bcf0d2
+    SHA1: c007a5fb918f38ea0e5295077c264e0785bdd646
+    SHA256: 41856176aa3af446c206ec18261d6a12cdc98dea472df7f3244e34d383c2858a
+  InternalName: ''
+  Copyright: ''
+  Imphash: 86915b1ccd40702f0a8d238c992bf841
+  RichPEHeaderHash:
+    MD5: c4e48624c268e5eaf809dd945257764c
+    SHA1: b644e2f9ae515241d2e80b7ce7bca8ed81991921
+    SHA256: 8ece65dca648ca77acb19aac8c946f3a807a6363321623647fb9647983cc510e
+  Sections:
+    .text:
+      Entropy: 6.263727989227387
+      Virtual Size: '0x27a4'
+    .rdata:
+      Entropy: 3.9555171807670537
+      Virtual Size: '0x7a8'
+    .data:
+      Entropy: 0.14263576814887827
+      Virtual Size: '0x1110'
+    .pdata:
+      Entropy: 3.854461272258798
+      Virtual Size: '0x18c'
+    INIT:
+      Entropy: 4.902503983613164
+      Virtual Size: '0x4cc'
+    .reloc:
+      Entropy: 3.4364908905004214
+      Virtual Size: '0x24'
+  ImportedFunctions:
+  - RtlInitUnicodeString
+  - KeLowerIrql
+  - KfRaiseIrql
+  - KeAcquireSpinLockAtDpcLevel
+  - KeReleaseSpinLockFromDpcLevel
+  - ExAllocatePool
+  - ExFreePoolWithTag
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoReleaseRemoveLockEx
+  - ObfDereferenceObject
+  - PsLookupProcessByProcessId
+  - PsGetProcessSectionBaseAddress
+  - ZwQuerySystemInformation
+  - ObReferenceObjectByName
+  - IoCreateDriver
+  - __C_specific_handler
+  - IoDriverObjectType
+  - ExAllocatePoolWithTag
+  - ExAllocatePool2
+  - MmUnmapIoSpace
+  - MmMapIoSpaceEx
+  - IoGetCurrentProcess
+  - ZwClose
+  - MmGetPhysicalMemoryRanges
+  - MmCopyMemory
+  - MmGetVirtualForPhysical
+  - KeStackAttachProcess
+  - KeUnstackDetachProcess
+  - ObOpenObjectByPointer
+  - ZwAllocateVirtualMemory
+  - PsGetProcessPeb
+  - ZwQueryInformationProcess
+  - ZwProtectVirtualMemory
+  - MmCopyVirtualMemory
+  ExportedFunctions: ''
+  Imports:
+  - ntoskrnl.exe
+  PDBPath: F:\Source Codes\Aspect-Driver-Rewrite\x64\Release\Windows-Memory-Informer.pdb
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2025-06-19 21:05:50'
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2024-10-10 19:04:53'
+      ValidTo: '2025-10-08 19:04:53'
+      Signature: 3870e583035a72db64856d80e17833cd3badd24f19abf9a3d7c7485743dd875f69102820df4992d74f8fba0529be4e16f4234910064a3a1863299a29b82d3fac869915a368ec0e5d0127282221bce84db444d2e9974dc2761a2080a7bc7508d7064f32b2d97b0263d0d937527a8af95f18bcb54ec21a453ba35e55869791416a2a8813fcf95e889e65158dbb5b4cba653c989179947d286051ef6b0d56f41da479db08c6b93c44fa5c8399e126594cc53dfa756180607a1dd29559061d828b0ce2c5a462245ed0995a196ad96223b6eb1a787b4d10b5a7d4e3a130750103bc9c713fc8f32015273bb238b15aae25e4765d7ab81c5d3df82ef6a7d3c2e7a61dab024ff02df6876a86ec7198aa6e28c8e69a015129a717b1036113911f0aeefa8d05081974d026196f24bc1e4ef942599fafbd1b2c316bda73237f1822296888df2344c92b08c363976beb7020242b3069e6691f19e715e1d1a19ddc03235263c9bb7b8390145af57603105ced358f394547e3be96718835917234eb7fd7134d9fb605656717ed6b15f0583068c84c6c01abf31cc1df1fe7c4d2935590e6017cf8cc5635e1cd7054240fd0059f168e90ec1a49f24e0f050034d99e4aa6599a64d280d00ea8af57d3125caddb342a0b2c160a2f95d97e6045e69dc1c1b3fa56dfd40380ce60536a59750edf0069dc7c27f8ccc8f073b46d169b8fed1fd40ac6f00c
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 330000006e1229856f0ade6cfc00000000006e
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 3066a9830894e57ce6e47f7a6b58b84f
+        SHA1: ce441ecd2f11e400515a85d5a592da38f950f3dc
+        SHA256: 3e30a731a3b620db0971ecd743ecd312bcdf14c82b9bdc9918102bacbf70520d
+        SHA384: 68c6537d64e3a4f02a2c1d04257c13ab1def23c9c54bafc434176be50a411a75c118c9f8edc81f97b8a1db2dc1d009e3
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      ValidFrom: '2014-10-15 20:31:27'
+      ValidTo: '2029-10-15 20:41:27'
+      Signature: 96b5c33b31f27b6ba11f59dd742c3764b1bca093f9f33347e9f95df21d89f4579ee33f10a3595018053b142941b6a70e5b81a2ccbd8442c1c4bed184c2c4bd0c8c47bcbd8886fb5a0896ae2c2fdfbf9366a32b20ca848a6945273f732332936a23e9fffdd918edceffbd6b41738d579cf8b46d499805e6a335a9f07e6e86c06ba8086725afc0998cdba7064d4093188ba959e69914b912178144ac57c3ae8eae947bcb3b8edd7ab4715bba2bc3c7d085234b371277a54a2f7f1ab763b94459ed9230cce47c099212111f52f51e0291a4d7d7e58f8047ff189b7fd19c0671dcf376197790d52a0fbc6c12c4c50c2066f50e2f5093d8cafb7fe556ed09d8a753b1c72a6978dcf05fe74b20b6af63b5e1b15c804e9c7aa91d4df72846782106954d32dd6042e4b61ac4f24636de357302c1b5e55fb92b59457a9243d7c4e963dd368f76c728caa8441be8321a66cde5485c4a0a602b469206609698dcd933d721777f886dac4772daa2466eab64682bd24e98fb35cc7fec3f136d11e5db77edc1c37e1f6a4a14f8b4a721c671866770cdd819a35d1fa09b9a7cc55d4d728e74077fa74d00fcdd682412772a557527cda92c1d8e7c19ee692c9f7425338208db38cc7cc74f6c3a6bc237117872fe55596460333e2edfc42de72cd7fb0a82256fb8d70c84a5e1c4746e2a95329ea0fecdb4188fd33bad32b2b19ab86d0543fbff0d0f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 330000000d690d5d7893d076df00000000000d
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 83f69422963f11c3c340b81712eef319
+        SHA1: 0c5e5f24590b53bc291e28583acb78e5adc95601
+        SHA256: d8be9e4d9074088ef818bc6f6fb64955e90378b2754155126feebbbd969cf0ae
+        SHA384: 260ad59ba706420f68ba212931153bd89f760c464b21be55fba9d014fff322407859d4ebfb78ea9a3330f60dc9821a63
+    Signer:
+    - SerialNumber: 330000006e1229856f0ade6cfc00000000006e
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      Version: 1


### PR DESCRIPTION
## Summary

- Adds YAML entry for signeddrv.sys (SHA256: 4dc3a03a046c210a7c6cd37db8d6bd34bf3760a612232cc82acf941a9e508e0f)
- Category: malicious — probable cheat driver; purpose-built offensive kernel toolkit
- WHQL-signed via Microsoft WHCP attestation path (cert expired 2025-10-08, loads on Win10/Win11 via timestamp countersignature)
- 0/73 VT detections, not in MS blocklist, not previously listed in LOLDrivers

## Driver Capabilities

18 IOCTLs with no device access control (plain IoCreateDevice, no SDDL):
- Kernel address/KASLR bypass (PsGetProcessSectionBaseAddress, ZwQuerySystemInformation)
- Arbitrary cross-process memory read/write (MmCopyVirtualMemory, KernelMode)
- Arbitrary kernel virtual address memmove
- Physical memory read/write via page-table walk (MmMapIoSpaceEx, MmCopyMemory)
- Cross-process page protection change (ZwProtectVirtualMemory)
- Mouse input injection (MouClass ring buffer, win32kfull.sys)
- Hardcoded pool tag scanner (tag ConT, 2MB)

## Verification

Primitives dynamically confirmed on Windows 10 21H2 and Windows 11 Build 26200:
- Device opens successfully from unprivileged user-mode process
- Kernel module base disclosure confirmed
- MmCopyVirtualMemory kernel read confirmed
- PPL bypass (KTHREAD.PreviousMode) confirmed

## References

- VirusTotal: https://www.virustotal.com/gui/file/4dc3a03a046c210a7c6cd37db8d6bd34bf3760a612232cc82acf941a9e508e0f

Reported by Robel Campbell, Halcyon (@x0rb3l)