### PR TITLE
Add GoFly64.sys WFP network filter driver with process kill primitive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -135,3 +135,4 @@ drivers/c8c357be337ef4c99019aa8fe0a09a61.bin filter=lfs diff=lfs merge=lfs -text
 drivers/d2070f9c767ddb80bc8b61c15933de32.bin filter=lfs diff=lfs merge=lfs -text
 drivers/e0bbbff8573de4305a653aa83066068b.bin filter=lfs diff=lfs merge=lfs -text
 drivers/835dd954d9f306f09050fd1751e9e1d2.bin filter=lfs diff=lfs merge=lfs -text
+drivers/26b2da88cb95b98b46bb985f67f76154.bin filter=lfs diff=lfs merge=lfs -text

--- a/drivers/26b2da88cb95b98b46bb985f67f76154.bin
+++ b/drivers/26b2da88cb95b98b46bb985f67f76154.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fdfdd13a0c548bb68c9d5aa8599a9265d4659da3e237fe7a42ac6ac06b9a06a
+size 132088

--- a/yaml/c2ed6a76-95ad-45fd-97d4-b55deefb3e32.yaml
+++ b/yaml/c2ed6a76-95ad-45fd-97d4-b55deefb3e32.yaml
@@ -1,0 +1,273 @@
+Id: c2ed6a76-95ad-45fd-97d4-b55deefb3e32
+Tags:
+- GoFly64.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-04-22'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create GoFly64 binPath=C:\windows\temp\GoFly64.sys type=kernel &&
+    sc.exe start GoFly64
+  Description: "GoFly64.sys is a WFP (Windows Filtering Platform) network filter driver\
+    \ signed by a Chinese software company (\u5357\u4EAC\u5072\u8A00\u777F\u7F51\u7EDC\
+    \u79D1\u6280\u6709\u9650\u516C\u53F8 / Nanjing Siyanrui Network Technology) that\
+    \ exposes 20+ IOCTLs to usermode with no authentication. The most critical primitive\
+    \ is IOCTL 0x12227A which opens any process by PID via ZwOpenProcess and terminates\
+    \ it via ZwTerminateProcess, enabling kernel-level EDR/AV process killing. Additional\
+    \ capabilities include WFP-based network traffic interception and packet injection\
+    \ (FwpsInjectNetworkSendAsync, FwpsInjectNetworkReceiveAsync), IPv4 traffic redirection\
+    \ (IOCTL 0x122262 via RtlIpv4StringToAddressA), process creation monitoring (PsSetCreateProcessNotifyRoutineEx),\
+    \ image load monitoring (PsSetLoadImageNotifyRoutine), and kernel-mode file write\
+    \ operations. VT shows 88 malicious execution parents including malware droppers\
+    \ and PowerShell scripts, confirming heavy abuse in the wild for BYOVD attacks.\
+    \ Also distributed as PandaSpeed64.sys and drv_02581.sys."
+  Usecase: Elevate privileges
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/299
+Detection: []
+Acknowledgement:
+  Person: wwwab
+  Handle: '@wwwab123'
+KnownVulnerableSamples:
+- Filename: GoFly64.sys
+  MD5: 26b2da88cb95b98b46bb985f67f76154
+  SHA1: bc61ef6d7ad9ee878028f24d50e9dcf6d7d88bf2
+  SHA256: 2fdfdd13a0c548bb68c9d5aa8599a9265d4659da3e237fe7a42ac6ac06b9a06a
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: ''
+  Description: ''
+  Product: ''
+  ProductVersion: ''
+  FileVersion: ''
+  MachineType: AMD64
+  OriginalFilename: ''
+  Authentihash:
+    MD5: f19fa1e0a31f27b0e6bb25ac4469ea8f
+    SHA1: fb3648664354ff7ea5d7fa1a4edb1321a930c2dd
+    SHA256: 4d0f2253d787ef071341406c5e93356ae960be4f4cd459d173c2b900cbcac76a
+  RichPEHeaderHash:
+    MD5: 0d259c5363f4861da2734427ba6dc26d
+    SHA1: 30035e591da87a95a8c294c5a0735cc215cbd9c7
+    SHA256: 7417eb6a24366ed7cacaf4294e50ef3da02f8834726d073f0740371eb3d79f37
+  Sections:
+    .text:
+      Entropy: 5.660149163787182
+      Virtual Size: '0x158b0'
+    .rdata:
+      Entropy: 5.522314988821053
+      Virtual Size: '0x1454'
+    .data:
+      Entropy: 0.6285701439607255
+      Virtual Size: '0x601'
+    .pdata:
+      Entropy: 4.965399521268505
+      Virtual Size: '0x1458'
+    INIT:
+      Entropy: 5.684646856442114
+      Virtual Size: '0xffe'
+    .reloc:
+      Entropy: 3.8931125438513394
+      Virtual Size: '0x44'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2019-07-25 11:41:48'
+  InternalName: ''
+  Copyright: ''
+  Imports:
+  - ntoskrnl.exe
+  - fwpkclnt.sys
+  - NDIS.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoDetachDevice
+  - IoGetDeviceObjectPointer
+  - ObfDereferenceObject
+  - ZwCreateFile
+  - ZwQueryInformationFile
+  - ZwSetInformationFile
+  - ZwReadFile
+  - ZwWriteFile
+  - strrchr
+  - RtlUnicodeStringToAnsiString
+  - RtlFreeAnsiString
+  - PsSetCreateProcessNotifyRoutineEx
+  - PsSetLoadImageNotifyRoutine
+  - PsRemoveLoadImageNotifyRoutine
+  - IoAttachDeviceToDeviceStack
+  - ObReferenceObjectByHandle
+  - KeInitializeEvent
+  - KeSetEvent
+  - KeWaitForSingleObject
+  - IoBuildDeviceIoControlRequest
+  - IoFreeIrp
+  - IoGetRelatedDeviceObject
+  - KeClearEvent
+  - MmIsAddressValid
+  - KeBugCheckEx
+  - MmBuildMdlForNonPagedPool
+  - RtlIpv4StringToAddressA
+  - ZwOpenProcess
+  - ZwTerminateProcess
+  - PsGetCurrentProcessId
+  - ZwClose
+  - PoStartNextPowerIrp
+  - PoCallDriver
+  - IofCompleteRequest
+  - IofCallDriver
+  - DbgPrint
+  - RtlInitUnicodeString
+  - strstr
+  - __C_specific_handler
+  - PsGetProcessImageFileName
+  - IoGetCurrentProcess
+  - IoFreeMdl
+  - IoAllocateMdl
+  - MmMapLockedPagesSpecifyCache
+  - MmUnlockPages
+  - MmProbeAndLockPages
+  - ExInterlockedRemoveHeadList
+  - ExFreePoolWithTag
+  - ExInterlockedInsertTailList
+  - ExAllocatePoolWithTag
+  - ExAllocatePool
+  - KeReleaseSpinLock
+  - KeAcquireSpinLockRaiseToDpc
+  - _strnicmp
+  - strlen
+  - _stricmp
+  - MmGetSystemRoutineAddress
+  - KeBugCheck
+  - PsCreateSystemThread
+  - ExUuidCreate
+  - ZwSetInformationThread
+  - RtlCompareMemory
+  - KeAcquireInStackQueuedSpinLock
+  - KeReleaseInStackQueuedSpinLock
+  - PsTerminateSystemThread
+  - FwpsQueryPacketInjectionState0
+  - FwpsInjectNetworkReceiveAsync0
+  - FwpsInjectForwardAsync0
+  - FwpsInjectNetworkSendAsync0
+  - FwpsFreeNetBufferList0
+  - FwpsAllocateNetBufferAndNetBufferList0
+  - FwpsInjectionHandleDestroy0
+  - FwpsInjectionHandleCreate0
+  - FwpmSubLayerAdd0
+  - FwpmFilterAdd0
+  - FwpmCalloutAdd0
+  - FwpmTransactionAbort0
+  - FwpmTransactionCommit0
+  - FwpmTransactionBegin0
+  - FwpmEngineClose0
+  - FwpmEngineOpen0
+  - FwpsCalloutUnregisterById0
+  - FwpsCalloutRegister1
+  - NdisAdvanceNetBufferDataStart
+  - NdisRetreatNetBufferDataStart
+  - NdisFreeNetBufferListPool
+  - NdisAllocateNetBufferListPool
+  - NdisFreeGenericObject
+  - NdisAllocateGenericObject
+  - NdisGetDataBuffer
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services CA
+        , G2
+      ValidFrom: '2012-12-21 00:00:00'
+      ValidTo: '2020-12-30 23:59:59'
+      Signature: 03099b8f79ef7f5930aaef68b5fae3091dbb4f82065d375fa6529f168dea1c9209446ef56deb587c30e8f9698d23730b126f47a9ae3911f82ab19bb01ac38eeb599600adce0c4db2d031a6085c2a7afce27a1d574ca86518e979406225966ec7c7376a8321088e41eaddd9573f1d7749872a16065ea6386a2212a35119837eb6
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 7e93ebfb7cc64e59ea4b9a77d406fc3b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: d0785ad36e427c92b19f6826ab1e8020
+        SHA1: 365b7a9c21bd9373e49052c3e7b3e4646ddd4d43
+        SHA256: c2abb7484da91a658548de089d52436175fdb760a1387d225611dc0613a1e2ff
+        SHA384: eab4fe5ef90e0de4a6aa3a27769a5e879f588df5e4785aa4104debd1f81e19ea56d33e3a16e5facf99f68b5d8e3d287b
+    - Subject: C=BE, O=GlobalSign nv,sa, CN=GlobalSign CodeSigning CA , G3
+      ValidFrom: '2016-03-16 00:00:00'
+      ValidTo: '2024-03-16 00:00:00'
+      Signature: 3b41bbc84f561182b719e3d96dc185ae9e690ec84326234b8d44c8e87d5f070e5341d563444a890bb874ac7db578792f8426e2d7f7bad1ae2dfd69cffa7c64dc24162a4adac097a9bbd5dd88e7a1929a0aa5f6f7bace85d6e4e3d455deeddc3e211f1bc87788cffc65fb05b48f12a630d30d66982f6c2e6f85187c8ff5f6fbb1ab10e183270885b07321ba5d2cba8330b73984dd5db67fd28bb455534c42a2bc4a6c78395b631ca37827bfbe34836b6d7b1e60fbc29b0d88ac8c72546bdc3b88ba81525e689783b8ce7fa3cdf9ea2f2676facd0b06ac4344497bf64c9442b2abcfd542d51942696e618664c7b37d078bdbe5767b6e5f65a91690a2cee4ae6492
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 47c30ffefc22bb280f96fea75251
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 729cf4baceff4ef7aa199ad4f4ebed3d
+        SHA1: f478f0e790d5c8ec6056a3ab2567404a991d2837
+        SHA256: c3c88c2a500cb5a97abca837193a5bd382f6eb3aeb0008edbce65ea2a3dbfd5c
+        SHA384: e62bbb1ba1ad3df59f2c7265df5576af6b5d4a7473b74985a9d956975fdfc517ffbdd2172b0e3ea36befcb6a9026c872
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services Signer
+        , G4
+      ValidFrom: '2012-10-18 00:00:00'
+      ValidTo: '2020-12-29 23:59:59'
+      Signature: 783bb4912a004cf08f62303778a38427076f18b2de25dca0d49403aa864e259f9a40031cddcee379cb216806dab632b46dbff42c266333e449646d0de6c3670ef705a4356c7c8916c6e9b2dfb2e9dd20c6710fcd9574dcb65cdebd371f4378e678b5cd280420a3aaf14bc48829910e80d111fcdd5c766e4f5e0e4546416e0db0ea389ab13ada097110fc1c79b4807bac69f4fd9cb60c162bf17f5b093d9b5be216ca13816d002e380da8298f2ce1b2f45aa901af159c2c2f491bdb22bbc3fe789451c386b182885df03db451a179332b2e7bb9dc20091371eb6a195bcfe8a530572c89493fb9cf7fc9bf3e226863539abd6974acc51d3c7f92e0c3bc1cd80475
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0ecff438c8febf356e04d86a981b1a50
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: e9d38360b914c8863f6cba3ee58764d3
+        SHA1: 4cba8eae47b6bf76f20b3504b98b8f062694a89b
+        SHA256: 88901d86a4cc1f1bb193d08e1fb63d27452e63f83e228c657ab1a92e4ade3976
+        SHA384: e9f2a75334a9e336c5a4712eadee88d0374b0fdc273262f4e65c9040ad2793067cc076696db5279a478773485e285652
+    - Subject: C=BE, O=GlobalSign nv,sa, OU=Root CA, CN=GlobalSign Root CA
+      ValidFrom: '2011-04-15 19:55:08'
+      ValidTo: '2021-04-15 20:05:08'
+      Signature: 5ff8d065746a81c6a6ca5b03b6914ae84bbdef2ba142f0efb4a5adcd3389ec0b9585ac62501108aa58d25aa08310e5a6337af25af2c5fe787cf09c83df190ad97396002dd62ccde914d41d9de83f3c1a76f7904efb01350a6c9313a0c356eb67a0e4d17a96dec267f190f80a7bf5321b94ec5f751f8d1b34da6c58a7cb2d279e2226b7c9aa30cc0777b836e38201b5393ccc8dd9a75f7f23b3877fdb5798918bd7ce2520e39d644fdd87f72b68490318e0a5df7c5f68644d36838d4781f2e9e0a869abfa7b163c05a449ea8830190a6c73055178dfd41ddd3ad47f2de44e54be83431e7a7433b4a4ebd77073bc2a02988966eef6bc8f749378e329025a5a43e258ce7ccf9acad236893be25fda26054ec8d4e72c910e1797c5beee8b13112323294ffa83d050f6bafad53db3173df4ff034aa325dce67561d1fa35086bd62744d068b78d45e0eb852cc8a15d614474160e5958aed2b5eea5bcd6d7076ab62978fd976767dd8d4f17944fd2ed0caf972437c3a29c81da6be143b6577b4cecbf791319e79fe844e94781b75e701e91f83dd17b27f50b7056434805dda92fab86101d0b12e31ad04c6e75ded645b30b748887935c564a41029af7aeb799d8b67f88fa11f2457cf4d71b91c01cf1a0fbd4080a411a142acef4eb34486e66879ed54b7a397fbb0e3d3861cf735706e412066bd96b5308cd7018c22d4f974691bca9f0
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 6129152700000000002a
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 0bb058d116f02817737920f112d9fd3b
+        SHA1: fd116235171a4feafedee586b7a59185fb5fd7e6
+        SHA256: f970426cc46d2ae0fc5f899fa19dbe76e05f07e525654c60c3c9399492c291f4
+        SHA384: c0df876be008c26ca407fe904e6f5e7ccded17f9c16830ce9f8022309c9e64c97f494810f152811ae43e223b82ad7cc6
+    - Subject: "C=CN, ST=\u6C5F\u82CF\u7701, L=\u5357\u4EAC\u5E02, O=\u5357\u4EAC\u5072\
+        \u8A00\u777F\u7F51\u7EDC\u79D1\u6280\u6709\u9650\u516C\u53F8, CN=\u5357\u4EAC\
+        \u5072\u8A00\u777F\u7F51\u7EDC\u79D1\u6280\u6709\u9650\u516C\u53F8, emailAddress=sale@wandouip.com"
+      ValidFrom: '2019-02-13 07:30:14'
+      ValidTo: '2021-05-05 04:29:02'
+      Signature: 387d9d06cb3ac2e121d455ba62686d463bc706bad343dfd227e6c3497dbfa8e8ca8161bc52c133dd21875d197b06d0b8b6f244668d8866810efef2f3b708e855e21f8d8ac4278a7c1f4a33d0d03e3005926906a94a6b9b96179d31ad07b412f43b274ca4b898637ac24c6db69126e5fa945465a433f9794bc55d80b83963e59c5697d27a8188d827f99cac9713f81ace4207fbe4e7df35d2e25363c1ff79dfc312b5d702b01a6ccebfec73357e938f2e0d31f1a9b37083a0f22777256e0dc0ab547b6fccc4245c10f0a3c77be53e2b267200a1b9e568bf9bfc9b7b88c09369357897f91cab801e95c5dd7777aaa0f655b59a48cd21c415f10ae3f45e03714d44
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 75ec63fc23b0d4a38d5abd1b
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 208e3de30fd127319cb70a271429a509
+        SHA1: dc9620e6f0f4728e3679477cfde6193f7ffb0c4b
+        SHA256: df6849f4f3e629ebfeab0fc2ebc6bb6ea67b5aa7a7092fe76e53a678192b330c
+        SHA384: a9afa66ca9c969c9c4e73d8396c263b2eb570fa6dde1a27fa4666c40a80a0b8b8f174ba94075fb532d16545501e348a1
+    Signer:
+    - SerialNumber: 75ec63fc23b0d4a38d5abd1b
+      Issuer: C=BE, O=GlobalSign nv,sa, CN=GlobalSign CodeSigning CA , G3
+      Version: 1
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: 73466ab4aca361de1e85e223aa420e3a


### PR DESCRIPTION
## Summary

- **GoFly64.sys** — WFP network filter driver signed by Nanjing Siyanrui Network Technology (南京偲言睿网络科技有限公司) via GlobalSign CodeSigning CA
- Also distributed as **PandaSpeed64.sys** and **drv_02581.sys**
- 4/73 VT detections, 88 malicious execution parents (malware droppers, PowerShell scripts) — heavily abused for BYOVD attacks
- Vendor code-signed (GlobalSign, not WHQL), `LoadsDespiteHVCI: FALSE`
- Full PE metadata extracted via `metadata-extractor.py`

## Verified IOCTL Primitives

| IOCTL | Primitive |
|---|---|
| `0x12227A` | **Process kill** — `ZwOpenProcess` + `ZwTerminateProcess` by PID (EDR/AV killer) |
| `0x122262` | IPv4 traffic redirection via `RtlIpv4StringToAddressA` |
| `0x122222` | WFP network filter rule injection |
| `0x122226` | WFP filter rule configuration |
| `0x12225A` | Kernel-mode file write operations |
| `0x12225E` | Module/driver loading |

Additional capabilities: WFP packet interception and injection (`FwpsInjectNetworkSendAsync`, `FwpsInjectNetworkReceiveAsync`), process creation monitoring (`PsSetCreateProcessNotifyRoutineEx`), image load monitoring (`PsSetLoadImageNotifyRoutine`).

## Acknowledgement

Reported by [@wwwab123](https://github.com/wwwab123) with binary sample attached to the issue.

Closes #299