### PR TITLE
Add xkpsm and LnvMSRIO driver entries

### DIFF
--- a/drivers/517917ff2e5008c791d007cecab5e335.bin
+++ b/drivers/517917ff2e5008c791d007cecab5e335.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7023f08c9f99076a5fb82a0f661847e2951800f095fca1793a0e6bd9c949b478
+size 40432

--- a/drivers/bb08ca77afc108421b8135d22ea6b374.bin
+++ b/drivers/bb08ca77afc108421b8135d22ea6b374.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28c5bb735f9fc38e0ebd366978898f0cfcd455e4ff8bf1a321768b09e01ee84d
+size 15136

--- a/drivers/e2b952939b8e9d76cff7d130b797a74d.bin
+++ b/drivers/e2b952939b8e9d76cff7d130b797a74d.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:245b6ab442a7d53dc30ece28e1c6de727c019669385877cbe929b81aa1a2ad2f
+size 50216

--- a/yaml/767ed0a0-606b-4297-a858-e2af5b4a0400.yaml
+++ b/yaml/767ed0a0-606b-4297-a858-e2af5b4a0400.yaml
@@ -1,0 +1,196 @@
+Id: 767ed0a0-606b-4297-a858-e2af5b4a0400
+Tags:
+- xkpsm.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-06-16'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create xkpsm binPath=C:\windows\temp\xkpsm.sys type=kernel && sc.exe
+    start xkpsm
+  Description: xkpsm.sys is an xkeeper kernel driver from JiranJikyosoft. The driver
+    exposes IOCTL 0x8505E008 to user mode and reaches ZwTerminateProcess, enabling
+    kernel-mediated process termination without sufficient caller or target validation.
+    This makes the driver useful in BYOVD-style process termination and security tool
+    impairment scenarios after it is loaded.
+  Usecase: Terminate processes
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/343
+Detection: []
+Acknowledgement:
+  Person: ''
+  Handle: '@wwwab123'
+KnownVulnerableSamples:
+- Filename: xkpsm.sys
+  MD5: bb08ca77afc108421b8135d22ea6b374
+  SHA1: d60fc160f73450ee63c9f46dd55d5cede6fe3dcd
+  SHA256: 28c5bb735f9fc38e0ebd366978898f0cfcd455e4ff8bf1a321768b09e01ee84d
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: Jiransoft Co. Ltd.
+  Description: xkpsm
+  Product: xkeeper
+  ProductVersion: 3,0,0,1
+  FileVersion: 3,0,0,1
+  MachineType: AMD64
+  OriginalFilename: xkpsm.sys
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: 68dea920d822aa2e15f3dd7f2c59678a
+  Authentihash:
+    MD5: 883b58a5cb813602c1031eb7ed5aabc7
+    SHA1: 2c069a4256886e514bc0aeeb84ea7f01b4803041
+    SHA256: 55b469434acef9803975cdf59c7d80777127847ce27711682f3ba81f9b5f7d9f
+  RichPEHeaderHash:
+    MD5: 15ac8f3a02a6987206b9005157ab14f0
+    SHA1: 501a38c1d5cd75c7dcae023ddf85bb56e2de6f96
+    SHA256: b951a7d9bfcda84832dc92715fe035598f3d1f754eb1d8b84d2c1c74d5f716ce
+  Sections:
+    .text:
+      Entropy: 6.06878886604991
+      Virtual Size: '0x718'
+    .rdata:
+      Entropy: 4.112379378913309
+      Virtual Size: '0x1dc'
+    .data:
+      Entropy: 0.6652613916307886
+      Virtual Size: '0x161'
+    .pdata:
+      Entropy: 3.395600232402961
+      Virtual Size: '0x6c'
+    INIT:
+      Entropy: 5.087363973736573
+      Virtual Size: '0x2ce'
+    .rsrc:
+      Entropy: 3.2845454027776504
+      Virtual Size: '0x3c8'
+    .reloc:
+      Entropy: 1.3741854163060885
+      Virtual Size: '0x18'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2014-06-19 00:04:07'
+  InternalName: xkpsm.sys
+  Copyright: Copyright (C) 2009 JIRANSOFT. All right reserved.
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ExAllocatePoolWithTag
+  - IoDeleteSymbolicLink
+  - ExFreePoolWithTag
+  - IoDeleteDevice
+  - KeSetEvent
+  - KeReleaseSpinLock
+  - PsSetCreateProcessNotifyRoutine
+  - ZwClose
+  - IofCompleteRequest
+  - ObReferenceObjectByHandle
+  - ZwOpenProcess
+  - IoCreateSymbolicLink
+  - ObfDereferenceObject
+  - IoCreateDevice
+  - ZwTerminateProcess
+  - DbgPrint
+  - KeAcquireSpinLockRaiseToDpc
+  - KeBugCheckEx
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services CA
+        , G2
+      ValidFrom: '2012-12-21 00:00:00'
+      ValidTo: '2020-12-30 23:59:59'
+      Signature: 03099b8f79ef7f5930aaef68b5fae3091dbb4f82065d375fa6529f168dea1c9209446ef56deb587c30e8f9698d23730b126f47a9ae3911f82ab19bb01ac38eeb599600adce0c4db2d031a6085c2a7afce27a1d574ca86518e979406225966ec7c7376a8321088e41eaddd9573f1d7749872a16065ea6386a2212a35119837eb6
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 7e93ebfb7cc64e59ea4b9a77d406fc3b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: d0785ad36e427c92b19f6826ab1e8020
+        SHA1: 365b7a9c21bd9373e49052c3e7b3e4646ddd4d43
+        SHA256: c2abb7484da91a658548de089d52436175fdb760a1387d225611dc0613a1e2ff
+        SHA384: eab4fe5ef90e0de4a6aa3a27769a5e879f588df5e4785aa4104debd1f81e19ea56d33e3a16e5facf99f68b5d8e3d287b
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services Signer
+        , G4
+      ValidFrom: '2012-10-18 00:00:00'
+      ValidTo: '2020-12-29 23:59:59'
+      Signature: 783bb4912a004cf08f62303778a38427076f18b2de25dca0d49403aa864e259f9a40031cddcee379cb216806dab632b46dbff42c266333e449646d0de6c3670ef705a4356c7c8916c6e9b2dfb2e9dd20c6710fcd9574dcb65cdebd371f4378e678b5cd280420a3aaf14bc48829910e80d111fcdd5c766e4f5e0e4546416e0db0ea389ab13ada097110fc1c79b4807bac69f4fd9cb60c162bf17f5b093d9b5be216ca13816d002e380da8298f2ce1b2f45aa901af159c2c2f491bdb22bbc3fe789451c386b182885df03db451a179332b2e7bb9dc20091371eb6a195bcfe8a530572c89493fb9cf7fc9bf3e226863539abd6974acc51d3c7f92e0c3bc1cd80475
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0ecff438c8febf356e04d86a981b1a50
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: e9d38360b914c8863f6cba3ee58764d3
+        SHA1: 4cba8eae47b6bf76f20b3504b98b8f062694a89b
+        SHA256: 88901d86a4cc1f1bb193d08e1fb63d27452e63f83e228c657ab1a92e4ade3976
+        SHA384: e9f2a75334a9e336c5a4712eadee88d0374b0fdc273262f4e65c9040ad2793067cc076696db5279a478773485e285652
+    - Subject: C=KR, ST=Seoul, L=Gangnam Gu, O=JiranJikyosoft co., ltd., OU=Digital
+        ID Class 3 , Microsoft Software Validation v2, OU=Management Dept., CN=JiranJikyosoft
+        co., ltd.
+      ValidFrom: '2013-08-09 00:00:00'
+      ValidTo: '2016-08-08 23:59:59'
+      Signature: 14b55a59c75e36129cec027f691b3258878f6b54f32d7b96e5a0a189b3c1ad9be9a14b8a30e181b3f2ba7c504abd9afc3b3a49f464af4dcf9f318c5342150c0c40581e665cf37a910ea7d7f4cf672fa5481bf4b74fb14434c301a452c19aca84ac65f35172ba5986aae749ea4ba160cad16251a116a96659362021c1080f3b2f226c972ad8270302cb7b48aa6525744558271f47bcd9c047cce4fada99288a2a5e314e28ee749d1fdb145d627451c496e54e1410124d3a3f6f5bba439fa1fb7d93451bec817891981657f6dda3941167298ab3131425ffab41792eadd24ce54f9395cd3474c6e984830d77612af6d22194f075b40eaa47cec3a16e16d6ac4ce9
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 628d42d99b0e996f0adc5aad72b20e5e
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: fc764a0c14e0c7b486de615fceee5076
+        SHA1: 5f46c0e34b3454b5200146fae149a51572c3afac
+        SHA256: 76408c0d92beed0575551640cc74732f90ef542d123756cd1573d75f690cf355
+        SHA384: 02f233454f4b0a2d2913bef27b3f096756633241443701e82e3334b84b2c3d7a722f088c28d0fb083e95af1081b63ff4
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=(c) 2006 VeriSign,
+        Inc. , For authorized use only, CN=VeriSign Class 3 Public Primary Certification
+        Authority , G5
+      ValidFrom: '2011-02-22 19:25:17'
+      ValidTo: '2021-02-22 19:35:17'
+      Signature: 812a82168c34672be503eb347b8ca2a3508af45586f11e8c8eae7dee0319ce72951848ad6211fd20fd3f4706015ae2e06f8c152c4e3c6a506c0b36a3cf7a0d9c42bc5cf819d560e369e6e22341678c6883762b8f93a32ab57fbe59fba9c9b2268fcaa2f3821b983e919527978661ee5b5d076bcd86a8e26580a8e215e2b2be23056aba0cf347934daca48c077939c061123a050d89a3ec9f578984fbecca7c47661491d8b60f195de6b84aacbc47c8714396e63220a5dc7786fd3ce38b71db7b9b03fcb71d3264eb1652a043a3fa2ead59924e7cc7f233424838513a7c38c71b242228401e1a461f17db18f7f027356cb863d9cdb9645d2ba55eefc629b4f2c7f821cc04ba57fd01b6abc667f9e7d3997ff4f522fa72f5fdff3a1c423aa1f98018a5ee8d1cd4669e4501feaaeefffb178f30f7f1cd29c59decb5d549003d85b8cbbb933a276a49c030ae66c9f723283276f9a48356c848ce5a96aaa0cc0cc47fb48e97af6de35427c39f86c0d6e473089705dbd054625e0348c2d59f7fa7668cd09db04fd4d3985f4b7ac97fb22952d01280c70f54b61e67cdc6a06c110384d34875e72afeb03b6e0a3aa66b769905a3f177686133144706fc537f52bd92145c4a246a678caf8d90aad0f679211b93267cc3ce1ebd883892ae45c6196a4950b305f8ae59378a6a250394b1598150e8ba8380b72335f476b9671d5918ad208d94
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 611993e400000000001c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 78a717e082dcc1cda3458d917e677d14
+        SHA1: 4a872e0e51f9b304469cd1dedb496ee9b8b983a4
+        SHA256: 317fa1d234ebc49040ebc5e8746f8997471496051b185a91bdd9dfbb23fab5f8
+        SHA384: b71052da4eb9157c8c1a5d7f55df19d69b9128598b72fcca608e5b7cc7d64c43c5504b9c86355a6dc22ee40c88cc385c
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=Terms of use
+        at https://www.verisign.com/rpa (c)10, CN=VeriSign Class 3 Code Signing 2010
+        CA
+      ValidFrom: '2010-02-08 00:00:00'
+      ValidTo: '2020-02-07 23:59:59'
+      Signature: 5622e634a4c461cb48b901ad56a8640fd98c91c4bbcc0ce5ad7aa0227fdf47384a2d6cd17f711a7cec70a9b1f04fe40f0c53fa155efe749849248581261c911447b04c638cbba134d4c645e80d85267303d0a98c646ddc7192e645056015595139fc58146bfed4a4ed796b080c4172e737220609be23e93f449a1ee9619dccb1905cfc3dd28dac423d6536d4b43d40288f9b10cf2326cc4b20cb901f5d8c4c34ca3cd8e537d66fa520bd34eb26d9ae0de7c59af7a1b42191336f86e858bb257c740e58fe751b633fce317c9b8f1b969ec55376845b9cad91faaced93ba5dc82153c2825363af120d5087111b3d5452968a2c9c3d921a089a052ec793a54891d3
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 5200e5aa2556fc1a86ed96c9d44b33c7
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: b30c31a572b0409383ed3fbe17e56e81
+        SHA1: 4843a82ed3b1f2bfbee9671960e1940c942f688d
+        SHA256: 03cda47a6e654ed85d932714fc09ce4874600eda29ec6628cfbaeb155cab78c9
+        SHA384: bbda8407c4f9fc4e54d772f1c7fb9d30bc97e1f97ecd51c443063d1fa0644e266328781776cd5c44896c457c75f4d7da
+    Signer:
+    - SerialNumber: 628d42d99b0e996f0adc5aad72b20e5e
+      Issuer: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=Terms of use at
+        https://www.verisign.com/rpa (c)10, CN=VeriSign Class 3 Code Signing 2010
+        CA
+      Version: 1

--- a/yaml/87680018-393b-47b6-8130-6b41bed2bc7c.yaml
+++ b/yaml/87680018-393b-47b6-8130-6b41bed2bc7c.yaml
@@ -1,0 +1,339 @@
+Id: 87680018-393b-47b6-8130-6b41bed2bc7c
+Tags:
+- LnvMSRIO.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-06-16'
+MitreID: T1068
+CVE:
+- CVE-2025-8061
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create LnvMSRIO binPath=C:\windows\temp\LnvMSRIO.sys type=kernel
+    && sc.exe start LnvMSRIO
+  Description: LnvMSRIO.sys is a Lenovo Dispatcher driver affected by CVE-2025-8061.
+    Vulnerable Lenovo Dispatcher 3.0 and 3.1 drivers expose the WinMsrDev device interface
+    with insufficient access control. Public research documents primitives for physical
+    memory read (IOCTL 0x9C406104), physical memory write (IOCTL 0x9C40A108), MSR
+    read (IOCTL 0x9C402084), and MSR write (IOCTL 0x9C402088), enabling an authenticated
+    local user to execute code with elevated privileges when Memory Integrity is not
+    enabled. Lenovo reports Dispatcher 3.2 and driver versions 3.1.0.41 and later
+    as not affected.
+  Usecase: Elevate privileges
+  Privileges: kernel
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/242
+- https://github.com/symeonp/Lenovo-CVE-2025-8061
+- https://blog.quarkslab.com/exploiting-lenovo-driver-cve-2025-8061.html
+- https://nvd.nist.gov/vuln/detail/CVE-2025-8061
+- https://support.lenovo.com/us/en/product_security/LEN-200860
+- https://github.com/segura2010/lenovo-dispatcher-poc
+- https://github.com/spawn451/CVE-2025-8061-Exploit
+Detection: []
+Acknowledgement:
+  Person: nasbench
+  Handle: '@nasbench'
+KnownVulnerableSamples:
+- Filename: LnvMSRIO.sys
+  MD5: 517917ff2e5008c791d007cecab5e335
+  SHA1: f496bc9b6e77fef03f945b48f86b840baf61fe47
+  SHA256: 7023f08c9f99076a5fb82a0f661847e2951800f095fca1793a0e6bd9c949b478
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: Lenovo
+  Description: Lenovo filter driver
+  Product: Lenovo filter driver
+  ProductVersion: 3.1.0.36
+  FileVersion: 3.1.0.36
+  MachineType: AMD64
+  OriginalFilename: LnvMSRIO.sys
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: 3b2a2be6141c8dd9d480fe7ab5ede02b
+  Authentihash:
+    MD5: 74f2be8834f3ac2de12d64b705bf5d08
+    SHA1: b74a2e4f0a40748a9dc136cd7eaceecbfe40bba0
+    SHA256: bcc5394705e552d0312592c507b71a6bd921782f82bb5b4acc721d2f056030a5
+  RichPEHeaderHash:
+    MD5: 69fd0a1931e95ec5f2a763c14d238399
+    SHA1: eca66a34a452e4eade0671b7105f22558f315d1c
+    SHA256: cc8f06d333952c06f0ba32f3ef67ad714a7d76ce5377cd2a3bbc2a874c4a89a4
+  Sections:
+    .text:
+      Entropy: 5.854164604481378
+      Virtual Size: '0x273d'
+    .rdata:
+      Entropy: 4.443687519955218
+      Virtual Size: '0xbac'
+    .data:
+      Entropy: 0.6046349582600534
+      Virtual Size: '0x308'
+    .pdata:
+      Entropy: 3.9855270716338467
+      Virtual Size: '0x240'
+    INIT:
+      Entropy: 4.738959355178401
+      Virtual Size: '0x522'
+    .rsrc:
+      Entropy: 3.2551386485994502
+      Virtual Size: '0x380'
+    .reloc:
+      Entropy: 3.56352788201102
+      Virtual Size: '0x34'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2024-11-20 22:42:05'
+  InternalName: LnvMSRIO.sys
+  Copyright: Copyright (C) 2024, Lenovo. All Rights Reserved
+  Imports:
+  - FLTMGR.SYS
+  - ntoskrnl.exe
+  - HAL.dll
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - FltRegisterFilter
+  - FltUnregisterFilter
+  - FltStartFiltering
+  - FltCreateCommunicationPort
+  - FltCloseCommunicationPort
+  - FltCloseClientPort
+  - FltSendMessage
+  - FltBuildDefaultSecurityDescriptor
+  - FltFreeSecurityDescriptor
+  - IoCreateDevice
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - PoRegisterPowerSettingCallback
+  - PoUnregisterPowerSettingCallback
+  - PsSetCreateProcessNotifyRoutineEx
+  - ZwPowerInformation
+  - __C_specific_handler
+  - RtlInitUnicodeString
+  - IofCompleteRequest
+  - MmUnmapIoSpace
+  - MmMapIoSpace
+  - RtlCopyUnicodeString
+  - DbgPrintEx
+  - ProbeForWrite
+  - ProbeForRead
+  - ExFreePoolWithTag
+  - ExAllocatePool2
+  - IoCreateSymbolicLink
+  - HalGetBusDataByOffset
+  - HalSetBusDataByOffset
+  - WdfVersionBind
+  - WdfLdrQueryInterface
+  - WdfVersionUnbind
+  - WdfVersionBindClass
+  - WdfVersionUnbindClass
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Trusted Root
+        G4
+      ValidFrom: '2013-08-01 12:00:00'
+      ValidTo: '2038-01-15 12:00:00'
+      Signature: bb61d97da96cbe17c4911bc3a1a2008de364680f56cf77ae70f9fd9a4a99b9c9785c0c0c5fe4e61429560b36495d4463e0ad9c9618661b230d3d79e96d6bd654f8d23cc14340ae1d50f552fc903bbb9899696bc7c1a7a868a427dc9df927ae3085b9f6674d3a3e8f5939225344ebc85d03caed507a7d62210a80c87366d1a005605fe8a5b4a7afa8f76d359c7c5a8ad6a23899f3788bf44dd2200bde04ee8c9b4781720dc01432ef30592eaee071f256e46a976f92506d968d687a9ab236147a06f224b9091150d708b1b8897a8423614229e5a3cda22041d7d19c64d9ea26a18b14d74c19b25041713d3f4d7023860c4adc81d2cc3294840d0809971c4fc0ee6b207430d2e03934108521150108e85532de7149d92817504de6be4dd175acd0cafb41b843a5aad3c305444f2c369be2fae245b823536c066f67557f46b54c3f6e285a7926d2a4a86297d21ee2ed4a8bbc1bfd474a0ddf67667eb25b41d03be4f43bf40463e9efc2540051a08a2ac9ce78ccd5ea870418b3ceaf4988aff39299b6b3e6610fd28500e7501ae41b959d19a1b99cb19bb1001eefd00f4f426cc90abcee43fa3a71a5c84d26a535fd895dbc85621d32d2a02b54ed9a57c1dbfa10cf19b78b4a1b8f01b6279553e8b6896d5bbc68d423e88b51a256f9f0a680a0d61eb3bc0f0f537529aaea1377e4de8c8121ad07104711ad873d07d175bccff3667e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 059b1b579e8e2132e23907bda777755c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 41b622dd54995550fdc2f31ea12f8d9b
+        SHA1: 420704040c93dfe9d3ad01a26c07f2be1f4888c1
+        SHA256: 4816e2e9e37ba61e1def6f7a4c623e981c7af355e51349b5554a3d56c5252e24
+        SHA384: 4ea1b34b10b982a96a38915843507820ad632c6aad8343e337b34d660cd8366fa154544ae80668ae1fdf3931d57e1996
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      ValidFrom: '2021-04-29 00:00:00'
+      ValidTo: '2036-04-28 23:59:59'
+      Signature: 3a23443d8d0876ee8fbc3a99d356e0021aa5f84834f32cb6e67466f79472b100caaf6c302713129e90449f4bfd9ea37c26d537bc3a5d486d95d53f49f427bb16814550fd9cbdb685e0767e3771cb22f75aaa90cff5936ae3eb20d1d55079889a8a8ac1b6bda148187edcd8801a111918cd61998156f6c9e376e7c4e41b5f43f83e94ff76393d9ed499cf4add28eb5f26a1955848d51afed7273ffd90d17686dd1cb0605cf30da8eee089a1bd39e1384eda6ebb369dfbe521535ac3cae96af1a23edb43b833c84f38149299f5ddce546dd95d02141f40337c03e295b2c221757352cb46d8c4341ca2a54b8dcd6f76372c853f1ace26e918be9007b0437f9588208270f0cccaeffd29355c1f893855f7378a8b09a1cb0be9311aff2e195c3971e1be9ca70a06d62667b792e64e5fde7aac49cf2ea47492addb3ca49c861fe3c1561b2b23ff8fb5ea887b706be6a0bafd3a3f45a6c4e81691528b41c048844b964dab4440e38df01528ceedf11856072a2f10c40c08643c338fae288c3ccb8f880b0dbf3bf4ce1e7b8eefb5ebcbb7f07713e6e7283fac12aea52f226c41f9825c1566cc6c0ecac586c3f626330c074ba0d307026a6a4030484b34a85120bbad1b8508e2590d6dca05502bea4a1c9ea5fda0a71f0674e7f2d65290fdaf854821f9573bb49c03ed8645f4b4616ebf68e2266086eac8afa9fe941de7631b3a8656784e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 08ad40b260d29c4c9f5ecda9bd93aed9
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 5d8003a64dfa5a4d88365da1566038cb
+        SHA1: 79465b56bc7ad55a37bdf633943da8bfc84db228
+        SHA256: 84bdc82e2f2a7f7aaa782667dac556ffcb2b33240c1f9c0a00a3264526a98332
+        SHA384: 65b1d4076a89ae273f57e6eeedecb3eae129b4168f76fa7671914cdf461d542255c59d9b85b916ae0ca6fc0fcf7a8e64
+    - Subject: C=US, ST=North Carolina, L=Morrisville, O=Lenovo, OU=G29, CN=Lenovo
+      ValidFrom: '2024-10-30 00:00:00'
+      ValidTo: '2025-10-29 23:59:59'
+      Signature: 88af5de36514a3d179ba4e91a0d9a6ca151f1c7b8c575b838940241ad1c35ddec84196e9c494ba6c4c949028e4bd2f10c019ec49fbecc065d8a39127adbee5d4d2f9103d902f064f1566f065c2dd6ab5b24a7726e6f6980577efefb8667fdc1f9687e9059fbc297abda2954ed0401ac9e73eb8a13f93a9c328e00336e030d144a5c31c319616ec047049616e7751af98b1c5ec06f09fa7f177a02acb60e69bf81294a7c3d69151e77f06a133e8e41f17961a50c750de2eec2dfa2ecff8470005e8c9d441d34bea706993ccf8a6a4b8ff2a6b63eabddb50003dbe361ec6e482d06469332804f196ea8f4faf4268e69a6157116d49da333b9edec3d773882e97f7d25f5323be844407fad9d211974efcb61a8793fffc13ecf1ef71af78634df177f46a3d3315e428de30cffe43c027e21ed555fb45bf764916050d6468ee6527cf3b3b43bba72f9cb98cd8ee1588db70e17acc9fcde65c2590cf0a275bb1a8b7497c2e0c67fbcafde9b75cbdcd68511c52e38e7cf5b07c887db175fcb6264db8a22fe2573ec5fa27d9b0f2c1dcc02ced797819157dc570e3c2739d5b212ea680c6446192baa10b0b4b1113e974e070c7c3fa707584f55623686e851657fc54bc3d27167758580dbdb3a0a1c264921e41eb074b76bc1f0452ddfb3d0cfa0de64f6f7def5c44f1f16cdb4aacfb44b453b859228f36c4ff578197ed9690b152fd2e69
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 0b60337461b8bb50cbf83e6bea99ea0e
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 7ef16cb5545e847cef80aee6db6fb728
+        SHA1: 8e8fdcaa9d5943a7cc298815f9144d5aec014de0
+        SHA256: 7d84324a4b209440d8fa048ba61a70ca2e5d4f82881a458c45d50b80e2a40abd
+        SHA384: 5c582862ce3cd29630ba8f35068f63f7fc54e1b626e19dd4951413f23d3433381d8266287a91255978359138c22c207d
+    Signer:
+    - SerialNumber: 0b60337461b8bb50cbf83e6bea99ea0e
+      Issuer: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      Version: 1
+- Filename: LnvMSRIO.sys
+  MD5: e2b952939b8e9d76cff7d130b797a74d
+  SHA1: 0186912447648a5e4b9c9c31d718f605d5e5c925
+  SHA256: 245b6ab442a7d53dc30ece28e1c6de727c019669385877cbe929b81aa1a2ad2f
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: Lenovo
+  Description: Lenovo filter driver
+  Product: Lenovo filter driver
+  ProductVersion: 3.1.0.35
+  FileVersion: 3.1.0.35
+  MachineType: AMD64
+  OriginalFilename: LnvMSRIO.sys
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: 3b2a2be6141c8dd9d480fe7ab5ede02b
+  Authentihash:
+    MD5: 0534526a3718f09d57d41ee52bac6925
+    SHA1: 68969b2b53412322917be77774b3175155f28b71
+    SHA256: 5ea22a51f3db36d0fb6f14787a66422b408411f05108c3a75a702eb77870c022
+  RichPEHeaderHash:
+    MD5: 69fd0a1931e95ec5f2a763c14d238399
+    SHA1: eca66a34a452e4eade0671b7105f22558f315d1c
+    SHA256: cc8f06d333952c06f0ba32f3ef67ad714a7d76ce5377cd2a3bbc2a874c4a89a4
+  Sections:
+    .text:
+      Entropy: 5.854164604481378
+      Virtual Size: '0x273d'
+    .rdata:
+      Entropy: 4.440145110492177
+      Virtual Size: '0xbac'
+    .data:
+      Entropy: 0.6046349582600534
+      Virtual Size: '0x308'
+    .pdata:
+      Entropy: 3.9855270716338467
+      Virtual Size: '0x240'
+    INIT:
+      Entropy: 4.738959355178401
+      Virtual Size: '0x522'
+    .rsrc:
+      Entropy: 3.2612879510596366
+      Virtual Size: '0x380'
+    .reloc:
+      Entropy: 3.56352788201102
+      Virtual Size: '0x34'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2024-10-09 23:38:50'
+  InternalName: LnvMSRIO.sys
+  Copyright: Copyright (C) 2024, Lenovo. All Rights Reserved
+  Imports:
+  - FLTMGR.SYS
+  - ntoskrnl.exe
+  - HAL.dll
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - FltRegisterFilter
+  - FltUnregisterFilter
+  - FltStartFiltering
+  - FltCreateCommunicationPort
+  - FltCloseCommunicationPort
+  - FltCloseClientPort
+  - FltSendMessage
+  - FltBuildDefaultSecurityDescriptor
+  - FltFreeSecurityDescriptor
+  - IoCreateDevice
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - PoRegisterPowerSettingCallback
+  - PoUnregisterPowerSettingCallback
+  - PsSetCreateProcessNotifyRoutineEx
+  - ZwPowerInformation
+  - __C_specific_handler
+  - RtlInitUnicodeString
+  - IofCompleteRequest
+  - MmUnmapIoSpace
+  - MmMapIoSpace
+  - RtlCopyUnicodeString
+  - DbgPrintEx
+  - ProbeForWrite
+  - ProbeForRead
+  - ExFreePoolWithTag
+  - ExAllocatePool2
+  - IoCreateSymbolicLink
+  - HalGetBusDataByOffset
+  - HalSetBusDataByOffset
+  - WdfVersionBind
+  - WdfLdrQueryInterface
+  - WdfVersionUnbind
+  - WdfVersionBindClass
+  - WdfVersionUnbindClass
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Trusted Root
+        G4
+      ValidFrom: '2013-08-01 12:00:00'
+      ValidTo: '2038-01-15 12:00:00'
+      Signature: bb61d97da96cbe17c4911bc3a1a2008de364680f56cf77ae70f9fd9a4a99b9c9785c0c0c5fe4e61429560b36495d4463e0ad9c9618661b230d3d79e96d6bd654f8d23cc14340ae1d50f552fc903bbb9899696bc7c1a7a868a427dc9df927ae3085b9f6674d3a3e8f5939225344ebc85d03caed507a7d62210a80c87366d1a005605fe8a5b4a7afa8f76d359c7c5a8ad6a23899f3788bf44dd2200bde04ee8c9b4781720dc01432ef30592eaee071f256e46a976f92506d968d687a9ab236147a06f224b9091150d708b1b8897a8423614229e5a3cda22041d7d19c64d9ea26a18b14d74c19b25041713d3f4d7023860c4adc81d2cc3294840d0809971c4fc0ee6b207430d2e03934108521150108e85532de7149d92817504de6be4dd175acd0cafb41b843a5aad3c305444f2c369be2fae245b823536c066f67557f46b54c3f6e285a7926d2a4a86297d21ee2ed4a8bbc1bfd474a0ddf67667eb25b41d03be4f43bf40463e9efc2540051a08a2ac9ce78ccd5ea870418b3ceaf4988aff39299b6b3e6610fd28500e7501ae41b959d19a1b99cb19bb1001eefd00f4f426cc90abcee43fa3a71a5c84d26a535fd895dbc85621d32d2a02b54ed9a57c1dbfa10cf19b78b4a1b8f01b6279553e8b6896d5bbc68d423e88b51a256f9f0a680a0d61eb3bc0f0f537529aaea1377e4de8c8121ad07104711ad873d07d175bccff3667e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 059b1b579e8e2132e23907bda777755c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 41b622dd54995550fdc2f31ea12f8d9b
+        SHA1: 420704040c93dfe9d3ad01a26c07f2be1f4888c1
+        SHA256: 4816e2e9e37ba61e1def6f7a4c623e981c7af355e51349b5554a3d56c5252e24
+        SHA384: 4ea1b34b10b982a96a38915843507820ad632c6aad8343e337b34d660cd8366fa154544ae80668ae1fdf3931d57e1996
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      ValidFrom: '2021-04-29 00:00:00'
+      ValidTo: '2036-04-28 23:59:59'
+      Signature: 3a23443d8d0876ee8fbc3a99d356e0021aa5f84834f32cb6e67466f79472b100caaf6c302713129e90449f4bfd9ea37c26d537bc3a5d486d95d53f49f427bb16814550fd9cbdb685e0767e3771cb22f75aaa90cff5936ae3eb20d1d55079889a8a8ac1b6bda148187edcd8801a111918cd61998156f6c9e376e7c4e41b5f43f83e94ff76393d9ed499cf4add28eb5f26a1955848d51afed7273ffd90d17686dd1cb0605cf30da8eee089a1bd39e1384eda6ebb369dfbe521535ac3cae96af1a23edb43b833c84f38149299f5ddce546dd95d02141f40337c03e295b2c221757352cb46d8c4341ca2a54b8dcd6f76372c853f1ace26e918be9007b0437f9588208270f0cccaeffd29355c1f893855f7378a8b09a1cb0be9311aff2e195c3971e1be9ca70a06d62667b792e64e5fde7aac49cf2ea47492addb3ca49c861fe3c1561b2b23ff8fb5ea887b706be6a0bafd3a3f45a6c4e81691528b41c048844b964dab4440e38df01528ceedf11856072a2f10c40c08643c338fae288c3ccb8f880b0dbf3bf4ce1e7b8eefb5ebcbb7f07713e6e7283fac12aea52f226c41f9825c1566cc6c0ecac586c3f626330c074ba0d307026a6a4030484b34a85120bbad1b8508e2590d6dca05502bea4a1c9ea5fda0a71f0674e7f2d65290fdaf854821f9573bb49c03ed8645f4b4616ebf68e2266086eac8afa9fe941de7631b3a8656784e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 08ad40b260d29c4c9f5ecda9bd93aed9
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 5d8003a64dfa5a4d88365da1566038cb
+        SHA1: 79465b56bc7ad55a37bdf633943da8bfc84db228
+        SHA256: 84bdc82e2f2a7f7aaa782667dac556ffcb2b33240c1f9c0a00a3264526a98332
+        SHA384: 65b1d4076a89ae273f57e6eeedecb3eae129b4168f76fa7671914cdf461d542255c59d9b85b916ae0ca6fc0fcf7a8e64
+    - Subject: C=US, ST=North Carolina, L=Morrisville, O=Lenovo, OU=G29, CN=Lenovo
+      ValidFrom: '2023-11-06 00:00:00'
+      ValidTo: '2024-11-05 23:59:59'
+      Signature: 284e5244446cd93f082eb7a834ac19cf3a443baf3f396c07d1d2fc4ebdc7f1df9540a4fcb44cd40d0350d131d6bacdd5599b856782100b76ced81720bb9dd72e2ae22617e0b6dfd467dd24285b3caf8762d3e6a4f70110904f78a11fc21d81d84c58fab913e326555556a79c8caae2b807d2a6abeaa40c8503f88a9e0855e7f5e04be4495e092e252c4bb99ca46028197f361ff853be0acdd3640377607636ae604bd53b3ef1b2262fdb10dae3c77251a3023160f6a8117e629e3f8c65ef405a2851634232f0ba2151713a3fd9954e28c9ba6b9c334964a582b51b97f15145cb8197ad978e52358986a8391f4b3569d9f99078bf12970f4da9505dc57540cc2a22b5575f6b2318cbc29a142098eea589f358e282e9d7ccce949ccff4fe8dac3a026ce7bb80c5d90a83d97be2a65f824b0556999ba4bc4b6fadfa85115afc7bc62b1b08eadc3ffba9f2eb5441736629e46e95ec071036e810bfe12d96221bf79573c56f4fbef40ceaa56cbdeb31d05b4806fac253497c15d65b00a6d89508d7d3d1ddc426bab803e6eeda46d728ea05173dfade4e3c816cd0064bc71cd8ff79e098bfa091b0e46478da1222aac527803fa8daa6bc57ede33fb1720688d2f5c794c300412d5e3e42dd32a4a3d948e2534322fa1f591d41378421d817aa6c909719f077fe410df11a4240923013119492ad2f5359056742f2aef7303f8439c66232
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 07ea0db629e58978271f50224ec6a2d9
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: fdb1e44856241333527c1aad4f3932fd
+        SHA1: 96f91b910bd5be2f2ed088d4b8d0f891d56e0755
+        SHA256: 26e1608fb1c5620aec95b97613e7110d7adbe2a856605c56bede6cc9d26da191
+        SHA384: 77ba85f1144431f2e8e3b7ee1d586bcd497212a3b157b01df228f55e876791dc849d0a77e90ef6fa40a071eeff097658
+    Signer:
+    - SerialNumber: 07ea0db629e58978271f50224ec6a2d9
+      Issuer: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      Version: 1

--- a/yaml/98b064c4-c9ff-4cac-a6b6-a24964b70923.yaml
+++ b/yaml/98b064c4-c9ff-4cac-a6b6-a24964b70923.yaml
@@ -10,13 +10,20 @@ Commands:
   Command: sc.exe create chinese_cheat_driver binPath=C:\windows\temp\chinese_cheat_driver.sys
     type=kernel && sc.exe start chinese_cheat_driver
   Description: chinese_cheat_driver.sys is a vulnerable kernel driver from the KeServiceDescriptorTable/vulnerable-drivers
-    repository. The driver exposes dangerous kernel primitives to usermode.
+    repository. The driver exposes dangerous kernel primitives to usermode. Public
+    exploit research documents IOCTL 0x222000 for arbitrary kernel virtual memory
+    reads, IOCTL 0x222018 for physical memory reads, and IOCTL 0x22201C for physical
+    memory writes, which can be chained for local privilege escalation from an administrator
+    context to NT AUTHORITY\SYSTEM.
   Usecase: Elevate privileges
   Privileges: kernel
   OperatingSystem: Windows 10
 Resources:
 - https://github.com/magicsword-io/LOLDrivers/issues/325
+- https://github.com/magicsword-io/LOLDrivers/issues/351
 - https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+- https://github.com/Haider303/facebook-media-driver-exploit
+- https://medium.com/@haider303mustafa/exploiting-a-signed-vulnerable-kernel-driver-for-ring-0-privilege-escalation-678fe2054d6a
 Detection: []
 Acknowledgement:
   Person: ''


### PR DESCRIPTION
## Summary
- Add `xkpsm.sys` from #343 with the reported process-termination IOCTL context and a verified LFS sample.
- Add `LnvMSRIO.sys` for CVE-2025-8061 from #242 with Lenovo Dispatcher 3.1.0.36 and 3.1.0.35 samples, public research references, and extracted PE metadata.
- Enrich the existing `chinese_cheat_driver.sys` entry with #351's public PoC/writeup details and IOCTL notes.
- Clarify YARA generator wording to describe resource `VersionInfo` values instead of PE header values.

Closes #242
Closes #343
Closes #351
Refs #131

## Validation
- `python3 bin/validate.py`
- `python3 -m py_compile bin/yara-generator/yara-generator.py bin/validate.py bin/metadata-extractor.py`
