### PR TITLE
Add Lenovo BootRepair.sys (PhantomKiller exploit)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -140,3 +140,4 @@ drivers/6d46f925df569b488e9b63778ab0d91e.bin filter=lfs diff=lfs merge=lfs -text
 drivers/ff6d5b0c4d9b2fd12d60656fd031c184.bin filter=lfs diff=lfs merge=lfs -text
 drivers/66ab7f46db42bf52db06840ec3b4deb3.bin filter=lfs diff=lfs merge=lfs -text
 drivers/26b2da88cb95b98b46bb985f67f76154.bin filter=lfs diff=lfs merge=lfs -text
+drivers/82699276b0f59a2304120a6baaf64a6b.bin filter=lfs diff=lfs merge=lfs -text

--- a/drivers/82699276b0f59a2304120a6baaf64a6b.bin
+++ b/drivers/82699276b0f59a2304120a6baaf64a6b.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ab36c116767eaae53a466fbc2dae7cfd608ed77721f65e83312037fbd57c946
+size 30320

--- a/yaml/7cc0a40d-7902-4400-9fc4-0070053991cb.yaml
+++ b/yaml/7cc0a40d-7902-4400-9fc4-0070053991cb.yaml
@@ -1,0 +1,207 @@
+Id: 7cc0a40d-7902-4400-9fc4-0070053991cb
+Tags:
+- bootrepair.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-05-19'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create BootRepair binPath=C:\windows\temp\BootRepair.sys type=kernel
+    && sc.exe start BootRepair
+  Description: BootRepair.sys is a legitimate Lenovo kernel driver shipped with Lenovo
+    PC Manager (signed by LENOVO via Symantec Class 3 SHA256 Code Signing CA, compile
+    date 2018-01-03). The driver creates a device object at \\.\BootRepair with no
+    DACL restrictions, so any local user can open a handle. The IRP_MJ_DEVICE_CONTROL
+    dispatcher accepts IOCTL 0x222014 with a 4-byte DWORD input (target PID) and chains
+    PsLookupProcessByProcessId -> ObOpenObjectByPointer -> ZwTerminateProcess against
+    the supplied PID, with no caller validation. Because the kernel-mode caller bypasses
+    user-mode access checks, the primitive can terminate any process on the system
+    including PPL-protected AV/EDR processes. The driver also imports ZwCreateKey
+    / ZwSetValueKey / ZwQueryValueKey (registry access for the boot-repair feature),
+    PsCreateSystemThread / IoRegisterShutdownNotification, and KeBugCheckEx.
+  Usecase: Terminate arbitrary processes from kernel mode (including PPL-protected
+    AV/EDR processes) via an unauthenticated IOCTL handler.
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://medium.com/@jehadbudagga/phantom-killer-reverse-engineering-and-weaponizing-a-lenovo-driver-to-terminate-edr-processes-9191cd06374f
+- https://github.com/redteamfortress/PhantomKiller
+Detection: []
+Acknowledgement:
+  Person: Jehad Abudagga
+  Handle: '@j3h4ck'
+KnownVulnerableSamples:
+- Filename: BootRepair.sys
+  MD5: 82699276b0f59a2304120a6baaf64a6b
+  SHA1: 87903559afa09a0dfe251598c14e58124bddde1d
+  SHA256: 5ab36c116767eaae53a466fbc2dae7cfd608ed77721f65e83312037fbd57c946
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: e1e5f6628200ed317625c64c1d1819aa
+  Authentihash:
+    MD5: b1b3128961d3cb0c2fac16215719e8f6
+    SHA1: f8b69357a559dd51090026ce7d7999eb993ecc6c
+    SHA256: 498adc5cd35a5bab1fb935dc93158b297b0882b80206bbb74d003df0f1c8c037
+  RichPEHeaderHash:
+    MD5: dfd08a6b37c0d5175b05304630257dcc
+    SHA1: 032a883d2dd938e6db24e7823cb699af9c535670
+    SHA256: f722f00ec078f6c3123a6cf695c3fa047e21686599f2818b2352e238aa43c649
+  Sections:
+    .text:
+      Entropy: 5.989688010531069
+      Virtual Size: '0x1b0d'
+    .rdata:
+      Entropy: 3.953370505905165
+      Virtual Size: '0x5c8'
+    .data:
+      Entropy: 2.4636528676691576
+      Virtual Size: '0xf1'
+    .pdata:
+      Entropy: 3.643658336143637
+      Virtual Size: '0x138'
+    .gfids:
+      Entropy: 0.8112781244591328
+      Virtual Size: '0x4'
+    INIT:
+      Entropy: 5.614216948545716
+      Virtual Size: '0x5a8'
+    .rsrc:
+      Entropy: 3.2778749886467695
+      Virtual Size: '0x360'
+    .reloc:
+      Entropy: 2.903107168362811
+      Virtual Size: '0x18'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2018-01-03 00:15:40'
+  Description: BootRepair
+  Company: LENOVO
+  InternalName: BootRepair.sys
+  OriginalFilename: BootRepair.sys
+  FileVersion: 2.5.30.11281
+  Product: BootRepair
+  ProductVersion: 2.5.30.11281
+  Copyright: LENOVO Corporation. All rights reserved.
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - RtlInitUnicodeString
+  - KeDelayExecutionThread
+  - ExFreePoolWithTag
+  - PsCreateSystemThread
+  - PsTerminateSystemThread
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoRegisterShutdownNotification
+  - ObfDereferenceObject
+  - ZwClose
+  - ZwTerminateProcess
+  - PsLookupProcessByProcessId
+  - ObOpenObjectByPointer
+  - __C_specific_handler
+  - RtlCompareMemory
+  - ExAllocatePool
+  - ZwCreateKey
+  - ZwOpenKey
+  - ZwFlushKey
+  - ZwQueryValueKey
+  - ZwSetValueKey
+  - KeBugCheckEx
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services CA
+        , G2
+      ValidFrom: '2012-12-21 00:00:00'
+      ValidTo: '2020-12-30 23:59:59'
+      Signature: 03099b8f79ef7f5930aaef68b5fae3091dbb4f82065d375fa6529f168dea1c9209446ef56deb587c30e8f9698d23730b126f47a9ae3911f82ab19bb01ac38eeb599600adce0c4db2d031a6085c2a7afce27a1d574ca86518e979406225966ec7c7376a8321088e41eaddd9573f1d7749872a16065ea6386a2212a35119837eb6
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 7e93ebfb7cc64e59ea4b9a77d406fc3b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: d0785ad36e427c92b19f6826ab1e8020
+        SHA1: 365b7a9c21bd9373e49052c3e7b3e4646ddd4d43
+        SHA256: c2abb7484da91a658548de089d52436175fdb760a1387d225611dc0613a1e2ff
+        SHA384: eab4fe5ef90e0de4a6aa3a27769a5e879f588df5e4785aa4104debd1f81e19ea56d33e3a16e5facf99f68b5d8e3d287b
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services Signer
+        , G4
+      ValidFrom: '2012-10-18 00:00:00'
+      ValidTo: '2020-12-29 23:59:59'
+      Signature: 783bb4912a004cf08f62303778a38427076f18b2de25dca0d49403aa864e259f9a40031cddcee379cb216806dab632b46dbff42c266333e449646d0de6c3670ef705a4356c7c8916c6e9b2dfb2e9dd20c6710fcd9574dcb65cdebd371f4378e678b5cd280420a3aaf14bc48829910e80d111fcdd5c766e4f5e0e4546416e0db0ea389ab13ada097110fc1c79b4807bac69f4fd9cb60c162bf17f5b093d9b5be216ca13816d002e380da8298f2ce1b2f45aa901af159c2c2f491bdb22bbc3fe789451c386b182885df03db451a179332b2e7bb9dc20091371eb6a195bcfe8a530572c89493fb9cf7fc9bf3e226863539abd6974acc51d3c7f92e0c3bc1cd80475
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0ecff438c8febf356e04d86a981b1a50
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: e9d38360b914c8863f6cba3ee58764d3
+        SHA1: 4cba8eae47b6bf76f20b3504b98b8f062694a89b
+        SHA256: 88901d86a4cc1f1bb193d08e1fb63d27452e63f83e228c657ab1a92e4ade3976
+        SHA384: e9f2a75334a9e336c5a4712eadee88d0374b0fdc273262f4e65c9040ad2793067cc076696db5279a478773485e285652
+    - Subject: C=US, ST=North Carolina, L=Morrisville, O=LENOVO, CN=LENOVO
+      ValidFrom: '2015-01-13 00:00:00'
+      ValidTo: '2018-01-12 23:59:59'
+      Signature: 75b8f6ae868125e42d59ea82fc36669b33ee6aabdd339bf4e5cce0a3a7190594a5f6274ff1da25b1cea47e3a2e580ec0177d855c8e23938de92d0949eea0729e3d359d9aa18bf222aabe93ac6caf443156a1f33c3d203a8b705815ca860d3e08ccb122e2980235cdc6f9f306a7809b245b6681af15d3dea9b1a99be92f4be31e313772f209973190a3f5fd8a8433639b68188ca01511eca876bb3f2eaad8b00301e3e89ed3df69039fbe80133cf766780c4444875e18d5876ffec2ec02d3ab90d786951827a13925cc556a6871e6e794ff73a5731e329a6cd1dbfedf16b77a6c7af4149cde0aab1c87ae4d68429f15df0cc934dba6e2d038f83739c3db948117
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 5716180db7d4989dc4a17083dcfa7567
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 5404bc6047806350940e277abad5f76f
+        SHA1: 51854ded636b6414d7f58aab51abe8746d52c825
+        SHA256: e95925f96c72f047e428169c5770bdbef983d7e7935515a7dfcc13d4033bf7fe
+        SHA384: 1988aaf8c4acc9db4a569df59db27a80b804815e21b94e127ead5dcf9e95db73aa48d7a81cef97d3bef7d4620f78150c
+    - Subject: C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec
+        Class 3 SHA256 Code Signing CA
+      ValidFrom: '2013-12-10 00:00:00'
+      ValidTo: '2023-12-09 23:59:59'
+      Signature: 13851a1e69a937f7a0bda4af7e1d6153fe9d8c5e0ca6751e781723ddfdec1a035539fb7195c7655aa78e30d2445a61db706fda2105c22e73ba49f1d193fe5dc9cd5e03e0899e3f741ed7f7388ba9d6cfbb352f3358a89256d1c84d3b82e6798416fc28b0b147f31da23eee87d9a67fa456a53fad842e29de7cbca8aaa33d0401eaba93a20e502229174c87e43a115fd6a425899b056b2fb4c9014c277b0bac190522a060153fdac9fb4d4c8ffb726777fd2794c7ba350e8849fe8dfd28af4a12bd0db39705de440c15fa362b03dcc15001f1a1115d14e5e2bd274b54be2b845e0fa6c374050aef97c38922b11f77f3bdcd43d4f14ca93fb58b84af64f2d01421
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 3d78d7f9764960b2617df4f01eca862a
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 1f056ff7d5f874984dc605402b7cb042
+        SHA1: bdb348353a2203deb4b767914fa1bd7248dd728b
+        SHA256: a08e79c386083d875014c409c13d144e0a24386132980df11ff59737c8489eb1
+        SHA384: fa2729064b49e0d77540c1ee95d5f74acaf8eaf55197851a3a40383335f8113e51190bc48b552196edf8ac5cf0c89278
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=(c) 2006 VeriSign,
+        Inc. , For authorized use only, CN=VeriSign Class 3 Public Primary Certification
+        Authority , G5
+      ValidFrom: '2011-02-22 19:25:17'
+      ValidTo: '2021-02-22 19:35:17'
+      Signature: 812a82168c34672be503eb347b8ca2a3508af45586f11e8c8eae7dee0319ce72951848ad6211fd20fd3f4706015ae2e06f8c152c4e3c6a506c0b36a3cf7a0d9c42bc5cf819d560e369e6e22341678c6883762b8f93a32ab57fbe59fba9c9b2268fcaa2f3821b983e919527978661ee5b5d076bcd86a8e26580a8e215e2b2be23056aba0cf347934daca48c077939c061123a050d89a3ec9f578984fbecca7c47661491d8b60f195de6b84aacbc47c8714396e63220a5dc7786fd3ce38b71db7b9b03fcb71d3264eb1652a043a3fa2ead59924e7cc7f233424838513a7c38c71b242228401e1a461f17db18f7f027356cb863d9cdb9645d2ba55eefc629b4f2c7f821cc04ba57fd01b6abc667f9e7d3997ff4f522fa72f5fdff3a1c423aa1f98018a5ee8d1cd4669e4501feaaeefffb178f30f7f1cd29c59decb5d549003d85b8cbbb933a276a49c030ae66c9f723283276f9a48356c848ce5a96aaa0cc0cc47fb48e97af6de35427c39f86c0d6e473089705dbd054625e0348c2d59f7fa7668cd09db04fd4d3985f4b7ac97fb22952d01280c70f54b61e67cdc6a06c110384d34875e72afeb03b6e0a3aa66b769905a3f177686133144706fc537f52bd92145c4a246a678caf8d90aad0f679211b93267cc3ce1ebd883892ae45c6196a4950b305f8ae59378a6a250394b1598150e8ba8380b72335f476b9671d5918ad208d94
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 611993e400000000001c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 78a717e082dcc1cda3458d917e677d14
+        SHA1: 4a872e0e51f9b304469cd1dedb496ee9b8b983a4
+        SHA256: 317fa1d234ebc49040ebc5e8746f8997471496051b185a91bdd9dfbb23fab5f8
+        SHA384: b71052da4eb9157c8c1a5d7f55df19d69b9128598b72fcca608e5b7cc7d64c43c5504b9c86355a6dc22ee40c88cc385c
+    Signer:
+    - SerialNumber: 5716180db7d4989dc4a17083dcfa7567
+      Issuer: C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec
+        Class 3 SHA256 Code Signing CA
+      Version: 1


### PR DESCRIPTION
## Summary

Closes #348 

Adds the legitimate Lenovo `BootRepair.sys` driver (signed by LENOVO via Symantec Class 3 SHA256 Code Signing CA, compile date **2018-01-03**) which exposes an unauthenticated arbitrary process-termination primitive. Surfaced by [Jehad Abudagga (@j3h4ck)](https://github.com/redteamfortress/PhantomKiller) in his *Phantom Killer* writeup; the PhantomKiller GitHub repo ships this exact binary renamed to `PhantomKiller.sys` as the PoC.

## Vulnerability

The driver creates a device object at `\\.\BootRepair` with **no DACL restrictions** and an `IRP_MJ_DEVICE_CONTROL` dispatcher that accepts IOCTL `0x222014` with a 4-byte DWORD (target PID), chaining:

```
PsLookupProcessByProcessId -> ObOpenObjectByPointer -> ZwTerminateProcess
```

against the supplied PID with no caller validation. Because the kernel-mode caller bypasses user-mode access checks, the primitive can terminate any process on the system — **including PPL-protected AV/EDR processes** — from a low-privileged context once the driver is loaded.

## Driver details

| field | value |
|---|---|
| Filename | `BootRepair.sys` |
| Product | BootRepair (Lenovo PC Manager component) |
| SHA256 | `5ab36c116767eaae53a466fbc2dae7cfd608ed77721f65e83312037fbd57c946` |
| MD5 | `82699276b0f59a2304120a6baaf64a6b` |
| Imphash | `e1e5f6628200ed317625c64c1d1819aa` |
| Authentihash (SHA256) | `498adc5cd35a5bab1fb935dc93158b297b0882b80206bbb74d003df0f1c8c037` |
| Compile date | 2018-01-03 00:15:40 UTC |
| Signer chain | `LENOVO` → `Symantec Class 3 SHA256 Code Signing CA` → `VeriSign Class 3 PPCA G5` |
| Leaf cert valid | 2015-01-13 → 2018-01-12 (expired; Symantec timestamp counter-sig keeps signature valid) |
| VT detection | 0/71 (legitimate vendor-signed driver, 8 unique submitter sources since 2018-06-22) |
| LoadsDespiteHVCI | **FALSE** (vendor code-signed; HVCI will block via publisher policy) |
| Category | vulnerable driver |
| Architecture | x64 (PE32+ native) |

## Imports of interest

`PsLookupProcessByProcessId`, `ObOpenObjectByPointer`, `ZwTerminateProcess` (the kill chain), plus registry primitives `ZwCreateKey`/`ZwOpenKey`/`ZwSetValueKey`/`ZwQueryValueKey` (the boot-repair feature), `PsCreateSystemThread` / `IoRegisterShutdownNotification`, and `KeBugCheckEx`.

## Test plan

- [x] `python3 bin/metadata-extractor.py` ran cleanly against the single new driver; only the new yaml was enriched (no collateral changes to other yaml entries)
- [x] Cert chain TBS hashes captured (LENOVO leaf, Symantec G2/G4 timestamping CA, Symantec Class 3 SHA256 CSCA, VeriSign G5 root)
- [x] LoadsDespiteHVCI correctly set to `FALSE` per the vendor-signed chain (not WHQL — no Microsoft Windows Hardware Compatibility Publisher in the chain)
- [x] Binary tracked via Git LFS at `drivers/82699276b0f59a2304120a6baaf64a6b.bin`

## Acknowledgement

[Jehad Abudagga (@j3h4ck)](https://twitter.com/j3h4ck) — [Phantom Killer — Reverse Engineering and Weaponizing a Lenovo Driver to Terminate EDR Processes](https://medium.com/@jehadbudagga/phantom-killer-reverse-engineering-and-weaponizing-a-lenovo-driver-to-terminate-edr-processes-9191cd06374f) — and the [PhantomKiller PoC](https://github.com/redteamfortress/PhantomKiller).