### PR TITLE
[codex] Add LOLRMM backlinks

### DIFF
--- a/loldrivers.io/content/_index.md
+++ b/loldrivers.io/content/_index.md
@@ -21,7 +21,7 @@ Feel free to open a [PR](https://github.com/magicsword-io/LOLDrivers/pulls), rai
 {{< /tip >}}
 
 {{< tip >}}
-You can also get the malicious driver list via **API** using [CSV](api/drivers.csv) or [JSON](api/drivers.json). Sysmon users check out the pre-built [config](https://github.com/magicsword-io/LOLDrivers/blob/main/detections/sysmon/sysmon_config_vulnerable_hashes.xml). There is a [Sigma rule](https://github.com/magicsword-io/LOLDrivers/blob/main/detections/sigma/driver_load_win_vuln_drivers.yml) for SIEMs. If you've found this project valuable, you'll absolutely love our sister projects, [LOLBAS](https://lolbas-project.github.io/#) and [GTFOBins](https://gtfobins.github.io), check them out!
+You can also get the malicious driver list via **API** using [CSV](api/drivers.csv) or [JSON](api/drivers.json). Sysmon users check out the pre-built [config](https://github.com/magicsword-io/LOLDrivers/blob/main/detections/sysmon/sysmon_config_vulnerable_hashes.xml). There is a [Sigma rule](https://github.com/magicsword-io/LOLDrivers/blob/main/detections/sigma/driver_load_win_vuln_drivers.yml) for SIEMs. If you've found this project valuable, you'll absolutely love our sister projects, [LOLBAS](https://lolbas-project.github.io/#), [GTFOBins](https://gtfobins.github.io), and [LOLRMM](https://lolrmm.io/), check them out!
 {{< /tip >}}
 
 {{< /column >}}

--- a/loldrivers.io/content/about/_index.md
+++ b/loldrivers.io/content/about/_index.md
@@ -12,6 +12,8 @@ Living Off The Land Drivers is a community-driven project that provides a curate
 
 Living Off The Land Drivers is an open-source project that welcomes contributions from the security community. By sharing knowledge and expertise, we can help each other stay informed and better defend against emerging threats. Whether you're a researcher, incident responder, or system administrator, we hope that Living Off The Land Drivers will be a valuable resource in your fight against cyber attacks.
 
+For related Living Off The Land research, visit [LOLRMM](https://lolrmm.io/), which tracks remote monitoring and management tooling abused by adversaries.
+
 {{< button "/" "Drivers" >}}
 {{< /column >}}
 
@@ -32,4 +34,3 @@ Currently, Nasreddine Bencherchali is a Threat Researcher at Nextron Systems, wi
 Honorable mentions, [Florian](https://twitter.com/cyb3rops)  and [Patrick](https://twitter.com/bareiss_patrick) for all their help getting the idea and the project off the ground!
 {{< /column >}}
 {{< /block >}}
-


### PR DESCRIPTION
## Summary

Adds backlinks from LOLDrivers to LOLRMM in the public site content:

- Adds LOLRMM to the landing page sister-project links.
- Adds a LOLRMM reference to the About page copy.

## Impact

Visitors can discover LOLRMM from both the homepage and About page without changing the site layout or navigation.

## Validation

- `git diff --check`
- `hugo --destination /tmp/loldrivers-hugo-build` after initializing the `loldrivers.io/themes/compose` submodule locally. The build passed with the existing Hugo `data.GetCSV` deprecation warning.
