### PR TITLE
Point MagicSword links to root

### DIFF
--- a/loldrivers.io/config/_default/menus/menu.en.toml
+++ b/loldrivers.io/config/_default/menus/menu.en.toml
@@ -12,4 +12,4 @@
 [[main]]
   name = "Free Prevention"
   weight = 6
-  url = "https://www.magicsword.io/plan?utm_source=loldrivers&utm_medium=website&utm_campaign=free_prevention&utm_content=nav_menu"
+  url = "https://www.magicsword.io/?utm_source=loldrivers&utm_medium=website&utm_campaign=free_prevention&utm_content=nav_menu"

--- a/loldrivers.io/content/_index.md
+++ b/loldrivers.io/content/_index.md
@@ -73,7 +73,7 @@ You can also get the malicious driver list via **API** using [CSV](api/drivers.c
   </div>
   <h3>Stop BYOVD attacks.<br><em>Free for up to 100 endpoints.</em></h3>
   <p>Turn this driver list into enforceable block policies with MagicSword, threat-driven application control.</p>
-  <a class="ms-cta-btn" href="https://www.magicsword.io/plan?utm_source=loldrivers&utm_medium=website&utm_campaign=free_prevention&utm_content=homepage_cta">
+  <a class="ms-cta-btn" href="https://www.magicsword.io/?utm_source=loldrivers&utm_medium=website&utm_campaign=free_prevention&utm_content=homepage_cta">
     Start Blocking for Free
     <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
   </a>

--- a/loldrivers.io/layouts/shortcodes/blockbanner.html
+++ b/loldrivers.io/layouts/shortcodes/blockbanner.html
@@ -28,7 +28,7 @@
   </div>
   <h4>Block <strong>{{ $name }}</strong> across your endpoints</h4>
   <p>Add this driver to your block policy in minutes with MagicSword, threat-driven application control. Free for up to 100 endpoints.</p>
-  <a class="ms-bb-btn" href="https://www.magicsword.io/plan?utm_source=loldrivers&utm_medium=website&utm_campaign=free_prevention&utm_content=driver_block_banner" target="_blank" rel="noopener">
+  <a class="ms-bb-btn" href="https://www.magicsword.io/?utm_source=loldrivers&utm_medium=website&utm_campaign=free_prevention&utm_content=driver_block_banner" target="_blank" rel="noopener">
     Start Blocking for Free
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
   </a>


### PR DESCRIPTION
## Summary

Updates the LOLDrivers MagicSword CTA links to send users to the MagicSword root domain instead of `/plan`, while preserving the existing UTM campaign parameters.

Changed links in:
- homepage CTA
- driver block banner shortcode
- Free Prevention nav menu item

## Validation

- `rg "magicsword\.io/plan" .` returns no matches
- `git diff --check` passes
- `hugo --minify` was attempted, but this checkout fails before rendering because the existing `block` shortcode template is missing (`content/_index.md:12:1`).
