### PR TITLE
[codex] Fix BlackSnufkin acknowledgement handle

### DIFF
--- a/yaml/3e3067b0-3d74-46fe-9f57-1ae3a0293958.yaml
+++ b/yaml/3e3067b0-3d74-46fe-9f57-1ae3a0293958.yaml
@@ -22,7 +22,7 @@ Resources:
 Detection: []
 Acknowledgement:
   Person: BlackSnufkin
-  Handle: '@BlackSnufkin'
+  Handle: '@BlackSnufkin42'
 KnownVulnerableSamples:
 - Filename: CcProtect.sys
   SHA256: 5f0cfe8357bb52b45068ddbac053e32bc38e6cb5e086746f5402657b0a5cfb1c

--- a/yaml/8f2d3be4-3e25-490f-82bc-0aca16aee101.yaml
+++ b/yaml/8f2d3be4-3e25-490f-82bc-0aca16aee101.yaml
@@ -24,7 +24,7 @@ Resources:
 Detection: []
 Acknowledgement:
   Person: BlackSnufkin
-  Handle: '@BlackSnufkin'
+  Handle: '@BlackSnufkin42'
 KnownVulnerableSamples:
 - Filename: PCTcore64.sys
   SHA256: c76dd87891e3e30db2aed057e7b04c19ca264f434c21f68a7a2d9b17a97aff39

--- a/yaml/96ba5e53-6a40-4813-b6f1-ccce31a883cf.yaml
+++ b/yaml/96ba5e53-6a40-4813-b6f1-ccce31a883cf.yaml
@@ -24,7 +24,7 @@ Resources:
 Detection: []
 Acknowledgement:
   Person: BlackSnufkin
-  Handle: '@BlackSnufkin'
+  Handle: '@BlackSnufkin42'
 KnownVulnerableSamples:
 - Filename: xhunter1.sys
   SHA256: e727d0753d2cd0b2f6eeba4cea53aa10b3ff3ed2afeb78f545fcf6d840f85c3e

--- a/yaml/bffcac17-f20c-43cc-baf0-93fd20bc1ed5.yaml
+++ b/yaml/bffcac17-f20c-43cc-baf0-93fd20bc1ed5.yaml
@@ -22,7 +22,7 @@ Resources:
 Detection: []
 Acknowledgement:
   Person: BlackSnufkin / lukmannurhikma
-  Handle: '@BlackSnufkin / @lukmannurhikma'
+  Handle: '@BlackSnufkin42 / @lukmannurhikma'
 KnownVulnerableSamples:
 - Filename: unknown.sys
   SHA256: 97bd65e98cdc4e93d49edd4ea905d43a61244df0fd3323e6649330de3b1be091


### PR DESCRIPTION
## Summary
- Updates four YAML acknowledgements that referenced `@BlackSnufkin` to the corrected X handle `@BlackSnufkin42`.
- Preserves the combined acknowledgement for `unknown.sys` by changing only the BlackSnufkin side of the handle pair.
- Resolves #372.

## Validation
- `python3 bin/validate.py -y yaml -s bin/spec/drivers.spec.json`
- `git diff --check`

Site and generated detection outputs are not included; the repository workflow regenerates those from YAML on `main`.
