### PR TITLE
Add bsitf.sys v3.2.12.0 sample and Ghidra-verified IOCTL description

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -134,3 +134,4 @@ drivers/7ee002414a5fa3650d418ebde92e528d.bin filter=lfs diff=lfs merge=lfs -text
 drivers/c8c357be337ef4c99019aa8fe0a09a61.bin filter=lfs diff=lfs merge=lfs -text
 drivers/d2070f9c767ddb80bc8b61c15933de32.bin filter=lfs diff=lfs merge=lfs -text
 drivers/e0bbbff8573de4305a653aa83066068b.bin filter=lfs diff=lfs merge=lfs -text
+drivers/835dd954d9f306f09050fd1751e9e1d2.bin filter=lfs diff=lfs merge=lfs -text

--- a/drivers/835dd954d9f306f09050fd1751e9e1d2.bin
+++ b/drivers/835dd954d9f306f09050fd1751e9e1d2.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41f604cfc56b101cafba8d12ee7f30409457deb13684091262571f1a6c1ddd07
+size 47400

--- a/yaml/9905c737-83ad-4801-a573-8267f3aea924.yaml
+++ b/yaml/9905c737-83ad-4801-a573-8267f3aea924.yaml
@@ -9,18 +9,25 @@ Category: vulnerable driver
 Commands:
   Command: sc.exe create bsitf binPath=C:\windows\temp\bsitf.sys type=kernel && sc.exe
     start bsitf
-  Description: bsitf.sys is a vulnerable kernel driver from the KeServiceDescriptorTable/vulnerable-drivers
-    repository. The driver exposes dangerous kernel primitives to usermode.
+  Description: bsitf.sys is the ASUS BIOS Flash Driver distributed with ASUS WinFlash
+    BIOS update utility. The driver persists on disk after WinFlash completes and
+    exposes physical memory read via MmMapIoSpace (IOCTL 0x222804), physically contiguous
+    kernel memory allocation mapped to usermode via MDL (IOCTL 0x222808), arbitrary
+    I/O port write (IOCTL 0x222810) and read (IOCTL 0x222818), PCI config space read
+    with BAR mapping to usermode (IOCTL 0x222814), and BIOS flash write via MmMapIoSpace
+    (IOCTL 0x22281c). WHQL attestation signed via Microsoft Windows Third Party Component
+    CA 2014. Device SDDL grants full access to Administrators group.
   Usecase: Elevate privileges
   Privileges: kernel
   OperatingSystem: Windows 10
 Resources:
 - https://github.com/magicsword-io/LOLDrivers/issues/325
+- https://github.com/magicsword-io/LOLDrivers/pull/332
 - https://github.com/KeServiceDescriptorTable/vulnerable-drivers
 Detection: []
 Acknowledgement:
   Person: ''
-  Handle: '@rainbowdynamix, @DbgPrint'
+  Handle: '@rainbowdynamix, @DbgPrint, @AkaTorich'
 KnownVulnerableSamples:
 - Filename: bsitf.sys
   MD5: 4d59cc4dd2c94cdb78e561f3a422e899
@@ -165,6 +172,154 @@ KnownVulnerableSamples:
         SHA384: 260ad59ba706420f68ba212931153bd89f760c464b21be55fba9d014fff322407859d4ebfb78ea9a3330f60dc9821a63
     Signer:
     - SerialNumber: 3300000061c88b129c2a7f1d87000000000061
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      Version: 1
+  LoadsDespiteHVCI: 'TRUE'
+  Imphash: 28d244dd772cc099f1ccc617f46863fc
+- Filename: bsitf.sys
+  MD5: 835dd954d9f306f09050fd1751e9e1d2
+  SHA1: d80b8c9dfd317c57cbd9c3c6dfacc5b787bac06d
+  SHA256: 41f604cfc56b101cafba8d12ee7f30409457deb13684091262571f1a6c1ddd07
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: ASUSTek Computer Inc.
+  Description: ASUS BIOS Flash Driver
+  Product: ASUS BIOS Flash Driver
+  ProductVersion: 3.2.12.0
+  FileVersion: 3.2.12.0
+  MachineType: AMD64
+  OriginalFilename: bsitf.sys
+  Authentihash:
+    MD5: b9a4fb5c158dbc15ffbda5db91d0248a
+    SHA1: fbb05ee844e53f280f97012f02ac3cc2778260b6
+    SHA256: ae8d7bf855b35951bed2e5cd14daf569befe3284f0b90a8296cc89ace3845fbe
+  RichPEHeaderHash:
+    MD5: a17da6e24f9d7f5d4335a7c4f22cd502
+    SHA1: 5b43331ee12aad91ad19fcafe4106b122494c7cd
+    SHA256: 64b94de97b482bdd0ff9f96d307093e6c2f631bcd1b1089ca53f5ae789628711
+  Sections:
+    .text:
+      Entropy: 6.227603841043359
+      Virtual Size: '0x1df4'
+    .rdata:
+      Entropy: 4.39396975570802
+      Virtual Size: '0xcc8'
+    .data:
+      Entropy: 1.6274053617928048
+      Virtual Size: '0x300'
+    .pdata:
+      Entropy: 4.058314104315186
+      Virtual Size: '0x2c4'
+    PAGE:
+      Entropy: 6.24798590167577
+      Virtual Size: '0x21ec'
+    INIT:
+      Entropy: 5.192733466798069
+      Virtual Size: '0x644'
+    .rsrc:
+      Entropy: 3.5556185158699756
+      Virtual Size: '0x418'
+    .reloc:
+      Entropy: 3.660708930055735
+      Virtual Size: '0x3c'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2025-07-09 23:10:34'
+  InternalName: bsitf.sys
+  Copyright: (C) ASUSTek Computer Inc. All rights reserved.
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - RtlInitUnicodeString
+  - MmGetSystemRoutineAddress
+  - ExAllocatePoolWithTag
+  - ExFreePoolWithTag
+  - MmBuildMdlForNonPagedPool
+  - MmMapLockedPages
+  - MmUnmapLockedPages
+  - MmMapIoSpace
+  - MmUnmapIoSpace
+  - MmAllocateContiguousMemory
+  - MmFreeContiguousMemory
+  - IoAllocateMdl
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoFreeMdl
+  - IoWMIRegistrationControl
+  - IoWMIOpenBlock
+  - IoWMIQueryAllData
+  - ObfDereferenceObject
+  - MmGetPhysicalAddress
+  - ZwCreateKey
+  - ZwClose
+  - ZwSetSecurityObject
+  - IoDeviceObjectType
+  - IoCreateDevice
+  - ObOpenObjectByPointer
+  - RtlGetDaclSecurityDescriptor
+  - RtlGetGroupSecurityDescriptor
+  - RtlGetOwnerSecurityDescriptor
+  - RtlGetSaclSecurityDescriptor
+  - SeCaptureSecurityDescriptor
+  - _snwprintf
+  - RtlLengthSecurityDescriptor
+  - SeExports
+  - RtlCreateSecurityDescriptor
+  - _wcsnicmp
+  - wcschr
+  - RtlAbsoluteToSelfRelativeSD
+  - RtlAddAccessAllowedAce
+  - RtlLengthSid
+  - IoIsWdmVersionAvailable
+  - RtlSetDaclSecurityDescriptor
+  - ZwOpenKey
+  - ZwSetValueKey
+  - ZwQueryValueKey
+  - RtlFreeUnicodeString
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2024-10-10 19:04:53'
+      ValidTo: '2025-10-08 19:04:53'
+      Signature: 3870e583035a72db64856d80e17833cd3badd24f19abf9a3d7c7485743dd875f69102820df4992d74f8fba0529be4e16f4234910064a3a1863299a29b82d3fac869915a368ec0e5d0127282221bce84db444d2e9974dc2761a2080a7bc7508d7064f32b2d97b0263d0d937527a8af95f18bcb54ec21a453ba35e55869791416a2a8813fcf95e889e65158dbb5b4cba653c989179947d286051ef6b0d56f41da479db08c6b93c44fa5c8399e126594cc53dfa756180607a1dd29559061d828b0ce2c5a462245ed0995a196ad96223b6eb1a787b4d10b5a7d4e3a130750103bc9c713fc8f32015273bb238b15aae25e4765d7ab81c5d3df82ef6a7d3c2e7a61dab024ff02df6876a86ec7198aa6e28c8e69a015129a717b1036113911f0aeefa8d05081974d026196f24bc1e4ef942599fafbd1b2c316bda73237f1822296888df2344c92b08c363976beb7020242b3069e6691f19e715e1d1a19ddc03235263c9bb7b8390145af57603105ced358f394547e3be96718835917234eb7fd7134d9fb605656717ed6b15f0583068c84c6c01abf31cc1df1fe7c4d2935590e6017cf8cc5635e1cd7054240fd0059f168e90ec1a49f24e0f050034d99e4aa6599a64d280d00ea8af57d3125caddb342a0b2c160a2f95d97e6045e69dc1c1b3fa56dfd40380ce60536a59750edf0069dc7c27f8ccc8f073b46d169b8fed1fd40ac6f00c
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 330000006e1229856f0ade6cfc00000000006e
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 3066a9830894e57ce6e47f7a6b58b84f
+        SHA1: ce441ecd2f11e400515a85d5a592da38f950f3dc
+        SHA256: 3e30a731a3b620db0971ecd743ecd312bcdf14c82b9bdc9918102bacbf70520d
+        SHA384: 68c6537d64e3a4f02a2c1d04257c13ab1def23c9c54bafc434176be50a411a75c118c9f8edc81f97b8a1db2dc1d009e3
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      ValidFrom: '2014-10-15 20:31:27'
+      ValidTo: '2029-10-15 20:41:27'
+      Signature: 96b5c33b31f27b6ba11f59dd742c3764b1bca093f9f33347e9f95df21d89f4579ee33f10a3595018053b142941b6a70e5b81a2ccbd8442c1c4bed184c2c4bd0c8c47bcbd8886fb5a0896ae2c2fdfbf9366a32b20ca848a6945273f732332936a23e9fffdd918edceffbd6b41738d579cf8b46d499805e6a335a9f07e6e86c06ba8086725afc0998cdba7064d4093188ba959e69914b912178144ac57c3ae8eae947bcb3b8edd7ab4715bba2bc3c7d085234b371277a54a2f7f1ab763b94459ed9230cce47c099212111f52f51e0291a4d7d7e58f8047ff189b7fd19c0671dcf376197790d52a0fbc6c12c4c50c2066f50e2f5093d8cafb7fe556ed09d8a753b1c72a6978dcf05fe74b20b6af63b5e1b15c804e9c7aa91d4df72846782106954d32dd6042e4b61ac4f24636de357302c1b5e55fb92b59457a9243d7c4e963dd368f76c728caa8441be8321a66cde5485c4a0a602b469206609698dcd933d721777f886dac4772daa2466eab64682bd24e98fb35cc7fec3f136d11e5db77edc1c37e1f6a4a14f8b4a721c671866770cdd819a35d1fa09b9a7cc55d4d728e74077fa74d00fcdd682412772a557527cda92c1d8e7c19ee692c9f7425338208db38cc7cc74f6c3a6bc237117872fe55596460333e2edfc42de72cd7fb0a82256fb8d70c84a5e1c4746e2a95329ea0fecdb4188fd33bad32b2b19ab86d0543fbff0d0f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 330000000d690d5d7893d076df00000000000d
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 83f69422963f11c3c340b81712eef319
+        SHA1: 0c5e5f24590b53bc291e28583acb78e5adc95601
+        SHA256: d8be9e4d9074088ef818bc6f6fb64955e90378b2754155126feebbbd969cf0ae
+        SHA384: 260ad59ba706420f68ba212931153bd89f760c464b21be55fba9d014fff322407859d4ebfb78ea9a3330f60dc9821a63
+    Signer:
+    - SerialNumber: 330000006e1229856f0ade6cfc00000000006e
       Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
         Windows Third Party Component CA 2014
       Version: 1


### PR DESCRIPTION
## Summary

- Adds new ASUS BIOS Flash Driver sample (bsitf.sys v3.2.12.0) to existing entry `9905c737`
- WHQL signed (Microsoft Windows Hardware Compatibility Publisher via Third Party Component CA 2014)
- 0/73 VT detections, LoadsDespiteHVCI: TRUE
- Full PE metadata via `metadata-extractor.py` (Authentihash, Imphash, cert chains, TBS hashes, sections, imports)

## Ghidra MCP Verified IOCTLs

| IOCTL | Primitive |
|---|---|
| `0x222804` | Physical memory read via `MmMapIoSpace` |
| `0x222808` | Contiguous kernel memory alloc mapped to usermode via MDL |
| `0x22280C` | Free contiguous memory (cleanup) |
| `0x222810` | Arbitrary I/O port write |
| `0x222814` | PCI config space read + BAR mapping to usermode |
| `0x222818` | Arbitrary I/O port read |
| `0x22281C` | BIOS flash write via `MmMapIoSpace` |

## Context

PR #332 submitted this hash as a brand-new YAML, but `bsitf.sys` was already tracked from issue #325. This PR properly adds it as an additional `KnownVulnerableSamples` entry on the existing YAML and enriches the description with Ghidra-confirmed IOCTL details.

## Acknowledgement

@AkaTorich added to acknowledgement for reporting this additional sample.

Supersedes #332