### PR TITLE
Add Gentlemen EDR killer driver coverage

### DIFF
--- a/drivers/07e9f0b8627a95960e79e930fb099e84.bin
+++ b/drivers/07e9f0b8627a95960e79e930fb099e84.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d91a78e739891c9854c254f5b2a6b84c0e167dfa253466cbccd2cdd1c20145d
+size 19672

--- a/drivers/40f64b91348bed955acf8551853b72a8.bin
+++ b/drivers/40f64b91348bed955acf8551853b72a8.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d769a5f1ad0d32fb4e06478d35401d9788bad1a477b813adbdf4fd93b2c2694
+size 107584

--- a/drivers/5f8df2c0389ead04ce2e69d632edcdbd.bin
+++ b/drivers/5f8df2c0389ead04ce2e69d632edcdbd.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6ee01303cf1d68015eee49f7dc7f26151a04ae642a47e49c70806931ce652d3
+size 116936

--- a/drivers/75590850346c74a95d505ea3f8ff4a75.bin
+++ b/drivers/75590850346c74a95d505ea3f8ff4a75.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef4e4b88df24825dbf4e7131e71a41002715d38b7a8c0c432aa936c854152ef3
+size 20856

--- a/drivers/eef8a950952696b018aa9c6da2f5d7ad.bin
+++ b/drivers/eef8a950952696b018aa9c6da2f5d7ad.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5abe477517f51d81061d2e69a9adebdcda80d36667d0afabe103fda4802d33db
+size 47240

--- a/yaml/2c7d54ff-7b49-4da8-ae77-00ac6fa2944f.yaml
+++ b/yaml/2c7d54ff-7b49-4da8-ae77-00ac6fa2944f.yaml
@@ -1,6 +1,7 @@
 Id: 2c7d54ff-7b49-4da8-ae77-00ac6fa2944f
 Tags:
 - HWAuidoOs2Ec.sys
+- havoc.sys
 Verified: 'TRUE'
 Author: Michael Haag
 Created: '2026-04-17'
@@ -19,6 +20,9 @@ Resources:
 - https://github.com/magicsword-io/LOLDrivers/issues/325
 - https://github.com/KeServiceDescriptorTable/vulnerable-drivers
 - https://www.security.com/threat-intelligence/dragonforce-msteams-backdoor
+- https://www.huntress.com/blog/w2-malvertising-to-kernel-mode-edr-kill
+- https://www.welivesecurity.com/en/eset-research/killing-me-gently-inside-gentlemens-edr-killer-framework/
+- https://github.com/magicsword-io/LOLDrivers/issues/377
 Detection: []
 Acknowledgement:
   Person: ''
@@ -170,3 +174,15 @@ KnownVulnerableSamples:
       Version: 1
   LoadsDespiteHVCI: 'TRUE'
   Imphash: 9cfa9662095195fc2607e952710e62ae
+- Filename: havoc.sys
+  MD5: eef8a950952696b018aa9c6da2f5d7ad
+  SHA1: 1fa071303fb846308571e64727501fb98b1c2be6
+  SHA256: 5abe477517f51d81061d2e69a9adebdcda80d36667d0afabe103fda4802d33db
+  Filesize: 47240
+  Signature: Signed
+  Company: Huawei Device Co., Ltd.
+  Description: HWAuidoOs2Ec
+  Product: Huawei Audio Driver
+  ProductVersion: 1.0.0.0
+  FileVersion: 1.0.0.0
+  OriginalFilename: HWAuidoOs2Ec.sys

--- a/yaml/2c7d54ff-7b49-4da8-ae77-00ac6fa2944f.yaml
+++ b/yaml/2c7d54ff-7b49-4da8-ae77-00ac6fa2944f.yaml
@@ -186,3 +186,189 @@ KnownVulnerableSamples:
   ProductVersion: 1.0.0.0
   FileVersion: 1.0.0.0
   OriginalFilename: HWAuidoOs2Ec.sys
+  Imphash: 543809105fd767866c03705a39fb25a8
+  Authentihash:
+    MD5: 1e4bd23e6cd64176a5602600c92398b6
+    SHA1: 129a114d49191b7b8663f3e84af8848458fe1e8a
+    SHA256: 097e26ab94ce6ac36fe5713e0120c805edb048e30bcfa317fd7025f50b761e92
+  RichPEHeaderHash:
+    MD5: 46c2fd23a66e7b916e2783e27e89503f
+    SHA1: 2ba2dc432cd157097970a01333dfe5ce93f94330
+    SHA256: 355290ae40ad0699b4c2d5d80639cd97c98b6f42664efbf37f0f6279b138f27e
+  Sections:
+    .text:
+      Entropy: 6.35819946938083
+      Virtual Size: '0x2ed4'
+    .rdata:
+      Entropy: 4.401761607315822
+      Virtual Size: '0xec4'
+    .data:
+      Entropy: 1.4047598783637012
+      Virtual Size: '0x61c'
+    .pdata:
+      Entropy: 4.257343383367369
+      Virtual Size: '0x450'
+    PAGE:
+      Entropy: 6.237332725680902
+      Virtual Size: '0x1ea0'
+    INIT:
+      Entropy: 5.3553386411676245
+      Virtual Size: '0x976'
+    .rsrc:
+      Entropy: 3.313302820377281
+      Virtual Size: '0x3a0'
+    .reloc:
+      Entropy: 3.6635907381239066
+      Virtual Size: '0x34'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2021-11-15 19:49:21'
+  InternalName: HWAuidoOs2Ec
+  Copyright: "Copyright \xA9 Huawei Device Co., Ltd. All rights reserved."
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - memcpy_s
+  - wcscat_s
+  - ExAllocatePoolWithTag
+  - ExFreePoolWithTag
+  - MmMapIoSpace
+  - MmUnmapIoSpace
+  - IoWMIOpenBlock
+  - IoWMIQueryAllData
+  - IoWMIExecuteMethod
+  - ObfDereferenceObject
+  - MmGetSystemRoutineAddress
+  - RtlGetVersion
+  - ObReferenceObjectByHandle
+  - ZwClose
+  - ZwTerminateProcess
+  - ZwOpenProcess
+  - __C_specific_handler
+  - PsProcessType
+  - RtlTimeToTimeFields
+  - KeInitializeEvent
+  - ExAcquireFastMutex
+  - ExReleaseFastMutex
+  - ExSystemTimeToLocalTime
+  - PsSetCreateProcessNotifyRoutineEx
+  - KeSetEvent
+  - KeWaitForMultipleObjects
+  - KeWaitForSingleObject
+  - PsCreateSystemThread
+  - PsTerminateSystemThread
+  - _wcsnicmp
+  - InitSafeBootMode
+  - ZwOpenKey
+  - ZwQueryValueKey
+  - ObOpenObjectByPointer
+  - IoDeleteSymbolicLink
+  - ZwSetSecurityObject
+  - IoDeviceObjectType
+  - IoCreateDevice
+  - RtlGetDaclSecurityDescriptor
+  - RtlGetGroupSecurityDescriptor
+  - RtlGetOwnerSecurityDescriptor
+  - RtlGetSaclSecurityDescriptor
+  - SeCaptureSecurityDescriptor
+  - _snwprintf
+  - RtlLengthSecurityDescriptor
+  - SeExports
+  - RtlCreateSecurityDescriptor
+  - wcschr
+  - RtlAbsoluteToSelfRelativeSD
+  - RtlAddAccessAllowedAce
+  - RtlLengthSid
+  - IoIsWdmVersionAvailable
+  - RtlSetDaclSecurityDescriptor
+  - ZwSetValueKey
+  - ZwCreateKey
+  - RtlFreeUnicodeString
+  - IoDeleteDevice
+  - IoCreateSymbolicLink
+  - RtlCopyUnicodeString
+  - IofCompleteRequest
+  - DbgPrint
+  - RtlInitUnicodeString
+  - HalGetBusDataByOffset
+  - WdfVersionBind
+  - WdfVersionUnbind
+  - WdfVersionUnbindClass
+  - WdfVersionBindClass
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=BE, O=GlobalSign nv,sa, CN=GlobalSign CodeSigning CA , SHA256 , G3
+      ValidFrom: '2016-06-15 00:00:00'
+      ValidTo: '2024-06-15 00:00:00'
+      Signature: 1584280ceda1c31982db632741d7cc637dd6bccf369bcfd25d4c028b581a16087ab198997fd8338a5c9e620a9aea90c2c563040be887580600078259c3a89432d9e0144da0d523e0c7ddbaf069e24a45652d4d49907866320eb068c0b088b08eed5c06f85c10483f2373ba3b53845280cdf0b315c8110a8b0578465908d4beb7ff4bf59c6a4c9c76a21185458cd437ee50dde13334a9a11f3a0bf156448a6fb333d0b18ed10c6007ee32c2f0246fbfaffb81017667c4a3e8e0abdc335528e367473ceb6aa4df94e9f4a6c081d1529851a6d602b73cea4aefd0ba65d23783534b7e677c8c40f6071cb0af0406dcf86c4688729ceb4e9dc3b0b954a3b94e97ca14
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 481b6a0726d2e83f2602d4825acd
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: b35d3f705a99b93f2a1ade225053ed44
+        SHA1: 4f1dda8d1357ab594cec773c66c05e4bc8085801
+        SHA256: 06936bac8d2f85d9ce6f7348ea421a1a949219182845192667b0e671fe0e4285
+        SHA384: d62c8126b964a1f15546d741362aa5cf56c08a0e998b12f9554dc0ff4dc9d10294f9dfa325c8727d48754ff36b3a9a3b
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Timestamp 2021
+      ValidFrom: '2021-01-01 00:00:00'
+      ValidTo: '2031-01-06 00:00:00'
+      Signature: 481cdcb5e99a23bce71ae7200e8e6746fd427251740a2347a3ab92d225c47059be14a0e52781a54d1415190779f0d104c386d93bbdfe4402664ded69a40ff6b870cf62e8f5514a7879367a27b7f3e7529f93a7ed439e7be7b4dd412289fb87a246034efcf4feb76477635f2352698382fa1a53ed90cc8da117730df4f36539704bf39cd67a7bda0cbc3d32d01bcbf561fc75080076bc810ef8c0e15ccfc41172e71b6449d8229a751542f52d323881daf460a2bab452fb5ce06124254fb2dfc929a8734351dabd63d61f5b9bf72e1b4f131df74a0d717e97b7f43f84ebc1e3a349a1facea7bf56cfba597661895f7ea7b48e6778f93698e1cb28da5b87a68a2f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 0d424ae0be3a88ff604021ce1400f0dd
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: c0189c338449a42fe8358c2c1fbecc60
+        SHA1: b8ac0ee6875594b80ad86a6df6dd1fa3048c187c
+        SHA256: a43de6baf968a942da017b70769fdb65b3cfb1bbca1f9174da26a7d8aae78ec5
+        SHA384: 76d3a316a5a106050298418cce3beea16100524723d9e3220b0de51bfb6f1c35a5d4c7cd10b358fef7bf94c3e3562150
+    - Subject: C=CN, ST=Guangdong, L=Dongguan, O=Huawei Device Co., Ltd., OU=IT Dept.,
+        CN=Huawei Device Co., Ltd.
+      ValidFrom: '2020-04-08 08:30:19'
+      ValidTo: '2023-04-09 08:30:19'
+      Signature: 562b6781159871db5a287d36a4faa5c04c039986bcee3f74a646d55cad7c5a9ed549279f5473bf39b7f0da2a8602542304eadedd6c118ded09a4db326cd0c1913d376df0803548a6820419ff4fd6e84966ec814315be2e780ec7194d3ce711c40ba6041437d86b07bfa6a193ed0ff61e4a1989a19ffe5e423d10421665d4f6a8bf810f3c516bc325ba00e87f2f4d2e08db325537a049c1546a51edf4fb037e291e5039c777afcb26cd4ad176055d8bb15ed5ae9d407e1b2be7d6d6ed832e088a843c058b9968fea30aa8a65f4f776b7f893055567c976a3b6eadd1b6d264986f590c415d950db2522b8918b2245d344c7ad54899dba116e3dd00b1888716dbeb
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 4b18d6298c19a073602b9e7b
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 71bdbc8a54046f3058155c9e75814db7
+        SHA1: aa25f4b5fbeda167fa4308b99acb47a729cc5787
+        SHA256: b5cfc93fce74edf4d63259ad1e0da3e8d115f22723c7f260248337f08144e5b6
+        SHA384: 6e32db4a37a11ad97e66ae8026979bf32988db16ab723c268086e5e9870d88953000a2c65526d64a7406179571abe3ec
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 Assured
+        ID Timestamping CA
+      ValidFrom: '2016-01-07 12:00:00'
+      ValidTo: '2031-01-07 12:00:00'
+      Signature: 719512e951875669cdefddda7caa637ab378cf06374084ef4b84bfcacf0302fdc5a7c30e20422caf77f32b1f0c215a2ab705341d6aae99f827a266bf09aa60df76a43a930ff8b2d1d87c1962e85e82251ec4ba1c7b2c21e2d65b2c1435430468b2db7502e072c798d63c64e51f4810185f8938614d62462487638c91522caf2989e5781fd60b14a580d7124770b375d59385937eb69267fb536189a8f56b96c0f458690d7cc801b1b92875b7996385228c61ca79947e59fc8c0fe36fb50126b66ca5ee875121e458609bba0c2d2b6da2c47ebbc4252b4702087c49ae13b6e17c424228c61856cf4134b6665db6747bf55633222f2236b24ba24a95d8f5a68e52
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 0aa125d6d6321b7e41e405da3697c215
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 8d26184fc613f89aba1cefb30fce1b53
+        SHA1: 63a7e376bad5ec2e419d514a403bcf46c8d31d95
+        SHA256: 56b5f0d9db578e3f142921daa387902722a76700375c7e1c4ae0ba004bacaa0c
+        SHA384: d8c9691fe9dbe182f07b49b07fbb4f589fa7b38b5c4d21f265d3a2e818f4b1bfb39e03faab2ec05bb10333a99914fb8a
+    Signer:
+    - SerialNumber: 4b18d6298c19a073602b9e7b
+      Issuer: C=BE, O=GlobalSign nv,sa, CN=GlobalSign CodeSigning CA , SHA256 , G3
+      Version: 1

--- a/yaml/6ca608ec-df2e-4a8d-8a0b-350f9e0271ab.yaml
+++ b/yaml/6ca608ec-df2e-4a8d-8a0b-350f9e0271ab.yaml
@@ -1,0 +1,168 @@
+Id: 6ca608ec-df2e-4a8d-8a0b-350f9e0271ab
+Tags:
+- IMFForceDelete
+- IMFForceDelete.sys
+- ForceDelete.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-06-22'
+MitreID: T1562.001
+CVE:
+- CVE-2019-6494
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create IMFForceDelete binPath=C:\windows\temp\IMFForceDelete.sys
+    type=kernel && sc.exe start IMFForceDelete
+  Description: IObit Malware Fighter IMFForceDelete.sys is a vulnerable force-delete
+    filter driver. ESET documents GentleKiller's Cleaner variant dropping this driver
+    without the trailing .sys extension, and CVE-2019-6494 describes IOCTL 0x8016E000
+    allowing low-privileged users to delete files regardless of access controls.
+  Usecase: Delete protected files and impair defenses through a vulnerable kernel
+    driver.
+  Privileges: kernel
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://www.welivesecurity.com/en/eset-research/killing-me-gently-inside-gentlemens-edr-killer-framework/
+- https://www.eset.com/us/about/newsroom/research/eset-research-gentlemen-ransomware-gang-edr-killers/
+- https://github.com/magicsword-io/LOLDrivers/issues/377
+- https://nvd.nist.gov/vuln/detail/CVE-2019-6494
+- https://github.com/advisories/GHSA-rj7p-8gjh-5gqf
+Detection: []
+Acknowledgement:
+  Person: ESET Research, 0xd3vnull
+  Handle: '@ESETresearch, @0xd3vnull'
+KnownVulnerableSamples:
+- Filename: IMFForceDelete.sys
+  MD5: 75590850346c74a95d505ea3f8ff4a75
+  SHA1: 12500f6c87ce62712a0ed6652c57468d15c14223
+  SHA256: ef4e4b88df24825dbf4e7131e71a41002715d38b7a8c0c432aa936c854152ef3
+  Imphash: 7816745e971bb8da69822ba11f0b6c0c
+  Authentihash:
+    MD5: 91745beee76b54a6e5101c031c03833b
+    SHA1: 58118cdd342ebd74ec8bef20ad2da155d2d701fd
+    SHA256: f003c8abf8a692de770eb3bb8babec8c72f836d856f9c96f4de30e3ab47fea0f
+  RichPEHeaderHash:
+    MD5: c59742756e448e47b7673ded67c45d30
+    SHA1: c3ca9eea968c480ca30e203a6f02217975bf11fc
+    SHA256: aeaa5c0937ebafe5e6c743e443fddcc92494ab90c4cba7d3434270332c6bd43d
+  Sections:
+    .text:
+      Entropy: 6.182311569738715
+      Virtual Size: '0x1047'
+    .rdata:
+      Entropy: 5.163965659867767
+      Virtual Size: '0x324'
+    .data:
+      Entropy: 0.30140680731160896
+      Virtual Size: '0x1110'
+    .pdata:
+      Entropy: 3.5988696353179748
+      Virtual Size: '0xb4'
+    INIT:
+      Entropy: 5.086052316781448
+      Virtual Size: '0x388'
+    .rsrc:
+      Entropy: 3.280523564332369
+      Virtual Size: '0x388'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2022-08-02 01:57:01'
+  Description: IMF ForceDelete filter driver
+  Company: IObit
+  InternalName: ForceDelete.sys
+  OriginalFilename: ForceDelete.sys
+  FileVersion: '7.0.0.5 built by: WinDDK'
+  Product: IObit Malware Fighter
+  ProductVersion: 7.0.0.5
+  Copyright: "\xA9 IObit. All rights reserved."
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ExAllocatePoolWithTag
+  - IoDeleteSymbolicLink
+  - ExFreePoolWithTag
+  - IoGetRelatedDeviceObject
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - KeSetEvent
+  - IoCreateFile
+  - KeInitializeEvent
+  - RtlUnicodeStringToAnsiString
+  - RtlUTF8ToUnicodeN
+  - IoFileObjectType
+  - ZwClose
+  - IofCompleteRequest
+  - ObReferenceObjectByHandle
+  - KeWaitForSingleObject
+  - IoFreeIrp
+  - IoAllocateIrp
+  - IoCreateSymbolicLink
+  - ObfDereferenceObject
+  - IoCreateDevice
+  - DbgPrint
+  - IofCallDriver
+  - KeBugCheckEx
+  - __C_specific_handler
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert High Assurance
+        EV Root CA
+      ValidFrom: '2011-04-15 19:45:33'
+      ValidTo: '2021-04-15 19:55:33'
+      Signature: 208cc159ed6f9c6b2dc14a3e751d454c41501cbd80ead9b0928b062a133f53169e56396a8a63b6782479f57db8b947a10a96c2f6cbbda2669f06e1acd279090efd3cdcac020c70af3f1bec787ed4eb4b056026d973619121edb06863e09712ab6fa012edd99fd2da273cb3e456f9d1d4810f71bd427ca689dccdd5bd95a2abf193117de8ac3129a85d6670419dfc75c9d5b31a392ad08505508bac91cac493cb71a59da4946f580cfa6e20c40831b5859d7e81f9d23dca5b18856c0a86ec22091ba574344f7f28bc954aab1db698b05d09a477767eefa78e5d84f61824cbd16da6c3a19cc2107580ff9d32fde6cf433a82f7ce8fe1722a9b62b75fed951a395c2f946d48b7015f332fbbdc2d73348904420a1c8b79f9a3fa17effaa11a10dfe0b2c195eb5c0c05973b353e18884ddb6cbf24898dc8bdd89f7b393a24a0d5dfd1f34a1a97f6a66f7a1fb090a9b3ac013991d361b764f13e573803afce7ad2b590f5aedc3999d5b63c97eda6cb16c77d6b2a4c9094e64c54fd1ecd20ecce689c8758e96160beeb0ec9d5197d9fe978bd0eac2175078fa96ee08c6a2a6b9ce3e765bcbc2d3c6ddc04dc67453632af0481bca8006e614c95c55cd48e8e9f2fc13274bdbd11650307cdefb75e0257da86d41a2834af8849b2cfa5dd82566f68aa14e25954feffeaeeefea9270226081e32523c09fcc0f49b235aa58c33ac3d9169410
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 61204db4000000000027
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 8e3ffc222fbcebdbb8b23115ab259be7
+        SHA1: ee20bff28ffe13be731c294c90d6ded5aae0ec0e
+        SHA256: 59826b69bc8c28118c96323b627da59aaca0b142cc5d8bad25a8fcfd399aa821
+        SHA384: f2dab7e56a33298654924501499487f6ba72c7d9477476a186e1ed7a9be031fade0e35ac09eff5e56bbbab95ae5374e7
+    - Subject: JURISDICTION_OF_INCORPORATION_C=CN, JURISDICTION_OF_INCORPORATION_SP=Sichuan,
+        JURISDICTION_OF_INCORPORATION_L=Wuhou District, Chengdu, BUSINESS_CATEGORY=Private
+        Organization, serialNumber=91510107072412418F, C=CN, ST=Sichuan, L=Chengdu,
+        O=IObit CO., LTD, CN=IObit CO., LTD
+      ValidFrom: '2019-08-27 00:00:00'
+      ValidTo: '2022-08-30 12:00:00'
+      Signature: 89d53256ccf4b2e50a8e05d88de9ed33f6adde16e143a6f7f042ec4ed9220c7c4195b543ad1ae9c5ae5421f192140d62b28449c83a0c31759765c127fed77c447072976f2d5e8d44e07dafbbc5a0cea9e8020081c3f8a22a1519e53d8c69ff3ffbd7e090e92593a738b8bd6d583b27e5e797672294147fd1b8492683b1b3f202c3e0c571f9fad02d95f8204e054fa722ac42bf21e54ec1891942ab339f004ab57cb01838539bf5196fc1579e0add7c42206ff5e10bb0934b4a801fab12ed748a6a858af5c9601296ce6ca9b14b46f731a0485f49f142ab65dacb0103daaee13b2269f2c2b2d2bb2b04abe93642ecc988fa536170194acc1c73d48a781d3d5f0e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0d98f5df96c592c5b76bfde1cb823096
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: d0ba095f2bdb679cea084b4106479484
+        SHA1: 80aba0ecbd2b71c84bc73ac42963bc9ce247a020
+        SHA256: a93f8b7111c3e2288e164e42131e2ad52867060479ade1f6e6b3124cde822cfa
+        SHA384: 8293c567ba382434adab5899693e47e5d6e06c0b9f3c158bf17675d5a1476627db51d00dc9573bf4b89412617e651ba6
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert EV Code Signing
+        CA
+      ValidFrom: '2012-04-18 12:00:00'
+      ValidTo: '2027-04-18 12:00:00'
+      Signature: 9e5b963a2e1288acab016da49f75e40187a3a532d7bcbaa97ea3d61417f7c2136b7c738f2b6ae50f265968b08e259b6ceffa6c939208c14dcf459e9c46d61e74a19b14a3fa012f4ab101e1724048111368b9369d914bd7c2391210c1c4dcbb6214142a615d4f387c661fc61bffadbe4f7f945b7343000f4d73b751cf0ef677c05bcd348cd96313aa0e6111d6f28e27fcb47bb8b91120918678ea0ed428ff2ad52438e837b2ec96bb9fbc4a1650e15ebf517d23a032c7c1949e7ac9c026a2cc2587a0127e749f2d8db1c8e784beb9d1e9debb6a4e887371e12238cb2487e9737e51b2ff98eb4e7e2fe0ca0efab35ed1ba0542a8489f83f63fc4caa8df68a05061
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 0dd0e3374ac95bdbfa6b434b2a48ec06
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: f92649915476229b093c211c2b18e6c4
+        SHA1: 2d54c16a8f8b69ccdea48d0603c132f547a5cf75
+        SHA256: 2cd702a7dec30aa441345672e8992ef9770ce4946f276d767b45b0ed627658fb
+        SHA384: 511b0e0d7f3a48935cf2413348ff5f327887dc1e58f887bb5ed528d09f79173b55ab6439cf097fc7693b5749f7304ace
+    Signer:
+    - SerialNumber: 0d98f5df96c592c5b76bfde1cb823096
+      Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert EV Code Signing
+        CA
+      Version: 1

--- a/yaml/acb5da93-1dcc-4d16-8415-6b4b221cb4a1.yaml
+++ b/yaml/acb5da93-1dcc-4d16-8415-6b4b221cb4a1.yaml
@@ -1,0 +1,38 @@
+Id: acb5da93-1dcc-4d16-8415-6b4b221cb4a1
+Tags:
+- 360netmon_wfp.sys
+- 360netmon.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-06-22'
+MitreID: T1562.001
+CVE: []
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create 360netmon_wfp binPath=C:\windows\temp\360netmon_wfp.sys
+    type=kernel && sc.exe start 360netmon_wfp
+  Description: Qihoo 360netmon_wfp.sys is a signed kernel driver documented by ESET
+    as the driver abused by the GentleKiller Network Blocker variant used in Gentlemen
+    ransomware intrusions. The sample is associated with ESET detection Win64/VulnDriver.Qihoo360.A.
+  Usecase: Impair defenses through a signed kernel driver abused by an EDR killer.
+  Privileges: kernel
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://www.welivesecurity.com/en/eset-research/killing-me-gently-inside-gentlemens-edr-killer-framework/
+- https://www.eset.com/us/about/newsroom/research/eset-research-gentlemen-ransomware-gang-edr-killers/
+- https://github.com/magicsword-io/LOLDrivers/issues/377
+Detection: []
+Acknowledgement:
+  Person: ESET Research, 0xd3vnull
+  Handle: '@ESETresearch, @0xd3vnull'
+KnownVulnerableSamples:
+- Filename: 360netmon_wfp.sys
+  MD5: 40f64b91348bed955acf8551853b72a8
+  SHA1: 9ad51ad97c01e97ab59214116740785e0f6320a8
+  SHA256: 3d769a5f1ad0d32fb4e06478d35401d9788bad1a477b813adbdf4fd93b2c2694
+  Filesize: 107584
+  Signature: Signed
+  Company: 360.cn Inc.
+  Description: 360netmon
+  Product: 360netmon
+  OriginalFilename: 360netmon.sys

--- a/yaml/acb5da93-1dcc-4d16-8415-6b4b221cb4a1.yaml
+++ b/yaml/acb5da93-1dcc-4d16-8415-6b4b221cb4a1.yaml
@@ -9,8 +9,8 @@ MitreID: T1562.001
 CVE: []
 Category: vulnerable driver
 Commands:
-  Command: sc.exe create 360netmon_wfp binPath=C:\windows\temp\360netmon_wfp.sys
-    type=kernel && sc.exe start 360netmon_wfp
+  Command: sc.exe create 360netmon_wfp binPath=C:\windows\temp\360netmon_wfp.sys type=kernel
+    && sc.exe start 360netmon_wfp
   Description: Qihoo 360netmon_wfp.sys is a signed kernel driver documented by ESET
     as the driver abused by the GentleKiller Network Blocker variant used in Gentlemen
     ransomware intrusions. The sample is associated with ESET detection Win64/VulnDriver.Qihoo360.A.
@@ -32,7 +32,253 @@ KnownVulnerableSamples:
   SHA256: 3d769a5f1ad0d32fb4e06478d35401d9788bad1a477b813adbdf4fd93b2c2694
   Filesize: 107584
   Signature: Signed
-  Company: 360.cn Inc.
+  Company: 360.cn
   Description: 360netmon
   Product: 360netmon
   OriginalFilename: 360netmon.sys
+  Imphash: 8961b79bdb35a91c4966a20141d1f406
+  Authentihash:
+    MD5: cde694feb0bcdf6edbb714a759b0227d
+    SHA1: b7487b99b29570010545f6538cfe90cccaa34d44
+    SHA256: e4df5e185217887012b88164e0fba76d6869c541f6d64db20da505b9707ef370
+  RichPEHeaderHash:
+    MD5: 353020153a3fd127e4af7bb7c92a24d1
+    SHA1: 35230f3dd05e9e6872b7f21a4dbb72e3dcca7ccc
+    SHA256: ff71b69b08b01e0d9e3b2a6d4c32c01802643ae14665e4458f40c6b721608544
+  Sections:
+    .text:
+      Entropy: 6.301885388384608
+      Virtual Size: '0x113db'
+    .rdata:
+      Entropy: 5.487935434459315
+      Virtual Size: '0x112c'
+    .data:
+      Entropy: 1.3151803067015335
+      Virtual Size: '0x47080'
+    .pdata:
+      Entropy: 4.928615374597669
+      Virtual Size: '0x648'
+    INIT:
+      Entropy: 5.31035249584799
+      Virtual Size: '0x14f2'
+    .rsrc:
+      Entropy: 3.287263713704036
+      Virtual Size: '0x370'
+    .reloc:
+      Entropy: 1.3005781581651334
+      Virtual Size: '0x6c'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2024-09-08 21:16:29'
+  InternalName: 360netmon.sys
+  FileVersion: 2.4.12.5300
+  ProductVersion: 2.4.12.5300
+  Copyright: (C) 360.cn Inc. All Rights Reserved.
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - fwpkclnt.sys
+  - TDI.SYS
+  - NDIS.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - IoFileObjectType
+  - ZwCreateFile
+  - ZwQueryDirectoryFile
+  - IoGetCurrentProcess
+  - ZwEnumerateValueKey
+  - IoAttachDevice
+  - ZwQueryInformationProcess
+  - ZwOpenFile
+  - IoQueryFileDosDeviceName
+  - ObOpenObjectByPointer
+  - KeStackAttachProcess
+  - ZwQueryKey
+  - IoFreeMdl
+  - KeWaitForSingleObject
+  - MmProbeAndLockPages
+  - MmUnlockPages
+  - IoAllocateMdl
+  - KeUnstackDetachProcess
+  - KeLeaveCriticalRegion
+  - KeEnterCriticalRegion
+  - ExReleaseResourceLite
+  - _wcsicmp
+  - IoBuildPartialMdl
+  - IoMakeAssociatedIrp
+  - ZwQuerySystemInformation
+  - wcsstr
+  - ExInterlockedInsertHeadList
+  - IoFreeIrp
+  - ExInterlockedRemoveHeadList
+  - _wcsupr
+  - _wcsnicmp
+  - _stricmp
+  - DbgPrint
+  - KeBugCheckEx
+  - ZwSetValueKey
+  - ZwDeleteValueKey
+  - RtlIntegerToUnicodeString
+  - PsLookupProcessByProcessId
+  - ZwCreateKey
+  - IoBuildDeviceIoControlRequest
+  - PsGetProcessPeb
+  - KeAcquireSpinLockRaiseToDpc
+  - ZwOpenKey
+  - IofCallDriver
+  - RtlUpcaseUnicodeChar
+  - ExCreateCallback
+  - ExInitializeResourceLite
+  - IoCreateDevice
+  - ObfDereferenceObject
+  - MmIsAddressValid
+  - PsGetCurrentProcessId
+  - PsGetCurrentThreadId
+  - IoCreateSymbolicLink
+  - RtlCompareMemory
+  - CmRegisterCallback
+  - ExRegisterCallback
+  - RtlTimeToTimeFields
+  - ObReferenceObjectByHandle
+  - ExQueryDepthSList
+  - IofCompleteRequest
+  - ZwClose
+  - InitSafeBootMode
+  - PsTerminateSystemThread
+  - ExInterlockedInsertTailList
+  - ExAllocatePool
+  - ZwQueryValueKey
+  - IoGetDeviceObjectPointer
+  - PsCreateSystemThread
+  - wcsrchr
+  - ObQueryNameString
+  - KeDelayExecutionThread
+  - MmUserProbeAddress
+  - IoCreateSynchronizationEvent
+  - RtlTimeFieldsToTime
+  - RtlEqualUnicodeString
+  - PsSetCreateProcessNotifyRoutine
+  - ExpInterlockedPopEntrySList
+  - KeAcquireInStackQueuedSpinLock
+  - KeReleaseSpinLock
+  - RtlGetVersion
+  - IoIsOperationSynchronous
+  - KeInitializeEvent
+  - ExpInterlockedPushEntrySList
+  - MmGetSystemRoutineAddress
+  - KeSetEvent
+  - ProbeForWrite
+  - IoDeleteDevice
+  - RtlInitUnicodeString
+  - IoRegisterDriverReinitialization
+  - KeReleaseInStackQueuedSpinLock
+  - ExInitializeNPagedLookasideList
+  - ExFreePoolWithTag
+  - IoDeleteSymbolicLink
+  - ProbeForRead
+  - ExAllocatePoolWithTag
+  - ExAcquireResourceExclusiveLite
+  - ExUnregisterCallback
+  - __C_specific_handler
+  - FwpmCalloutEnum0
+  - FwpsFlowAssociateContext0
+  - FwpsAcquireWritableLayerDataPointer0
+  - FwpsCalloutUnregisterById0
+  - FwpmProviderDestroyEnumHandle0
+  - FwpmSubLayerAdd0
+  - FwpsApplyModifiedLayerData0
+  - FwpsFreeCloneNetBufferList0
+  - FwpsFlowRemoveContext0
+  - FwpmCalloutDeleteByKey0
+  - FwpsQueryPacketInjectionState0
+  - FwpmCalloutDeleteById0
+  - FwpmProviderEnum0
+  - FwpmSubLayerDeleteByKey0
+  - FwpmProviderCreateEnumHandle0
+  - FwpsCloneStreamData0
+  - FwpsConstructIpHeaderForTransportPacket0
+  - FwpmSubLayerEnum0
+  - FwpsAllocateNetBufferAndNetBufferList0
+  - FwpsInjectionHandleCreate0
+  - FwpmTransactionCommit0
+  - FwpmSubLayerCreateEnumHandle0
+  - FwpmSubLayerDestroyEnumHandle0
+  - FwpmCalloutAdd0
+  - FwpmCalloutDestroyEnumHandle0
+  - FwpmFilterDeleteByKey0
+  - FwpsAllocateCloneNetBufferList0
+  - FwpmBfeStateSubscribeChanges0
+  - FwpmFilterEnum0
+  - FwpmProviderAdd0
+  - FwpsCalloutRegister0
+  - FwpmTransactionAbort0
+  - FwpmEngineOpen0
+  - FwpsAcquireClassifyHandle0
+  - FwpmFilterDestroyEnumHandle0
+  - FwpmProviderDeleteByKey0
+  - FwpmCalloutCreateEnumHandle0
+  - FwpmFilterAdd0
+  - FwpsCalloutRegister1
+  - FwpsInjectTransportSendAsync0
+  - FwpmTransactionBegin0
+  - FwpsReleaseClassifyHandle0
+  - FwpmEngineClose0
+  - FwpsDiscardClonedStreamData0
+  - FwpmFreeMemory0
+  - FwpmFilterDeleteById0
+  - FwpsFreeNetBufferList0
+  - FwpmFilterCreateEnumHandle0
+  - TdiMapUserRequest
+  - NdisAdvanceNetBufferListDataStart
+  - NdisGetDataBuffer
+  - NdisAllocateNetBufferListPool
+  - NdisRetreatNetBufferListDataStart
+  - NdisCopyFromNetBufferToNetBuffer
+  - NdisAllocateMdl
+  - NdisFreeGenericObject
+  - NdisSetTimer
+  - NdisInitializeTimer
+  - NdisCancelTimer
+  - NdisAllocateGenericObject
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2024-05-16 22:16:06'
+      ValidTo: '2025-05-14 22:16:06'
+      Signature: 47aa9e6ebb9bdffbdf6d8d99645f726af89374c6136a5f4b2d2f6fe82d8c103a41d186ec5e5ed63749401c724cb5aa6091e023f9125ecfee62f444fbde29edb037b58bd6118a66288ab639cace557ee4a888fe098088aaba592199b25725d664d21269f4aee0bc3682c4a6758c9446b50081d066fdf8cad7b5677c18d63d3404d0ce4ffab1215acc7345dc6ea61c65caee9f6950f957e87b146f7fa34abd5970c79a777436f8d80b6ee5b8876b698bc8d547b47c3d11788c8a730c8c25c7fc878b03243ce55e2c2b898edd1755cb95553578b588122b456ab70dbc084323dcb0487aa462d57b9863a5ecfaa85e5f5d5d3da96dc20ecbc7c2203900fb2f5e84c8
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 33000001112a0790aae5568529000000000111
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 778c1775b427242a721643a7a90eae19
+        SHA1: 553ed9bf72af4fce0ef52a7f0a2396245fc3d348
+        SHA256: 6910d4ed97543604c6ad630041532ff89e630311916332b6fda7b211aa29fa78
+        SHA384: dccc0fe272475403fc9e0c1db6c456428798dfbe00fb20c962f57858256565a2cf361acb4eba8c771ec7611f2aa06bc1
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      ValidFrom: '2012-04-18 23:48:38'
+      ValidTo: '2027-04-18 23:58:38'
+      Signature: 5a8a67daccd5fd0d264177bf0a4678b4b3de12692b7723c2652f015fd203f461ba509d2e8c3972f36c3e6ab11e766decb7f382dcccbbc56970287366173f54ebee011648c446d91b80ae813a8d0f796d68b09eea2d3f39d3ca387ebd5e7c086e19dcc6c2f438336861e2524783e1000156d2bacb878205310a418b4ee77f5f5fed5fd3392d45eba213bffd1ec298417161165fc80a70257c59693124e471e70abb0417f79f721ec9d2bb1abe3d02fe090cb243b4591a99539396215fe0d6b72601429536ac27fdbef48577683d18bdf4be98882211865216f345ec0397107087a37043713cdbc98603170cf5735bc67de15c64edd7c548d7ed32e2d1aad3cfa7f6574e61f977eb67f288b3de00da038fd08a34373e1dd862b8d2b1f3e12f8b723b81967c6ffcec667672601b24f2a0896d5b6d002eef28dd868705c2b4b9e5be64c22af24a155c98e2c42785ff52e3627e0fb2020bd766c70ab2d33d200414503259830a7d9bed5a38120152ba2f5e20728e4af1fde771028c3be107bec973f4dd47d8b4efb4a4b330b9893e76cab90098567eabea8ab8a5d038ab6977130b142fe9aa411ff7babd3a2b348aee0aab63e663f788248e200d2b3b9de3c24952ac9f1f0e393b5dd46e506ae67d523aaa7c3315290d265e0158a74ea93d7a846f743f609fe4324f3600af6d71d33ea646655f8174f1fec171da4ca0415a82ddf11f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 610baac1000000000009
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: a569061297e8e824767dbc3184a69bea
+        SHA1: adbb26a587a8f44b4fccaecb306f980d1c55a150
+        SHA256: cec1afd0e310c55c1dcc601ab8e172917706aa32fb5eaf826813547fdf02dd46
+        SHA384: e947cac936803f5683196e4ff1b259096073395d0b908522ddce90d57597c9f7b57f7ddcdbe021ba863d843c340da8ba
+    Signer:
+    - SerialNumber: 33000001112a0790aae5568529000000000111
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      Version: 1

--- a/yaml/f8ed41ef-18f0-441c-99b8-def062214d0e.yaml
+++ b/yaml/f8ed41ef-18f0-441c-99b8-def062214d0e.yaml
@@ -14,6 +14,8 @@ Commands:
   OperatingSystem: Windows 10
 Resources:
 - https://github.com/BlackSnufkin/BYOVD
+- https://www.welivesecurity.com/en/eset-research/killing-me-gently-inside-gentlemens-edr-killer-framework/
+- https://github.com/magicsword-io/LOLDrivers/issues/377
 Acknowledgement:
   Person: ''
   Handle: ''
@@ -272,5 +274,15 @@ KnownVulnerableSamples:
       Issuer: CN=Thawte Timestamping CA,OU=Thawte Certification,O=Thawte,L=Durbanville,ST=Western
         Cape,C=ZA
       Version: 1
+- Filename: googleApiUtil64.sys
+  MD5: 5f8df2c0389ead04ce2e69d632edcdbd
+  SHA1: ec296f9501ad71e430810cb5cdc38d954d4ba536
+  SHA256: f6ee01303cf1d68015eee49f7dc7f26151a04ae642a47e49c70806931ce652d3
+  Filesize: 116936
+  Signature: Signed
+  Company: Baidu, Inc.
+  Description: Baidu Antivirus BdApi Driver
+  Product: Baidu Antivirus
+  OriginalFilename: BdApiUtil64.sys
 Tags:
 - BdApiUtil64.sys

--- a/yaml/f8ed41ef-18f0-441c-99b8-def062214d0e.yaml
+++ b/yaml/f8ed41ef-18f0-441c-99b8-def062214d0e.yaml
@@ -5,9 +5,8 @@ MitreID: T1068
 Category: vulnerable driver
 Verified: 'TRUE'
 Commands:
-  Command: sc.exe create BdApiUtil64.sys
-    binPath=C:\windows\temp\BdApiUtil64.sys
-    type=kernel && sc.exe start BdApiUtil64.sys
+  Command: sc.exe create BdApiUtil64.sys binPath=C:\windows\temp\BdApiUtil64.sys type=kernel
+    && sc.exe start BdApiUtil64.sys
   Description: Driver can be used to load unsigned drivers
   Usecase: Elevate privileges
   Privileges: kernel
@@ -283,6 +282,249 @@ KnownVulnerableSamples:
   Company: Baidu, Inc.
   Description: Baidu Antivirus BdApi Driver
   Product: Baidu Antivirus
-  OriginalFilename: BdApiUtil64.sys
+  OriginalFilename: ''
+  Imphash: 7f0cfc7ad79e21e810f2f8b940b85130
+  Authentihash:
+    MD5: e36fc4ce8e1c5c462228886bcc11147e
+    SHA1: a7a0e8fa40e2579ac338abe3ddeb34973c4eceea
+    SHA256: a62a024b4db990e938d5ae7d83c2f2bf419ff1236e53adad216b8b0fb96257bd
+  RichPEHeaderHash:
+    MD5: e734ef5ee4a0a713d8eeaba51a26b111
+    SHA1: d0eb1c9935763928f36127634ee7aa6316b53a55
+    SHA256: c36513f9cad1ffd1daa6febe5d0c7a9baead7427cd1b1e3ab6a9ef004cd5cc60
+  Sections:
+    .text:
+      Entropy: 6.269920885814862
+      Virtual Size: '0x5fb0'
+    .rdata:
+      Entropy: 4.554319933353829
+      Virtual Size: '0x21dc'
+    .data:
+      Entropy: 1.4051264446957596
+      Virtual Size: '0xfa80'
+    .pdata:
+      Entropy: 4.510655225055284
+      Virtual Size: '0x66c'
+    PAGE:
+      Entropy: 5.912960719403388
+      Virtual Size: '0x283'
+    INIT:
+      Entropy: 5.74689114961608
+      Virtual Size: '0xece'
+    .rsrc:
+      Entropy: 3.3529606887874537
+      Virtual Size: '0x360'
+    .reloc:
+      Entropy: 4.776467402333935
+      Virtual Size: '0xa48'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2015-05-05 20:21:26'
+  InternalName: Baidu Antivirus
+  FileVersion: 5,4,3,125107
+  ProductVersion: 5,4,3,125107
+  Copyright: Copyright (C) 2014 Baidu, Inc. All rights reserved.
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - FLTMGR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - MmGetSystemRoutineAddress
+  - IoDetachDevice
+  - PsSetCreateProcessNotifyRoutine
+  - wcsrchr
+  - ZwQueryValueKey
+  - ZwClose
+  - IofCompleteRequest
+  - PsGetVersion
+  - IoCreateSymbolicLink
+  - PsGetCurrentProcessId
+  - IoCreateDevice
+  - ExCreateCallback
+  - ZwOpenKey
+  - RtlCompareMemory
+  - MmIsAddressValid
+  - _stricmp
+  - ExGetPreviousMode
+  - ZwQuerySystemInformation
+  - IoFreeMdl
+  - _vsnprintf
+  - NtClose
+  - ObReferenceObjectByHandle
+  - strrchr
+  - ObfDereferenceObject
+  - ExQueueWorkItem
+  - RtlVolumeDeviceToDosName
+  - PsLookupProcessByProcessId
+  - ZwQuerySymbolicLinkObject
+  - _wcsnicmp
+  - ZwReadFile
+  - IoGetRelatedDeviceObject
+  - KeSetEvent
+  - RtlAppendUnicodeToString
+  - IoCreateFile
+  - KeInitializeEvent
+  - ZwQueryObject
+  - ZwOpenSymbolicLinkObject
+  - ZwSetInformationFile
+  - ObQueryNameString
+  - IoFileObjectType
+  - ZwCreateFile
+  - IoGetCurrentProcess
+  - ExFreePoolWithTag
+  - KeWaitForSingleObject
+  - IoFreeIrp
+  - IoAllocateIrp
+  - ZwQueryInformationProcess
+  - ObfReferenceObject
+  - ZwTerminateProcess
+  - ZwQueryInformationFile
+  - ObOpenObjectByPointer
+  - IofCallDriver
+  - _vsnwprintf
+  - ZwCreateKey
+  - ZwDeleteValueKey
+  - ZwSetValueKey
+  - CmRegisterCallback
+  - CmUnRegisterCallback
+  - ZwDeleteKey
+  - DbgPrintEx
+  - NtBuildNumber
+  - wcschr
+  - IoAcquireVpbSpinLock
+  - SeCreateAccessState
+  - IoGetFileObjectGenericMapping
+  - ObCreateObject
+  - ObInsertObject
+  - IoGetDeviceObjectPointer
+  - RtlUpperChar
+  - RtlPrefixUnicodeString
+  - IoReleaseVpbSpinLock
+  - RtlEqualUnicodeString
+  - IoDeleteSymbolicLink
+  - ExAllocatePoolWithTag
+  - mbstowcs
+  - RtlAppendUnicodeStringToString
+  - _wcsicmp
+  - __C_specific_handler
+  - FltEnumerateInstances
+  - FltEnumerateFilters
+  - FltObjectDereference
+  - FltGetFilterInformation
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=BE, O=GlobalSign nv,sa, CN=GlobalSign Timestamping CA , G2
+      ValidFrom: '2011-04-13 10:00:00'
+      ValidTo: '2028-01-28 12:00:00'
+      Signature: 4e5e56901e46b4d94931f3bb1739281bc216ddfd41dc0905049b6fb2a29ad6992e40990055b5ea3fa52076d38634d417cc553ac782eeefa8babcd8069f1550dfcd167b523a02d7191afdaff0785ce04bc518df3a241edaacb8a95804020730dbb0125efe31bef00448f4f070f83a5e5683cf3dfb0dbcf4c5ed979db9d4dba52784e3389b8ba735864420a43b6da46a0ba183fd28ebdaef28f6cc885dfb0a3b00abe021ebe22f356c0f8e344597eba2f79933357ecb9a8abb454de73f9fc2d98afa65b26ec77e65ffe892e12c31a2f7b02736488f266f3bee4d761f79c3e57f9635bc2d0ecc01b08e7fff518080a792d4b34446648c874f166307314b63b0dff3
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 0400000000012f4ee152d7
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: e140543fe3256027cfa79fc3c19c1776
+        SHA1: c655f94eb1ecc93de319fc0c9a2dc6c5ec063728
+        SHA256: 3ca71e85908ff67368e4dc00253f5691b9e6d50c966e7784143d75fb92aa3448
+        SHA384: d9d366f9328f2b55ee19a32cc5fd5148b81d764282fe5dc196c872ae249caa51d2c212ef39f33945dfe0cda81925e326
+    - Subject: C=SG, O=GMO GlobalSign Pte Ltd, CN=GlobalSign TSA for MS Authenticode
+        , G2
+      ValidFrom: '2015-02-03 00:00:00'
+      ValidTo: '2026-03-03 00:00:00'
+      Signature: 8032dc078d1ca09c9d3c2ae83d218b59a14d7ecc44ce03be7eaabcc4e67b73bb4bf188da904e7537283863b9d72b0f54a956ce7739973073cd9bd9d905451c8da4b8035d4fd91c2e98e0e988e6ecd7057e562a7bf7165ba3ad8f972512841bb25c634a0ad2ef10544782843569289c0ce41f141624fa75dc74726e4ecae36a43afcf7d3648d1bde906912c2fa6c871fdcfbdd89d2198fcafdbde228cafa7f377ef9ddca3704b441af078851ef2a58c39b5dc881c37edad14f5070b26bdbe6d025eb1b8b0586c853a0df6ff5a270cc5de53e7543c564cc94e4c30f6f25cfb1a8cc282bead5991f61b4d557bcf5b01dcfd7ad36f235c32479b01f3c15114468a9b
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 112106a081d33fd87ae5824cc16b52094e03
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: a0ac4d48fe852f7b3ed4e623d59a825f
+        SHA1: d4db9846bc4d7db142eeb364286f6de7c102420c
+        SHA256: 78d2e41a13eb4e9171bae2d2adb192cf39210b5231f77cda936bcfbe8c003bdf
+        SHA384: 990ed96dca5979deeedc98a012279f04efb5559d7e7f5084a12f3802ee9439326557aecefd081cff739b78515b5d7f50
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=(c) 2006 VeriSign,
+        Inc. , For authorized use only, CN=VeriSign Class 3 Public Primary Certification
+        Authority , G5
+      ValidFrom: '2006-11-08 00:00:00'
+      ValidTo: '2021-11-07 23:59:59'
+      Signature: 1302ddf8e88600f25af8f8200c59886207cecef74ef9bb59a198e5e138dd4ebc6618d3adeb18f20dc96d3e4a9420c33cbabd6554c6af44b310ad2c6b3eabd707b6b88163c5f95e2ee52a67cecd330c2ad7895603231fb3bee83a0859b4ec4535f78a5bff66cf50afc66d578d1978b7b9a2d157ea1f9a4bafbac98e127ec6bdff
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 250ce8e030612e9f2b89f7054d7cf8fd
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 918d9eb6a6cd36c531eceb926170a7e1
+        SHA1: 0ae95700d65e6f59715aa47048993ca7858e676a
+        SHA256: 47c46e6eaa3780eace3d0d891346cd373359d246b21a957219dbab4c8f37c166
+        SHA384: e54017c93ba52f012cc15aeb3bcbce1e90a0006ff8dca231a24fc572926770f63213343f538003407bed3463fa9c4a85
+    - Subject: C=US, O=VeriSign, Inc., OU=Class 3 Public Primary Certification Authority
+      ValidFrom: '2006-05-23 17:01:29'
+      ValidTo: '2016-05-23 17:11:29'
+      Signature: 01e446b33b457f7513877e5f43de468ecb8abdb64741bccccc7491d8ce395195a4a6b547c0efd2da7b8f5711f4328c7ccd3fee42da04214af7c843884a6f5cca14fc4bd19f4cbdd4556ecc02be0da6888f8609baa425bde8b0f0fa8b714e67b0cb82a8d78e55f737ebf03e88efe4e08afd1c6e2e61414875b4b02c1d28d8490fd715f02473253ccc880cde284c6554fe5eae8cea19ad2c51b29b3a47f53c80350117e24987d6544afb4bab07bcbf7d79cfbf35005cbb9ecffc82891b39a05197b6dec0b307ff449644c0342a195cabeef03bec294eb513c537857e75d5b4d60d066eb5d26c237167eaf1718eaf4e74aa0cf9ecbf4c58fa5e909b6d39cb86883f8b1ca81632d5fe6db9f1f8b3ead791f6364778c0272a15c768d6f4c5fc4f4ec8673f102d409ff11ec96148e7a703fc31730cf04688fe56da492995ef09daa3e5beef60ecd954a0599c28bd54ef66157f874c84dba60e95672e517b3439b641c28c846826dc240209e7818e0a972defeea7b998a60f818dc710b5e1ed982f486f53854964789bec5dac970b5526c3efba8dc8d1a52f5a7f936b611a339b18b8a26210de24ea76e12f43ebecdd7c12342489da2855aee5754e312b6763b6a8d7ab730a03cec5ea593fc7eb2a45aea8625b2f009939abb45f73c308ec80118f470e8f2a1343e191066255bbffba3da9a93d260faeca7d628b155589d694344dd665
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 610c120600000000001b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 53c41bc1164e09e0cd1617a5bf913efd
+        SHA1: 93c03aac8951d494ecd5696b1c08658541b18727
+        SHA256: 40bddadac24dc61ca4fb5cab2a2bc5d876bc36808311039a7a3e1a4066f7489b
+        SHA384: f51d4e75ba638f7314cd59b8d6d45f3b34d35ce6986e9d205cd6f333e8e8d8e9c91f636e6bc84731b6661673f40963d8
+    - Subject: C=CN, ST=Beijing, L=Beijing, O=Baidu Online Network Technology (Beijing)
+        Co.,Ltd., OU=Baidu security, CN=Baidu Online Network Technology (Beijing)
+        Co.,Ltd.
+      ValidFrom: '2015-03-25 00:00:00'
+      ValidTo: '2016-03-25 23:59:59'
+      Signature: 90533b0d3594d89f8a2b3e5c9713367dfe07271f79e754e79c8629c7997ad1193191008a0059d297b77521e0462db4bccc6fb834c1495edf0a055d0a70f6e7102fe35c742a3590b2634df5da3fcdce55b8d93a78f53e4f7b01d190f3e1847677a8480b388960083b83599dc659523d5781ff4964a1e223298e7cdf69cdad04480d53b030430571a697cbe3a5edfa74b4bf0963e15d261baca66613fee39d0e38089e5b53650f984a3ba1dc62cc2a1d3aa9bfde63ee88f9dbf622e099e173547e5e9e8970cd4cf1ff51246d1d2bca20224505388fbd07a53a4122ae903d8c314ee73494cbd08d4ec2bc739f886925140d722cad7449ed833c9bfd0bb43f8063be
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 5faee9e83f32948f3b2040ac6df0145c
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 19b6a14d4467bf6bfe847e7e26fd7105
+        SHA1: 7dae7f2a9198a1a0847a2313a0f5661cfc8467e4
+        SHA256: 90455a2260e99df3f2c5c96e96f61708e8f2a29804ee2cafef030db611bfc0b1
+        SHA384: 0e1b35202b760c9a7e613882009199be1c7db68c8778282e20390485b2ed30f4a51ee5251634740661bd972fadc54b7b
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=Terms of use
+        at https://www.verisign.com/rpa (c)10, CN=VeriSign Class 3 Code Signing 2010
+        CA
+      ValidFrom: '2010-02-08 00:00:00'
+      ValidTo: '2020-02-07 23:59:59'
+      Signature: 5622e634a4c461cb48b901ad56a8640fd98c91c4bbcc0ce5ad7aa0227fdf47384a2d6cd17f711a7cec70a9b1f04fe40f0c53fa155efe749849248581261c911447b04c638cbba134d4c645e80d85267303d0a98c646ddc7192e645056015595139fc58146bfed4a4ed796b080c4172e737220609be23e93f449a1ee9619dccb1905cfc3dd28dac423d6536d4b43d40288f9b10cf2326cc4b20cb901f5d8c4c34ca3cd8e537d66fa520bd34eb26d9ae0de7c59af7a1b42191336f86e858bb257c740e58fe751b633fce317c9b8f1b969ec55376845b9cad91faaced93ba5dc82153c2825363af120d5087111b3d5452968a2c9c3d921a089a052ec793a54891d3
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 5200e5aa2556fc1a86ed96c9d44b33c7
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: b30c31a572b0409383ed3fbe17e56e81
+        SHA1: 4843a82ed3b1f2bfbee9671960e1940c942f688d
+        SHA256: 03cda47a6e654ed85d932714fc09ce4874600eda29ec6628cfbaeb155cab78c9
+        SHA384: bbda8407c4f9fc4e54d772f1c7fb9d30bc97e1f97ecd51c443063d1fa0644e266328781776cd5c44896c457c75f4d7da
+    Signer:
+    - SerialNumber: 5faee9e83f32948f3b2040ac6df0145c
+      Issuer: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=Terms of use at
+        https://www.verisign.com/rpa (c)10, CN=VeriSign Class 3 Code Signing 2010
+        CA
+      Version: 1
 Tags:
 - BdApiUtil64.sys

--- a/yaml/fc3467c3-6109-447d-b438-7a4276c3d8e5.yaml
+++ b/yaml/fc3467c3-6109-447d-b438-7a4276c3d8e5.yaml
@@ -162,6 +162,111 @@ KnownVulnerableSamples:
   SHA256: 2d91a78e739891c9854c254f5b2a6b84c0e167dfa253466cbccd2cdd1c20145d
   Filesize: 19672
   Signature: Signed
+  Imphash: 47c3554d0dee53d4f925ed52484bea12
+  Authentihash:
+    MD5: db166d299a9aa3671c9260869cecbe40
+    SHA1: d47243560273ada0b12276a0592a4a5682148fc4
+    SHA256: 1ce001eda18c7a0636c4053848a1ae69812704795ab057331903d7002d688027
+  RichPEHeaderHash:
+    MD5: 088a57b8b352520540d5f0b890dcb421
+    SHA1: 07b428b1908cff0ac4c47ae53dafbbb24a7e2349
+    SHA256: b6e1ef3061dbf72083a8ce23230aacfb28fb2d22190b2c1fb8bfe478e9df114d
+  Sections:
+    .text:
+      Entropy: 6.20284233182365
+      Virtual Size: '0xe33'
+    .rdata:
+      Entropy: 3.9991640402344313
+      Virtual Size: '0x534'
+    .data:
+      Entropy: 0.12227588125913882
+      Virtual Size: '0x1038'
+    .pdata:
+      Entropy: 3.5027788758062397
+      Virtual Size: '0xc0'
+    INIT:
+      Entropy: 4.548267326833211
+      Virtual Size: '0x260'
+    .reloc:
+      Entropy: 2.908694969562842
+      Virtual Size: '0x14'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2025-03-23 21:53:56'
+  Description: ''
+  Company: ''
+  InternalName: ''
+  OriginalFilename: ''
+  FileVersion: ''
+  Product: ''
+  ProductVersion: ''
+  Copyright: ''
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - atoi
+  - RtlInitUnicodeString
+  - ExAllocatePool
+  - ExFreePoolWithTag
+  - IoGetCurrentProcess
+  - KeStackAttachProcess
+  - KeUnstackDetachProcess
+  - ObReferenceObjectByName
+  - IoDriverObjectType
+  - KeDelayExecutionThread
+  - ExInitializePushLock
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - ZwClose
+  - ZwTerminateProcess
+  - ZwOpenProcess
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2024-10-10 19:04:53'
+      ValidTo: '2025-10-08 19:04:53'
+      Signature: 3870e583035a72db64856d80e17833cd3badd24f19abf9a3d7c7485743dd875f69102820df4992d74f8fba0529be4e16f4234910064a3a1863299a29b82d3fac869915a368ec0e5d0127282221bce84db444d2e9974dc2761a2080a7bc7508d7064f32b2d97b0263d0d937527a8af95f18bcb54ec21a453ba35e55869791416a2a8813fcf95e889e65158dbb5b4cba653c989179947d286051ef6b0d56f41da479db08c6b93c44fa5c8399e126594cc53dfa756180607a1dd29559061d828b0ce2c5a462245ed0995a196ad96223b6eb1a787b4d10b5a7d4e3a130750103bc9c713fc8f32015273bb238b15aae25e4765d7ab81c5d3df82ef6a7d3c2e7a61dab024ff02df6876a86ec7198aa6e28c8e69a015129a717b1036113911f0aeefa8d05081974d026196f24bc1e4ef942599fafbd1b2c316bda73237f1822296888df2344c92b08c363976beb7020242b3069e6691f19e715e1d1a19ddc03235263c9bb7b8390145af57603105ced358f394547e3be96718835917234eb7fd7134d9fb605656717ed6b15f0583068c84c6c01abf31cc1df1fe7c4d2935590e6017cf8cc5635e1cd7054240fd0059f168e90ec1a49f24e0f050034d99e4aa6599a64d280d00ea8af57d3125caddb342a0b2c160a2f95d97e6045e69dc1c1b3fa56dfd40380ce60536a59750edf0069dc7c27f8ccc8f073b46d169b8fed1fd40ac6f00c
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 330000006e1229856f0ade6cfc00000000006e
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 3066a9830894e57ce6e47f7a6b58b84f
+        SHA1: ce441ecd2f11e400515a85d5a592da38f950f3dc
+        SHA256: 3e30a731a3b620db0971ecd743ecd312bcdf14c82b9bdc9918102bacbf70520d
+        SHA384: 68c6537d64e3a4f02a2c1d04257c13ab1def23c9c54bafc434176be50a411a75c118c9f8edc81f97b8a1db2dc1d009e3
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      ValidFrom: '2014-10-15 20:31:27'
+      ValidTo: '2029-10-15 20:41:27'
+      Signature: 96b5c33b31f27b6ba11f59dd742c3764b1bca093f9f33347e9f95df21d89f4579ee33f10a3595018053b142941b6a70e5b81a2ccbd8442c1c4bed184c2c4bd0c8c47bcbd8886fb5a0896ae2c2fdfbf9366a32b20ca848a6945273f732332936a23e9fffdd918edceffbd6b41738d579cf8b46d499805e6a335a9f07e6e86c06ba8086725afc0998cdba7064d4093188ba959e69914b912178144ac57c3ae8eae947bcb3b8edd7ab4715bba2bc3c7d085234b371277a54a2f7f1ab763b94459ed9230cce47c099212111f52f51e0291a4d7d7e58f8047ff189b7fd19c0671dcf376197790d52a0fbc6c12c4c50c2066f50e2f5093d8cafb7fe556ed09d8a753b1c72a6978dcf05fe74b20b6af63b5e1b15c804e9c7aa91d4df72846782106954d32dd6042e4b61ac4f24636de357302c1b5e55fb92b59457a9243d7c4e963dd368f76c728caa8441be8321a66cde5485c4a0a602b469206609698dcd933d721777f886dac4772daa2466eab64682bd24e98fb35cc7fec3f136d11e5db77edc1c37e1f6a4a14f8b4a721c671866770cdd819a35d1fa09b9a7cc55d4d728e74077fa74d00fcdd682412772a557527cda92c1d8e7c19ee692c9f7425338208db38cc7cc74f6c3a6bc237117872fe55596460333e2edfc42de72cd7fb0a82256fb8d70c84a5e1c4746e2a95329ea0fecdb4188fd33bad32b2b19ab86d0543fbff0d0f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 330000000d690d5d7893d076df00000000000d
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 83f69422963f11c3c340b81712eef319
+        SHA1: 0c5e5f24590b53bc291e28583acb78e5adc95601
+        SHA256: d8be9e4d9074088ef818bc6f6fb64955e90378b2754155126feebbbd969cf0ae
+        SHA384: 260ad59ba706420f68ba212931153bd89f760c464b21be55fba9d014fff322407859d4ebfb78ea9a3330f60dc9821a63
+    Signer:
+    - SerialNumber: 330000006e1229856f0ade6cfc00000000006e
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      Version: 1
 - Filename: PoisonX10.sys
   MD5: e4704b728eb6daeeb780688786303c4f
   SHA1: a3bfa49170fa5808d66415ba73f5aac68a195ffd

--- a/yaml/fc3467c3-6109-447d-b438-7a4276c3d8e5.yaml
+++ b/yaml/fc3467c3-6109-447d-b438-7a4276c3d8e5.yaml
@@ -1,6 +1,7 @@
 Id: fc3467c3-6109-447d-b438-7a4276c3d8e5
 Tags:
 - PoisonX.sys
+- G11.sys
 - PoisonX10.sys
 - PoisonX11.sys
 - PoisonX12.sys
@@ -37,6 +38,8 @@ Commands:
 Resources:
 - https://medium.com/@jehadbudagga/reverse-engineering-a-0day-used-against-crowdstrike-edr-a5ea1fbe3fd4
 - https://github.com/j3h4ck/PoisonKiller/
+- https://www.welivesecurity.com/en/eset-research/killing-me-gently-inside-gentlemens-edr-killer-framework/
+- https://github.com/magicsword-io/LOLDrivers/issues/377
 Acknowledgement:
   Person: Jehad Abudagga
   Handle: '@jehadbudagga'
@@ -153,6 +156,12 @@ KnownVulnerableSamples:
       Version: 1
   LoadsDespiteHVCI: 'FALSE'
   MagicHeader: 50 45 0 0
+- Filename: G11.sys
+  MD5: 07e9f0b8627a95960e79e930fb099e84
+  SHA1: 56bee9df5833a637f5c54d5911df98b0812fe643
+  SHA256: 2d91a78e739891c9854c254f5b2a6b84c0e167dfa253466cbccd2cdd1c20145d
+  Filesize: 19672
+  Signature: Signed
 - Filename: PoisonX10.sys
   MD5: e4704b728eb6daeeb780688786303c4f
   SHA1: a3bfa49170fa5808d66415ba73f5aac68a195ffd


### PR DESCRIPTION
## Summary

Adds the missing LOLDrivers coverage from the ESET Gentlemen EDR-killer report and issue #377.

- adds new `360netmon_wfp.sys` coverage for the GentleKiller Network Blocker driver, including an LFS-backed sample and extracted metadata
- adds new `IMFForceDelete.sys` / `IMFForceDelete` coverage for the GentleKiller Cleaner driver, including an LFS-backed sample and extracted metadata
- extends the existing `PoisonX`, `BdApiUtil64`, and `HWAuidoOs2Ec` entries with the exact `G11.sys`, `googleApiUtil64.sys`, and `havoc.sys` hashes reported by ESET
- adds LFS-backed samples and extracted metadata for `G11.sys`, `googleApiUtil64.sys`, and `havoc.sys`
- leaves the EXE-only EDR killer and stealer samples out of LOLDrivers scope

## Driver samples

- `360netmon_wfp.sys` / SHA-256 `3d769a5f1ad0d32fb4e06478d35401d9788bad1a477b813adbdf4fd93b2c2694`
- `IMFForceDelete.sys` / SHA-256 `ef4e4b88df24825dbf4e7131e71a41002715d38b7a8c0c432aa936c854152ef3`
- `G11.sys` / SHA-256 `2d91a78e739891c9854c254f5b2a6b84c0e167dfa253466cbccd2cdd1c20145d`
- `googleApiUtil64.sys` / SHA-256 `f6ee01303cf1d68015eee49f7dc7f26151a04ae642a47e49c70806931ce652d3`
- `havoc.sys` / SHA-256 `5abe477517f51d81061d2e69a9adebdcda80d36667d0afabe103fda4802d33db`

Closes #377

## Validation

- `python3 bin/validate.py -y yaml -s bin/spec/drivers.spec.json`
- `git diff --check`
- `git lfs status --porcelain`
- confirmed the committed driver samples are LFS pointers for their expected SHA-256 hashes
- GitHub `validate-yaml` checks passed
