### PR TITLE
[codex] Add OPSWAT AppRemover ardrv driver

### DIFF
--- a/drivers/826c6d2e3d80f2d43f7977f998525ad3.bin
+++ b/drivers/826c6d2e3d80f2d43f7977f998525ad3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07c5209bf83065fe760f4fee4ed2308b0c523671f68ca73a3854c2c8c28c0541
+size 17744

--- a/yaml/9eb0156e-4c43-487f-be8c-40a7b19a4279.yaml
+++ b/yaml/9eb0156e-4c43-487f-be8c-40a7b19a4279.yaml
@@ -1,0 +1,204 @@
+Id: 9eb0156e-4c43-487f-be8c-40a7b19a4279
+Tags:
+- ardrv.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-06-19'
+MitreID: T1068
+CVE:
+- CVE-2026-36425
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create ardrv binPath=C:\windows\temp\ardrv.sys type=kernel && sc.exe
+    start ardrv
+  Description: OPSWAT AppRemover ardrv.sys version 2017.10.02.1551 and earlier exposes
+    a user-accessible \\.\ardrv device. Public research documents IOCTL 0x2420031
+    reaching process-termination paths, including ZwTerminateProcess, without sufficient
+    caller or target validation. This allows local users to terminate arbitrary processes,
+    including security tooling, and makes the driver useful in BYOVD-style defense
+    impairment after it is loaded.
+  Usecase: Terminate arbitrary processes from kernel mode through an insufficiently
+    protected IOCTL handler.
+  Privileges: kernel
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://github.com/redteamfortress/CVE-2026-36425
+- https://github.com/magicsword-io/LOLDrivers/issues/374
+Detection: []
+Acknowledgement:
+  Person: Jehad Abudagga, wwwab
+  Handle: '@j3h4ck, @wwwab123'
+KnownVulnerableSamples:
+- Filename: ardrv.sys
+  MD5: 826c6d2e3d80f2d43f7977f998525ad3
+  SHA1: 7340eae2ccf3d57ac3ae271c9983996d8ae7fde0
+  SHA256: 07c5209bf83065fe760f4fee4ed2308b0c523671f68ca73a3854c2c8c28c0541
+  LoadsDespiteHVCI: 'FALSE'
+  Imphash: 04becf2aed91570c44993f040922303d
+  Authentihash:
+    MD5: 68b2bff40bed9106fe7d684926fae2cc
+    SHA1: cf52d28e919f5034a2d206491742ab21df16e0d4
+    SHA256: c23b96fdf13b405480bbcd2e611cc67d98fd92f92cd2444da73fd8c4a4770393
+  RichPEHeaderHash:
+    MD5: 3b6934b997e6bdf8c7a22007105b190d
+    SHA1: b437f306b8f280d2bc9f878e94cd1d5ed804fdac
+    SHA256: 9e822696e56f37827e85e7bd4934cfdbba5aa80da654025b29bffaa3c028ffd0
+  Sections:
+    .text:
+      Entropy: 5.9269739323177415
+      Virtual Size: '0xeed'
+    .rdata:
+      Entropy: 4.050036833496202
+      Virtual Size: '0x224'
+    .data:
+      Entropy: 0.5159719988134768
+      Virtual Size: '0x110'
+    .pdata:
+      Entropy: 3.5459473662913776
+      Virtual Size: '0x9c'
+    INIT:
+      Entropy: 5.158608395501925
+      Virtual Size: '0x440'
+    .rsrc:
+      Entropy: 3.340466534342975
+      Virtual Size: '0x360'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2017-10-02 16:52:04'
+  Description: AppRemover Driver
+  Company: OPSWAT, Inc.
+  InternalName: ardrv.sys
+  OriginalFilename: ardrv.sys
+  FileVersion: 2017.10.02.1551
+  Product: AppRemover Driver
+  ProductVersion: 4.3.2.1
+  Copyright: " \xA9 OPSWAT, Inc.  All rights reserved."
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - IoDeleteSymbolicLink
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - IoCreateDevice
+  - DbgPrint
+  - ZwAssignProcessToJobObject
+  - PsLookupProcessByProcessId
+  - ProbeForWrite
+  - IoCreateFile
+  - ZwSetValueKey
+  - ZwSetInformationFile
+  - KeDetachProcess
+  - IoFileObjectType
+  - ZwClose
+  - ZwCreateJobObject
+  - ObReferenceObjectByHandle
+  - ZwFlushKey
+  - KeAttachProcess
+  - MmIsAddressValid
+  - ObfDereferenceObject
+  - ZwTerminateProcess
+  - ZwQueryInformationFile
+  - ObOpenObjectByPointer
+  - FsRtlReleaseFile
+  - FsRtlAcquireFileExclusive
+  - ZwTerminateJobObject
+  - ZwOpenKey
+  - KeBugCheckEx
+  - __C_specific_handler
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services CA
+        , G2
+      ValidFrom: '2012-12-21 00:00:00'
+      ValidTo: '2020-12-30 23:59:59'
+      Signature: 03099b8f79ef7f5930aaef68b5fae3091dbb4f82065d375fa6529f168dea1c9209446ef56deb587c30e8f9698d23730b126f47a9ae3911f82ab19bb01ac38eeb599600adce0c4db2d031a6085c2a7afce27a1d574ca86518e979406225966ec7c7376a8321088e41eaddd9573f1d7749872a16065ea6386a2212a35119837eb6
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 7e93ebfb7cc64e59ea4b9a77d406fc3b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: d0785ad36e427c92b19f6826ab1e8020
+        SHA1: 365b7a9c21bd9373e49052c3e7b3e4646ddd4d43
+        SHA256: c2abb7484da91a658548de089d52436175fdb760a1387d225611dc0613a1e2ff
+        SHA384: eab4fe5ef90e0de4a6aa3a27769a5e879f588df5e4785aa4104debd1f81e19ea56d33e3a16e5facf99f68b5d8e3d287b
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services Signer
+        , G4
+      ValidFrom: '2012-10-18 00:00:00'
+      ValidTo: '2020-12-29 23:59:59'
+      Signature: 783bb4912a004cf08f62303778a38427076f18b2de25dca0d49403aa864e259f9a40031cddcee379cb216806dab632b46dbff42c266333e449646d0de6c3670ef705a4356c7c8916c6e9b2dfb2e9dd20c6710fcd9574dcb65cdebd371f4378e678b5cd280420a3aaf14bc48829910e80d111fcdd5c766e4f5e0e4546416e0db0ea389ab13ada097110fc1c79b4807bac69f4fd9cb60c162bf17f5b093d9b5be216ca13816d002e380da8298f2ce1b2f45aa901af159c2c2f491bdb22bbc3fe789451c386b182885df03db451a179332b2e7bb9dc20091371eb6a195bcfe8a530572c89493fb9cf7fc9bf3e226863539abd6974acc51d3c7f92e0c3bc1cd80475
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0ecff438c8febf356e04d86a981b1a50
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: e9d38360b914c8863f6cba3ee58764d3
+        SHA1: 4cba8eae47b6bf76f20b3504b98b8f062694a89b
+        SHA256: 88901d86a4cc1f1bb193d08e1fb63d27452e63f83e228c657ab1a92e4ade3976
+        SHA384: e9f2a75334a9e336c5a4712eadee88d0374b0fdc273262f4e65c9040ad2793067cc076696db5279a478773485e285652
+    - Subject: C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec
+        Class 3 SHA256 Code Signing CA
+      ValidFrom: '2013-12-10 00:00:00'
+      ValidTo: '2023-12-09 23:59:59'
+      Signature: 13851a1e69a937f7a0bda4af7e1d6153fe9d8c5e0ca6751e781723ddfdec1a035539fb7195c7655aa78e30d2445a61db706fda2105c22e73ba49f1d193fe5dc9cd5e03e0899e3f741ed7f7388ba9d6cfbb352f3358a89256d1c84d3b82e6798416fc28b0b147f31da23eee87d9a67fa456a53fad842e29de7cbca8aaa33d0401eaba93a20e502229174c87e43a115fd6a425899b056b2fb4c9014c277b0bac190522a060153fdac9fb4d4c8ffb726777fd2794c7ba350e8849fe8dfd28af4a12bd0db39705de440c15fa362b03dcc15001f1a1115d14e5e2bd274b54be2b845e0fa6c374050aef97c38922b11f77f3bdcd43d4f14ca93fb58b84af64f2d01421
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 3d78d7f9764960b2617df4f01eca862a
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 1f056ff7d5f874984dc605402b7cb042
+        SHA1: bdb348353a2203deb4b767914fa1bd7248dd728b
+        SHA256: a08e79c386083d875014c409c13d144e0a24386132980df11ff59737c8489eb1
+        SHA384: fa2729064b49e0d77540c1ee95d5f74acaf8eaf55197851a3a40383335f8113e51190bc48b552196edf8ac5cf0c89278
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=(c) 2006 VeriSign,
+        Inc. , For authorized use only, CN=VeriSign Class 3 Public Primary Certification
+        Authority , G5
+      ValidFrom: '2011-02-22 19:25:17'
+      ValidTo: '2021-02-22 19:35:17'
+      Signature: 812a82168c34672be503eb347b8ca2a3508af45586f11e8c8eae7dee0319ce72951848ad6211fd20fd3f4706015ae2e06f8c152c4e3c6a506c0b36a3cf7a0d9c42bc5cf819d560e369e6e22341678c6883762b8f93a32ab57fbe59fba9c9b2268fcaa2f3821b983e919527978661ee5b5d076bcd86a8e26580a8e215e2b2be23056aba0cf347934daca48c077939c061123a050d89a3ec9f578984fbecca7c47661491d8b60f195de6b84aacbc47c8714396e63220a5dc7786fd3ce38b71db7b9b03fcb71d3264eb1652a043a3fa2ead59924e7cc7f233424838513a7c38c71b242228401e1a461f17db18f7f027356cb863d9cdb9645d2ba55eefc629b4f2c7f821cc04ba57fd01b6abc667f9e7d3997ff4f522fa72f5fdff3a1c423aa1f98018a5ee8d1cd4669e4501feaaeefffb178f30f7f1cd29c59decb5d549003d85b8cbbb933a276a49c030ae66c9f723283276f9a48356c848ce5a96aaa0cc0cc47fb48e97af6de35427c39f86c0d6e473089705dbd054625e0348c2d59f7fa7668cd09db04fd4d3985f4b7ac97fb22952d01280c70f54b61e67cdc6a06c110384d34875e72afeb03b6e0a3aa66b769905a3f177686133144706fc537f52bd92145c4a246a678caf8d90aad0f679211b93267cc3ce1ebd883892ae45c6196a4950b305f8ae59378a6a250394b1598150e8ba8380b72335f476b9671d5918ad208d94
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 611993e400000000001c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 78a717e082dcc1cda3458d917e677d14
+        SHA1: 4a872e0e51f9b304469cd1dedb496ee9b8b983a4
+        SHA256: 317fa1d234ebc49040ebc5e8746f8997471496051b185a91bdd9dfbb23fab5f8
+        SHA384: b71052da4eb9157c8c1a5d7f55df19d69b9128598b72fcca608e5b7cc7d64c43c5504b9c86355a6dc22ee40c88cc385c
+    - Subject: C=US, ST=California, L=San Francisco, O=OPSWAT, Inc., CN=OPSWAT, Inc.
+      ValidFrom: '2015-06-02 00:00:00'
+      ValidTo: '2018-08-31 23:59:59'
+      Signature: 00b224b0896ac046b130e7a9af612e0c92ce6fa6f465ae4b5dc422432d880c3ef15357c56c0db528c8ca2055263c8a3857988ce32dcc13e1578b0493d6dec39d734547eef1e37a3ac334ba5979ae0b5ab7b2c8d75323076d8cd50b68fbb8c5e47e95d359b9a4be08ba4ada34eb70f4a27ed9b4d285e285c338d19f2ef15321301b9337bfa3549e16a189aa28af9e96bff5c1b083a57e89259c9a369f72dc312db3a04334a099006c54279a7ca199b2c94a79f198def484fbf7cb8f9d8cd6df8bcf97c33c79991ed92ac2080db67741aabfa7bc41fd426fc06f2c5f0594471245777401d169c91355784699b8f1b61eb857835083c4755b8244774b231fd19610
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 1ca9cc01747a11b1eaaf103c8d9a9e6c
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 222b2be1297ccd28fe05de06d1d9254f
+        SHA1: 47a67d8afd2c756e021a6547e66e4928ba32f53a
+        SHA256: 1eb2656b465452860774b29579998a45ffe61caebf4e77dc4fbf1bbdffb41340
+        SHA384: 3cba4aa32bfb91c8eedf6933c3e6e9dcc5a11b257fe2f71f790f2cd3db65a7e6cd865ef3e1b31b82af4a328433a4a663
+    Signer:
+    - SerialNumber: 1ca9cc01747a11b1eaaf103c8d9a9e6c
+      Issuer: C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec
+        Class 3 SHA256 Code Signing CA
+      Version: 1

--- a/yaml/9eb0156e-4c43-487f-be8c-40a7b19a4279.yaml
+++ b/yaml/9eb0156e-4c43-487f-be8c-40a7b19a4279.yaml
@@ -33,7 +33,7 @@ KnownVulnerableSamples:
   MD5: 826c6d2e3d80f2d43f7977f998525ad3
   SHA1: 7340eae2ccf3d57ac3ae271c9983996d8ae7fde0
   SHA256: 07c5209bf83065fe760f4fee4ed2308b0c523671f68ca73a3854c2c8c28c0541
-  LoadsDespiteHVCI: 'FALSE'
+  LoadsDespiteHVCI: 'TRUE'
   Imphash: 04becf2aed91570c44993f040922303d
   Authentihash:
     MD5: 68b2bff40bed9106fe7d684926fae2cc


### PR DESCRIPTION
## Summary

Adds the OPSWAT AppRemover `ardrv.sys` driver reported in #374.

- adds the vulnerable `ardrv.sys` sample as a Git LFS-backed driver object
- adds an enriched YAML entry for `CVE-2026-36425`
- documents the public advisory context: the user-accessible `\\.\ardrv` device and IOCTL `0x2420031` process-termination path, including `ZwTerminateProcess`

Closes #374

## Validation

- `python3 bin/validate.py -y yaml -s bin/spec/drivers.spec.json`
- `git diff --cached --check`
- `git lfs status`
- confirmed the staged driver is an LFS pointer for SHA-256 `07c5209bf83065fe760f4fee4ed2308b0c523671f68ca73a3854c2c8c28c0541`
