### PR TITLE
[codex] Add 360Hvm64 and NGStar driver binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -159,3 +159,5 @@ drivers/b7d34956622d0adc9242fb3f17944043.bin filter=lfs diff=lfs merge=lfs -text
 drivers/ed96f1a99a3693d40cc302d5ae0840b8.bin filter=lfs diff=lfs merge=lfs -text
 drivers/82699276b0f59a2304120a6baaf64a6b.bin filter=lfs diff=lfs merge=lfs -text
 drivers/b316425d6f200244a25bd7b9998d9c43.bin filter=lfs diff=lfs merge=lfs -text
+drivers/0b5c4cd701956b332e60ae85b8c3a7ea.bin filter=lfs diff=lfs merge=lfs -text
+drivers/297a9b187c6897749bc7bb92d02e95c0.bin filter=lfs diff=lfs merge=lfs -text

--- a/drivers/0b5c4cd701956b332e60ae85b8c3a7ea.bin
+++ b/drivers/0b5c4cd701956b332e60ae85b8c3a7ea.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f89d5d95b8a59e6d5e50a49217f83d080e4eaf4bb77b80d8f38cd915640ba124
+size 460056

--- a/drivers/297a9b187c6897749bc7bb92d02e95c0.bin
+++ b/drivers/297a9b187c6897749bc7bb92d02e95c0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4542b20be7adceb61fa5f538fed8c395951e775dbd7c4a2f7c6aee477c4d924e
+size 26880

--- a/yaml/5b9a202c-0695-532e-9d92-662cedefee07.yaml
+++ b/yaml/5b9a202c-0695-532e-9d92-662cedefee07.yaml
@@ -1,0 +1,135 @@
+Id: 5b9a202c-0695-532e-9d92-662cedefee07
+Tags:
+- NGStar.sys
+Verified: 'TRUE'
+Author: '@BohraDJayesh'
+Created: '2026-06-01'
+MitreID: T1068
+CVE: []
+Category: vulnerable driver
+Commands:
+  Command: pnputil /add-driver fdu11.cat && sc.exe create ngstar binPath=C:\windows\temp\NGStar.sys
+    type=kernel && sc.exe start ngstar
+  Description: "NGStar.sys is the kernel-mode USB fingerprint sensor driver for NITGEN\
+    \ Fingkey Hamster II/III devices. The driver creates \\Device\\gstar-0 exposed\
+    \ as \\\\.\\gstar-0 via IoCreateDevice with FILE_DEVICE_UNKNOWN and no IoCreateDeviceSecure\
+    \ call, making all 28 IOCTL codes (0x00222004-0x00222070) reachable by any unprivileged\
+    \ user-mode process (FILE_ANY_ACCESS on all codes). IOCTLs 0x0022206C and 0x00222070\
+    \ allocate a fixed 10-byte NonPagedPool block via the deprecated ExAllocatePool\
+    \ API then pass it directly as the receive buffer for an uncapped USB bulk transfer\
+    \ with no post-transfer bounds check \u2014 kernel pool overflow leading to local\
+    \ privilege escalation to SYSTEM. ExAllocatePool (non-tagged, removed from Windows\
+    \ 11 and Server 2022 kernel exports) causes a kernel bugcheck (BSOD) on any IOCTL\
+    \ reaching the allocation path \u2014 confirmed local DoS. IOCTL 0x00222050 decrements\
+    \ a session reference counter at [rbp+0x40] via lock add without an underflow\
+    \ guard; counter wraps to 0xFFFFFFFF from zero, corrupting the device extension\
+    \ refcount and triggering premature cleanup leading to use-after-free. Driver\
+    \ carries no embedded PE signature; trusted via catalog fdu11.cat (VeriSign-signed,\
+    \ expired 2014, valid via timestamp countersignature). VT detection: 0/77."
+  Usecase: "Local privilege escalation to SYSTEM via kernel pool overflow (IOCTLs\
+    \ 0x0022206C and 0x00222070 \u2014 fixed 10-byte NonPagedPool alloc passed as\
+    \ uncapped USB bulk receive buffer); confirmed kernel DoS / BSOD via deprecated\
+    \ ExAllocatePool on Windows 11 and Server 2022; device context use-after-free\
+    \ via session counter underflow (IOCTL 0x00222050). All primitives accessible\
+    \ from unprivileged user-mode after driver load. BYOVD: catalog-signed (0/77 VT),\
+    \ FILE_ANY_ACCESS surface reachable from any local process."
+  Privileges: kernel
+  OperatingSystem: Windows 7, Windows 8, Windows 10, Windows 11
+Resources:
+- Internal Research
+Acknowledgement:
+  Person: JayeshDuttBohra
+  Handle: '@BohraDJayesh'
+Detection: []
+KnownVulnerableSamples:
+- Filename: NGStar.sys
+  MD5: 297a9b187c6897749bc7bb92d02e95c0
+  SHA1: 3f102ab63f53869309443b5de9c9416a5e001284
+  SHA256: 4542b20be7adceb61fa5f538fed8c395951e775dbd7c4a2f7c6aee477c4d924e
+  Signature: ''
+  Date: '2012-07-04'
+  Publisher: NITGEN&COMPANY Co., Ltd.
+  Company: NITGEN&COMPANY Co., Ltd.
+  Description: NGStar Driver for Windows 2000/XP/Vista/7 (x64)
+  Product: NGStar.sys
+  ProductVersion: 2, 0, 0, 4
+  FileVersion: 1, 0, 2, 11
+  MachineType: AMD64
+  OriginalFilename: NGStar.sys
+  Authentihash:
+    MD5: b0f2bf18148addfad4ca53d4e00088b7
+    SHA1: 6ec95a0e99215e43742aec5fc55f2fe0345b3dc1
+    SHA256: e2bc6987462f4cfe4de4b53add75822cb2a197a6958b10cb9d85e16788703d18
+  InternalName: NGStar
+  Copyright: Copyright (C) 2000-2011 NITGEN&COMPANY Co., Ltd.
+  Imports:
+  - ntoskrnl.exe
+  - USBD.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - IoReleaseRemoveLockEx
+  - IoDetachDevice
+  - DbgPrint
+  - IoAllocateMdl
+  - IoFreeMdl
+  - IofCallDriver
+  - PoRequestPowerIrp
+  - IoCancelIrp
+  - PoSetPowerState
+  - ExAllocatePool
+  - MmUnmapLockedPages
+  - sprintf
+  - ExFreePool
+  - PoStartNextPowerIrp
+  - IoAcquireRemoveLockEx
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoDeleteSymbolicLink
+  - IoReleaseRemoveLockAndWaitEx
+  - KeWaitForSingleObject
+  - IoBuildPartialMdl
+  - IoFreeIrp
+  - RtlFreeAnsiString
+  - IoAttachDeviceToDeviceStack
+  - PoCallDriver
+  - IoAllocateIrp
+  - RtlInitUnicodeString
+  - IoIsWdmVersionAvailable
+  - IoDeleteDevice
+  - KeSetEvent
+  - MmMapLockedPages
+  - KeBugCheckEx
+  - IoInitializeRemoveLockEx
+  - RtlUnicodeStringToAnsiString
+  - KeInitializeEvent
+  - IoBuildDeviceIoControlRequest
+  - IoCreateSymbolicLink
+  - USBD_CreateConfigurationRequestEx
+  - USBD_ParseConfigurationDescriptor
+  Imphash: f439f8c9fec466e01688b1d0833513a8
+  RichPEHeaderHash:
+    MD5: eb2cd0517f8714f7dbc4b0514950d3cd
+    SHA1: 313be86d1b51712b39b608d936897d5e74304ec5
+    SHA256: b08b03325f19080d245bd0d190404c9c92d693afded600766f828d96eb8d371b
+  Sections:
+    .text:
+      Entropy: 6.323037572424943
+      Virtual Size: '0x5378'
+    .rdata:
+      Entropy: 4.7329152592332004
+      Virtual Size: '0x41c'
+    .data:
+      Entropy: 0.5159719988134768
+      Virtual Size: '0x110'
+    .pdata:
+      Entropy: 4.040981758720401
+      Virtual Size: '0x1e0'
+    INIT:
+      Entropy: 4.822569582967591
+      Virtual Size: '0x534'
+    .rsrc:
+      Entropy: 3.3987147831018927
+      Virtual Size: '0x490'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2011-01-20 01:16:57'
+  Signatures: {}

--- a/yaml/d4d82af5-0ac6-4d5d-944f-cf108475aba9.yaml
+++ b/yaml/d4d82af5-0ac6-4d5d-944f-cf108475aba9.yaml
@@ -1,0 +1,274 @@
+Id: d4d82af5-0ac6-4d5d-944f-cf108475aba9
+Tags:
+- 360hvm64.sys
+Verified: 'TRUE'
+Author: '@cyb3rh0und, @reiterjr'
+Created: '2026-04-30'
+MitreID: T1562.001
+CVE: []
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create 360hvm64 binPath=C:\windows\temp\360hvm64.sys type=kernel
+    && sc.exe start 360hvm64
+  Description: 360hvm64.sys is the kernel-mode hypervisor enforcement driver shipped
+    with Qihoo 360 Total Security. IOCTL 0x22240c on \\.\360Hvm issues a per-CPU DPC
+    broadcast that executes VMXOFF/VMSKINIT on every logical processor, disabling
+    VT-x/AMD-V hypervisor protection across all CPUs; the auth gate (sub_121f4) delegates
+    to \Device\360SelfProtection and fails open when that companion device is absent
+    (BYOVD scenario).
+  Usecase: Disable 360 Total Security's VT-x/AMD-V hypervisor-based protection engine
+    on all CPUs to enable subsequent loading of rootkits or unsigned drivers without
+    VM-level detection
+  Privileges: kernel
+  OperatingSystem: Windows 7, Windows 8, Windows 10, Windows 11
+Resources:
+- Internal Research
+Acknowledgement:
+  Person: John Rodriguez, Jonathan Reiter
+  Handle: '@cyb3rh0und, @reiterjr'
+Detection: []
+KnownVulnerableSamples:
+- Filename: 360Hvm64.sys
+  MD5: 0b5c4cd701956b332e60ae85b8c3a7ea
+  SHA1: 97cbe12e2538aa8a382485e6a00be9337ed72b85
+  SHA256: f89d5d95b8a59e6d5e50a49217f83d080e4eaf4bb77b80d8f38cd915640ba124
+  Signature:
+  - Qihoo 360 Software Co., Ltd.
+  Date: ''
+  Publisher: 360.cn Inc.
+  Company: "360\u5B89\u5168\u4E2D\u5FC3"
+  Description: 360Hvm64
+  Product: ''
+  ProductVersion: 2.0.0.1207
+  FileVersion: 2.0.0.1207
+  MachineType: AMD64
+  OriginalFilename: 360Hvm64.sys
+  Authentihash:
+    MD5: 88cf1a06379e4fdacdb0bbfb9e662f8e
+    SHA1: 5ce3859ef77f4557cd87dfcce0797d1434b2bf51
+    SHA256: a22cbe36242c92676cf6f905ebe5575902989c412875a6bc022f538e1c2455de
+  InternalName: 360Hvm64.sys
+  Copyright: (C) 360.cn Inc. All Rights Reserved.
+  Imports:
+  - ntoskrnl.exe
+  - NETIO.SYS
+  ExportedFunctions: ''
+  PDBPath: ''
+  Imphash: 1ea16ac7f83dccb38a51fdcb3a69cc78
+  RichPEHeaderHash:
+    MD5: f2dfe7bf0d4bb7330b18de85bb71ca73
+    SHA1: 3188fac534b56453599268360e812ba6b684c81c
+    SHA256: 04316336be7b0a1e89e6990c65624380c28de160cd1f21ded21141eecb45f276
+  Sections:
+    .text:
+      Entropy: 6.352208807784793
+      Virtual Size: '0x5759b'
+    .rdata:
+      Entropy: 5.0566087232063195
+      Virtual Size: '0x3bf4'
+    .data:
+      Entropy: 3.485225119882687
+      Virtual Size: '0x99978'
+    .pdata:
+      Entropy: 5.645268157307259
+      Virtual Size: '0x1b78'
+    INIT:
+      Entropy: 5.365037917226642
+      Virtual Size: '0x12b8'
+    .rsrc:
+      Entropy: 3.34811199017735
+      Virtual Size: '0x3c0'
+    .reloc:
+      Entropy: 5.010265572641341
+      Virtual Size: '0x1e48'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2025-07-14 00:40:56'
+  ImportedFunctions:
+  - IoDeleteSymbolicLink
+  - ExFreePoolWithTag
+  - ExReleaseFastMutex
+  - ExAcquireFastMutex
+  - PsSetLoadImageNotifyRoutine
+  - _wcsnicmp
+  - ZwReadFile
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - KeSetEvent
+  - ExGetPreviousMode
+  - MmGetSystemRoutineAddress
+  - IoCreateFile
+  - KeInitializeEvent
+  - KeInitializeDpc
+  - ZwSetInformationFile
+  - RtlFreeUnicodeString
+  - MmGetPhysicalAddress
+  - IoGetDeviceObjectPointer
+  - ZwQueryValueKey
+  - ExAllocatePool
+  - KeQueryMaximumProcessorCount
+  - InitSafeBootMode
+  - KeInsertQueueDpc
+  - ZwClose
+  - IofCompleteRequest
+  - KeWaitForSingleObject
+  - ZwFlushBuffersFile
+  - ExRegisterCallback
+  - PsGetVersion
+  - IoCreateSymbolicLink
+  - RtlCopyUnicodeString
+  - ObfDereferenceObject
+  - IoCreateDevice
+  - ZwQueryInformationFile
+  - ExCreateCallback
+  - ZwWriteFile
+  - DbgPrintEx
+  - MmAllocateContiguousMemorySpecifyCache
+  - IofCallDriver
+  - ZwOpenKey
+  - _stricmp
+  - PsGetProcessPeb
+  - ProbeForRead
+  - RtlAnsiStringToUnicodeString
+  - ZwMapViewOfSection
+  - RtlInitAnsiString
+  - ZwQuerySystemInformation
+  - KeReleaseSpinLock
+  - MmFreeContiguousMemory
+  - RtlEqualUnicodeString
+  - RtlImageDirectoryEntryToData
+  - KeDelayExecutionThread
+  - ZwUnmapViewOfSection
+  - IoGetCurrentProcess
+  - RtlAppendUnicodeStringToString
+  - MmIsAddressValid
+  - ZwCreateSection
+  - ZwOpenFile
+  - RtlImageNtHeader
+  - PsGetCurrentThreadTeb
+  - KeAcquireSpinLockRaiseToDpc
+  - KeLeaveCriticalRegion
+  - ExInitializePushLock
+  - ExfAcquirePushLockExclusive
+  - PsSetCreateProcessNotifyRoutine
+  - IoBuildDeviceIoControlRequest
+  - MmUserProbeAddress
+  - ExfReleasePushLock
+  - KeInvalidateRangeAllCaches
+  - ExfAcquirePushLockShared
+  - RtlLookupFunctionEntry
+  - ObfReferenceObject
+  - _strnicmp
+  - PsGetProcessImageFileName
+  - PsLookupProcessByProcessId
+  - PsReleaseProcessExitSynchronization
+  - KeUnstackDetachProcess
+  - MmIsDriverVerifying
+  - PsAcquireProcessExitSynchronization
+  - KeStackAttachProcess
+  - PsGetProcessWin32Process
+  - MmSystemRangeStart
+  - MmUnmapIoSpace
+  - ZwOpenDirectoryObject
+  - MmMapIoSpace
+  - ObReferenceObjectByHandle
+  - RtlCompareUnicodeString
+  - ExAcquireResourceExclusiveLite
+  - PsProcessType
+  - ProbeForWrite
+  - ExpInterlockedPushEntrySList
+  - ExIsResourceAcquiredExclusiveLite
+  - LpcPortObjectType
+  - ExpInterlockedPopEntrySList
+  - ObQueryNameString
+  - IoFileObjectType
+  - ZwWaitForSingleObject
+  - PsCreateSystemThread
+  - PsTerminateSystemThread
+  - ExAcquireResourceSharedLite
+  - ExReleaseResourceLite
+  - RtlPrefixUnicodeString
+  - ExQueryDepthSList
+  - ObQueryObjectAuditingByHandle
+  - ExDeleteResourceLite
+  - PsGetCurrentProcessId
+  - ExInitializePagedLookasideList
+  - ObReferenceObjectByName
+  - ExInitializeResourceLite
+  - PsGetCurrentProcessSessionId
+  - PsGetProcessId
+  - PsGetCurrentProcessWow64Process
+  - ExRaiseStatus
+  - IoDriverObjectType
+  - ExEventObjectType
+  - IoEnumerateDeviceObjectList
+  - RtlCompareMemory
+  - RtlEqualString
+  - PsGetProcessWow64Process
+  - KeBugCheckEx
+  - KeQueryActiveProcessorCount
+  - KeSetTargetProcessorDpc
+  - MmGetPhysicalMemoryRanges
+  - ZwCreateEvent
+  - ZwFsControlFile
+  - MmMapLockedPagesSpecifyCache
+  - MmSizeOfMdl
+  - RtlIpv6StringToAddressExW
+  - MmProbeAndLockPages
+  - MmUnlockPages
+  - RtlIpv4StringToAddressExW
+  - ObOpenObjectByPointer
+  - KeSetImportanceDpc
+  - KeClearEvent
+  - ExAllocatePoolWithTag
+  - ExUnregisterCallback
+  - KeEnterCriticalRegion
+  - ExQueueWorkItem
+  - __C_specific_handler
+  - NsiAllocateAndGetTable
+  - NsiDeregisterChangeNotification
+  - NsiRegisterChangeNotification
+  - NsiFreeTable
+  - NsiGetAllParameters
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2025-02-20 20:08:08'
+      ValidTo: '2026-02-18 20:08:08'
+      Signature: 3a915ff496468e86d34a86bc4951e3d12d88d33fdd9826b98e674328eb433cad2113c9b57ceef54448eff7b018068dd2dcdab1daadf0536e5840a50e8adfd9da55a6094444c2b2222c402518668f8b610fde25de085d0097ff8e1548d3f15214de67bc40ec593546a1d2996ac74a9667ad8a05872c13ea1f68febffa660d691ff628a2240586db6fb6e26c5df277774231f7cb85e07d2c9918693e23e31b55b10dcb8fc7a1c588aa9089a96f4cd119fa76a370a9abcf4d43a2ceefb1c8adfbd13c76ccecc99c11f6bb8a56f4ea2bf19a6183feb46852de6b673c9bdaf830ffa07ac365efaf5184e21e5c3f32b308342fd07f2e3e2eccc753057aa3688984a183
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 3300000124e76f6ca813a27c35000000000124
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: cfe40b64f31750e7a57db8c4ad451bff
+        SHA1: 4031068d5106d7b364c9b99daf963a00fce3c1fb
+        SHA256: 11dfc1860474603fc5821f01931eb0e945a652e9e5d48b5042472941109b1932
+        SHA384: fafef1d7376886b2895becf586b67dbb317d6ad4398625b0eed2725280d6b29ea072dc4ec32fbc5e041996f8708351f9
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      ValidFrom: '2012-04-18 23:48:38'
+      ValidTo: '2027-04-18 23:58:38'
+      Signature: 5a8a67daccd5fd0d264177bf0a4678b4b3de12692b7723c2652f015fd203f461ba509d2e8c3972f36c3e6ab11e766decb7f382dcccbbc56970287366173f54ebee011648c446d91b80ae813a8d0f796d68b09eea2d3f39d3ca387ebd5e7c086e19dcc6c2f438336861e2524783e1000156d2bacb878205310a418b4ee77f5f5fed5fd3392d45eba213bffd1ec298417161165fc80a70257c59693124e471e70abb0417f79f721ec9d2bb1abe3d02fe090cb243b4591a99539396215fe0d6b72601429536ac27fdbef48577683d18bdf4be98882211865216f345ec0397107087a37043713cdbc98603170cf5735bc67de15c64edd7c548d7ed32e2d1aad3cfa7f6574e61f977eb67f288b3de00da038fd08a34373e1dd862b8d2b1f3e12f8b723b81967c6ffcec667672601b24f2a0896d5b6d002eef28dd868705c2b4b9e5be64c22af24a155c98e2c42785ff52e3627e0fb2020bd766c70ab2d33d200414503259830a7d9bed5a38120152ba2f5e20728e4af1fde771028c3be107bec973f4dd47d8b4efb4a4b330b9893e76cab90098567eabea8ab8a5d038ab6977130b142fe9aa411ff7babd3a2b348aee0aab63e663f788248e200d2b3b9de3c24952ac9f1f0e393b5dd46e506ae67d523aaa7c3315290d265e0158a74ea93d7a846f743f609fe4324f3600af6d71d33ea646655f8174f1fec171da4ca0415a82ddf11f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 610baac1000000000009
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: a569061297e8e824767dbc3184a69bea
+        SHA1: adbb26a587a8f44b4fccaecb306f980d1c55a150
+        SHA256: cec1afd0e310c55c1dcc601ab8e172917706aa32fb5eaf826813547fdf02dd46
+        SHA384: e947cac936803f5683196e4ff1b259096073395d0b908522ddce90d57597c9f7b57f7ddcdbe021ba863d843c340da8ba
+    Signer:
+    - SerialNumber: 3300000124e76f6ca813a27c35000000000124
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      Version: 1


### PR DESCRIPTION
## Summary

Adds repo-owned replacements for the driver entries from #349 and #353 because the contributor forks cannot accept new Git LFS objects from maintainer-side pushes. This PR keeps the submitter/author acknowledgement from the original PRs while adding the binaries as proper LFS objects.

Included entries:
- 360Hvm64.sys / Qihoo 360 hypervisor enforcement driver from #349
- NGStar.sys / NITGEN fingerprint driver from #353

## Binary handling

- Downloaded both exact-hash samples from VirusTotal.
- Verified MD5/SHA1/SHA256 locally before adding.
- Added the driver files as Git LFS pointers under `drivers/<md5>.bin`.
- Ran `bin/metadata-extractor.py` against the two binaries and YAML files.

## Validation

- `python3 bin/metadata-extractor.py -d .context/metadata-pr349-353/samples -yaml .context/metadata-pr349-353/yaml`
- `python3 bin/validate.py` -> `No Errors found`
- `git diff --check`

Supersedes #349 and #353 for merge purposes if maintainers want the binaries included as LFS.