### PR TITLE
Enrich signeddrv, GGProtect64, and Sliff chain entries

### DIFF
--- a/yaml/028aecb5-70d0-4423-87d7-f037a11ef1c9.yaml
+++ b/yaml/028aecb5-70d0-4423-87d7-f037a11ef1c9.yaml
@@ -9,18 +9,27 @@ Category: vulnerable driver
 Commands:
   Command: sc.exe create signeddrv binPath=C:\windows\temp\signeddrv.sys type=kernel
     && sc.exe start signeddrv
-  Description: signeddrv.sys is a vulnerable kernel driver from the KeServiceDescriptorTable/vulnerable-drivers
-    repository. The driver exposes dangerous kernel primitives to usermode.
+  Description: signeddrv.sys is a Microsoft-signed vulnerable kernel driver that
+    exposes an unrestricted \\.\WinNotify device. Public research documents IOCTL
+    0x22200C for kernel base disclosure, IOCTL 0x222040 for arbitrary kernel
+    read, and IOCTL 0x222044 for arbitrary kernel write, enabling local privilege
+    escalation.
   Usecase: Elevate privileges
   Privileges: kernel
   OperatingSystem: Windows 10
 Resources:
 - https://github.com/magicsword-io/LOLDrivers/issues/325
+- https://github.com/magicsword-io/LOLDrivers/issues/367
+- https://github.com/magicsword-io/LOLDrivers/issues/370
 - https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+- https://github.com/Haider303/winnotify-exp
+- https://github.com/Haider303/sliff-driv-exploit
+- https://medium.com/@haider303mustafa/winnotify-signeddrv-sys-full-local-privilege-escalation-via-arbitrary-kernel-read-write-09e0c1ababf3
+- https://medium.com/@haider303mustafa/applockerflter-sliffdriver-sys-full-kernel-exploit-chain-from-driver-recon-to-system-shell-b57d87738308
 Detection: []
 Acknowledgement:
   Person: ''
-  Handle: '@rainbowdynamix, @DbgPrint'
+  Handle: '@rainbowdynamix, @DbgPrint, @Haider303'
 KnownVulnerableSamples:
 - Filename: signeddrv.sys
   MD5: e052ac7d39d07f6657cf049aae0c5b60

--- a/yaml/13d67487-8c65-47bb-a3d3-d799b5f7533b.yaml
+++ b/yaml/13d67487-8c65-47bb-a3d3-d799b5f7533b.yaml
@@ -9,18 +9,24 @@ Category: vulnerable driver
 Commands:
   Command: sc.exe create GGProtect64 binPath=C:\windows\temp\GGProtect64.sys type=kernel
     && sc.exe start GGProtect64
-  Description: GGProtect64.sys is a vulnerable kernel driver from the KeServiceDescriptorTable/vulnerable-drivers
-    repository. The driver exposes dangerous kernel primitives to usermode.
-  Usecase: Elevate privileges
+  Description: GGProtect64.sys is a Microsoft-signed anticheat kernel driver for
+    GG租号 that exposes a \\.\GGProtect64 device. Public research documents a
+    bypassable caller-registration flow through IOCTL 0x223C14 and a privileged
+    process termination path through IOCTL 0x223C04, allowing a local process to
+    terminate or suspend protected processes from kernel mode.
+  Usecase: Terminate or suspend protected processes
   Privileges: kernel
   OperatingSystem: Windows 10
 Resources:
 - https://github.com/magicsword-io/LOLDrivers/issues/325
+- https://github.com/magicsword-io/LOLDrivers/issues/368
 - https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+- https://github.com/Haider303/GGProtect-exploit
+- https://medium.com/@haider303mustafa/bypassing-weak-driver-authentication-to-kill-ppl-protected-processes-ggprotect64-sys-analysis-d8f44c5837b4
 Detection: []
 Acknowledgement:
   Person: ''
-  Handle: '@rainbowdynamix, @DbgPrint'
+  Handle: '@rainbowdynamix, @DbgPrint, @Haider303'
 KnownVulnerableSamples:
 - Filename: GGProtect64.sys
   MD5: b6a0d03122bd968b40ce97c145b491c7

--- a/yaml/430f94b4-69e8-4541-bea7-329be7d283b7.yaml
+++ b/yaml/430f94b4-69e8-4541-bea7-329be7d283b7.yaml
@@ -9,18 +9,24 @@ Category: vulnerable driver
 Commands:
   Command: sc.exe create lsigetwin_SliffDriver binPath=C:\windows\temp\lsigetwin_SliffDriver.sys
     type=kernel && sc.exe start lsigetwin_SliffDriver
-  Description: lsigetwin_SliffDriver.sys is a vulnerable kernel driver from the KeServiceDescriptorTable/vulnerable-drivers
-    repository. The driver exposes dangerous kernel primitives to usermode.
+  Description: lsigetwin_SliffDriver.sys is a Microsoft-signed vulnerable kernel
+    driver that exposes a \\.\SliffDriver device. Public research documents IOCTL
+    0x80002004 for mapping caller-supplied physical memory into user mode, enabling
+    local privilege escalation when chained with kernel address discovery and
+    virtual-to-physical translation primitives.
   Usecase: Elevate privileges
   Privileges: kernel
   OperatingSystem: Windows 10
 Resources:
 - https://github.com/magicsword-io/LOLDrivers/issues/325
+- https://github.com/magicsword-io/LOLDrivers/issues/370
 - https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+- https://github.com/Haider303/sliff-driv-exploit
+- https://medium.com/@haider303mustafa/applockerflter-sliffdriver-sys-full-kernel-exploit-chain-from-driver-recon-to-system-shell-b57d87738308
 Detection: []
 Acknowledgement:
   Person: ''
-  Handle: '@rainbowdynamix, @DbgPrint'
+  Handle: '@rainbowdynamix, @DbgPrint, @Haider303'
 KnownVulnerableSamples:
 - Filename: lsigetwin_SliffDriver.sys
   MD5: 49886067cd4221b0b8640cff66157c94

--- a/yaml/7f52f435-d217-4c13-98a4-4fdc6c8516c8.yaml
+++ b/yaml/7f52f435-d217-4c13-98a4-4fdc6c8516c8.yaml
@@ -9,18 +9,23 @@ Category: vulnerable driver
 Commands:
   Command: sc.exe create FoxKeDriver64 binPath=C:\windows\temp\FoxKeDriver64.sys type=kernel
     && sc.exe start FoxKeDriver64
-  Description: FoxKeDriver64.sys is a vulnerable kernel driver from the KeServiceDescriptorTable/vulnerable-drivers
-    repository. The driver exposes dangerous kernel primitives to usermode.
-  Usecase: Elevate privileges
+  Description: FoxKeDriver64.sys is a vulnerable Foxconn kernel driver that exposes
+    a \\.\Fox_FOXONE_Driver device. Public research documents IOCTL 0x2220C0 for
+    translating a caller-supplied virtual address to a physical address, which can
+    support local privilege escalation chains with other vulnerable drivers.
+  Usecase: Translate virtual addresses to physical addresses
   Privileges: kernel
   OperatingSystem: Windows 10
 Resources:
 - https://github.com/magicsword-io/LOLDrivers/issues/325
+- https://github.com/magicsword-io/LOLDrivers/issues/370
 - https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+- https://github.com/Haider303/sliff-driv-exploit
+- https://medium.com/@haider303mustafa/applockerflter-sliffdriver-sys-full-kernel-exploit-chain-from-driver-recon-to-system-shell-b57d87738308
 Detection: []
 Acknowledgement:
   Person: ''
-  Handle: '@rainbowdynamix, @DbgPrint'
+  Handle: '@rainbowdynamix, @DbgPrint, @Haider303'
 KnownVulnerableSamples:
 - Filename: FoxKeDriver64.sys
   MD5: 0215d56bfbc9a947b095aff1c31b53ad


### PR DESCRIPTION
## Summary
- Enrich the existing `signeddrv.sys` entry with WinNotify PoC/write-up references, IOCTL details, and submitter acknowledgement
- Enrich the existing `GGProtect64.sys` entry with process-kill PoC/write-up references, IOCTL details, and submitter acknowledgement
- Enrich the existing `lsigetwin_SliffDriver.sys` and `FoxKeDriver64.sys` entries with Sliff-chain references, device/IOCTL details, and submitter acknowledgement
- Keep the existing sample hashes/binaries because the submitted binaries match cataloged entries

## Validation
- `python3 bin/validate.py`

Closes #367
Closes #368
Closes #370