### PR TITLE
Add MyPortIO driver coverage

### DIFF
--- a/drivers/5a55272db2de6f37b30a0515b0c08383.bin
+++ b/drivers/5a55272db2de6f37b30a0515b0c08383.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18bf6cf0224a41058ba3944ff0df9e12fa256c7c353d6fa6132a464cd5db5709
+size 29184

--- a/drivers/cda61b27e94b5ec1f1cde870e59eeabb.bin
+++ b/drivers/cda61b27e94b5ec1f1cde870e59eeabb.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30d5e07d9e88722a5e0eec17d0437b859f782d1c15fc80b5381f3e3eb4221bc7
+size 26112

--- a/yaml/7d9fee48-82d8-4582-be9a-a46682054e3e.yaml
+++ b/yaml/7d9fee48-82d8-4582-be9a-a46682054e3e.yaml
@@ -1,0 +1,367 @@
+Id: 7d9fee48-82d8-4582-be9a-a46682054e3e
+Tags:
+- MyPortIO_x64.sys
+- MyPortIO_x86.sys
+- MyPortIO0
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-06-22'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create MyPortIO_x64 binPath=C:\windows\temp\MyPortIO_x64.sys type=kernel
+    && sc.exe start MyPortIO_x64
+  Description: 'MyPortIO_x64.sys and MyPortIO_x86.sys are Nuvoton Technology kernel
+    drivers bundled with ASRock Polychrome RGB. Public issue #380 and the MyPortIO-Exploit
+    writeup document unauthenticated IOCTL handlers that expose physical memory read/write
+    and I/O port access primitives from user mode.'
+  Usecase: Access physical memory and I/O port primitives through a vulnerable hardware
+    utility driver.
+  Privileges: kernel
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/380
+- https://sploitus.com/exploit?id=7004A1F2-9DB9-5904-9F61-0492A070C636
+- https://www.asrock.com/support/index.asp?cat=Utilities
+- https://download.asrock.com/Utility/RGB/PolychromeRGB(v2.0.190).zip
+- https://download.asrock.com/Utility/RGB/PolychromeRGB(v2.0.217).zip
+Detection: []
+Acknowledgement:
+  Person: Dark Monkey
+  Handle: '@v8k6b2jjps-prog'
+KnownVulnerableSamples:
+- Filename: MyPortIO_x64.sys
+  MD5: 5a55272db2de6f37b30a0515b0c08383
+  SHA1: f6bbd1917bcb4df7550bb42c50cd7ceef2ea1837
+  SHA256: 18bf6cf0224a41058ba3944ff0df9e12fa256c7c353d6fa6132a464cd5db5709
+  Imphash: 706a0591c3a83c9a119c940315eccb27
+  Authentihash:
+    MD5: 4f0814b7cdd539a5db392cd86749a141
+    SHA1: c24d4a9da33673c9a6c2c6ae60c941494bc1b384
+    SHA256: f07de42c0f0523698dd70119a327e47ac91e520af8cce16587bf6508456c8767
+  RichPEHeaderHash:
+    MD5: dc2e31e7900e28a161c588f2498d5690
+    SHA1: 47bdd9694c32998018ddb2b99536266131452d2f
+    SHA256: 2daf260989290d822b9fd6d5c3ef523aa91242bc743710ad693e361b626c4c8a
+  Sections:
+    .text:
+      Entropy: 5.726621417649219
+      Virtual Size: '0x3a36'
+    .rdata:
+      Entropy: 3.2811216132757504
+      Virtual Size: '0x2a4'
+    .data:
+      Entropy: 3.2776134368191148
+      Virtual Size: '0x16'
+    .pdata:
+      Entropy: 3.777628220418099
+      Virtual Size: '0x18c'
+    INIT:
+      Entropy: 5.226327071549516
+      Virtual Size: '0x29c'
+    .rsrc:
+      Entropy: 3.3779095750427826
+      Virtual Size: '0x468'
+    .reloc:
+      Entropy: 2.091917186688699
+      Virtual Size: '0x10'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2015-06-22 19:03:29'
+  Description: Port I/O Driver for Win32/64
+  Company: Nuvoton Technology Corp.
+  InternalName: MyPortIO.sys
+  OriginalFilename: MyPortIO.sys
+  FileVersion: 3,0,2009,325
+  Product: Nuvoton Port I/O Driver
+  ProductVersion: 3,0,2009,325
+  Copyright: Copyright (C) 2009 Nuvoton Technology Corp.
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - MmUnmapIoSpace
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - MmMapIoSpace
+  - PoCallDriver
+  - PoStartNextPowerIrp
+  - IoReportResourceUsage
+  - KeBugCheckEx
+  - DbgPrint
+  - IoDeleteSymbolicLink
+  - RtlInitUnicodeString
+  - HalSetBusDataByOffset
+  - HalGetBusDataByOffset
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services CA
+        , G2
+      ValidFrom: '2012-12-21 00:00:00'
+      ValidTo: '2020-12-30 23:59:59'
+      Signature: 03099b8f79ef7f5930aaef68b5fae3091dbb4f82065d375fa6529f168dea1c9209446ef56deb587c30e8f9698d23730b126f47a9ae3911f82ab19bb01ac38eeb599600adce0c4db2d031a6085c2a7afce27a1d574ca86518e979406225966ec7c7376a8321088e41eaddd9573f1d7749872a16065ea6386a2212a35119837eb6
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 7e93ebfb7cc64e59ea4b9a77d406fc3b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: d0785ad36e427c92b19f6826ab1e8020
+        SHA1: 365b7a9c21bd9373e49052c3e7b3e4646ddd4d43
+        SHA256: c2abb7484da91a658548de089d52436175fdb760a1387d225611dc0613a1e2ff
+        SHA384: eab4fe5ef90e0de4a6aa3a27769a5e879f588df5e4785aa4104debd1f81e19ea56d33e3a16e5facf99f68b5d8e3d287b
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services Signer
+        , G4
+      ValidFrom: '2012-10-18 00:00:00'
+      ValidTo: '2020-12-29 23:59:59'
+      Signature: 783bb4912a004cf08f62303778a38427076f18b2de25dca0d49403aa864e259f9a40031cddcee379cb216806dab632b46dbff42c266333e449646d0de6c3670ef705a4356c7c8916c6e9b2dfb2e9dd20c6710fcd9574dcb65cdebd371f4378e678b5cd280420a3aaf14bc48829910e80d111fcdd5c766e4f5e0e4546416e0db0ea389ab13ada097110fc1c79b4807bac69f4fd9cb60c162bf17f5b093d9b5be216ca13816d002e380da8298f2ce1b2f45aa901af159c2c2f491bdb22bbc3fe789451c386b182885df03db451a179332b2e7bb9dc20091371eb6a195bcfe8a530572c89493fb9cf7fc9bf3e226863539abd6974acc51d3c7f92e0c3bc1cd80475
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0ecff438c8febf356e04d86a981b1a50
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: e9d38360b914c8863f6cba3ee58764d3
+        SHA1: 4cba8eae47b6bf76f20b3504b98b8f062694a89b
+        SHA256: 88901d86a4cc1f1bb193d08e1fb63d27452e63f83e228c657ab1a92e4ade3976
+        SHA384: e9f2a75334a9e336c5a4712eadee88d0374b0fdc273262f4e65c9040ad2793067cc076696db5279a478773485e285652
+    - Subject: C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec
+        Class 3 Extended Validation Code Signing CA , G2
+      ValidFrom: '2014-03-04 00:00:00'
+      ValidTo: '2024-03-03 23:59:59'
+      Signature: 3f5b19f3fa13d575382a5aee9f5aa04ca91dc5cc94eede15fef5106ea41ba56483541858c40b28a185c34e74e5ff897cfed5ed3cba719f5602268f162a88feb0a32722ce4be2388e00a63a865f9de53ea8de644941744121fd07c88417da1d653082cb264f39d60427a481b14b49c3238b7e02321827b7ab0bf31872b6a4ee67066f38a6588de0f17e5da460c6a8e5505fe0e8bae28f9958b6b5a0a876f1a2f11c8841727e52979b0a36998d50f701eb3ce7f0226ae5358c63368a1ab1d967665f971aefa8209df02fba6cced9948500f158f17dc97c22b5075d02c6e60bbfab9393ff27188e33367e5734f1c3af04c184f156b3e8878336f8d30a31dc6e2c6d
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 191a32cb759c97b8cfac118dd5127f49
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 788b61bd26da89253179e3de2cdb527f
+        SHA1: 7d06f16e7bf21bce4f71c2cb7a3e74351451bf69
+        SHA256: b3c925b4048c3f7c444d248a2b101186b57cba39596eb5dce0e17a4ee4b32f19
+        SHA384: 2955e28cb7ec0ea9730b499a0f189f9621eceb02591a9486b583f12bb845885a30d6a871826318a167cc5f06b274e58c
+    - Subject: JURISDICTION_OF_INCORPORATION_C=TW, BUSINESS_CATEGORY=Private Organization,
+        serialNumber=28112646, C=TW, ST=Taiwan, L=Hsinchu, O=Nuvoton Technology Corporation,
+        CN=Nuvoton Technology Corporation
+      ValidFrom: '2015-04-13 00:00:00'
+      ValidTo: '2016-05-05 23:59:59'
+      Signature: 31fed84a3ee07c3ed5e4d94b0962716e669b232727b669344e30ea4f05756c5f9601baf0577e8995dc9a57738cbe5995263100a3ba22513dd85956b9c19440c2c8d2a3aa1f7bb10b3437de92384991940f3a8780f1d0935c46541c3e61f1b5e06c2532353ece6a1818b93a0d90539efb78d81409a4a1bd3e171cad76b54dfac0397d0fff23337c9603f6c0eb0452efef37af579f5158c15843c59dea2788d13d1e2aae5cb8ba7dc60b2906313f490d934ace04bd723fdb1a50686555452c391c1ba49373d1dd283244f58d821bb6a0de87591adb762b01ed53e9d1a1995234cad3fcfd0f157bc27a6ca293241c7358781ea3fdf7657700425bf1293ea8f28b04
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 6b88ee54fe362a0f3eb83754458d8eaf
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 7780155375d561d2713472b9edd96c78
+        SHA1: 7971b8276a764c48ec2fe31879f7f09cdf1c74ba
+        SHA256: 8de7847396dfd0076fd3f90144b21ed06ae807dd2cb5afbc8d2ce999521f5699
+        SHA384: f5d4e47b8fe5100ad638b3ea0b74989d627abe9cbc1355ed29381e7db4b7e8f096bbaffca52efeb271f070f9d53d8c22
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=(c) 2006 VeriSign,
+        Inc. , For authorized use only, CN=VeriSign Class 3 Public Primary Certification
+        Authority , G5
+      ValidFrom: '2011-02-22 19:25:17'
+      ValidTo: '2021-02-22 19:35:17'
+      Signature: 812a82168c34672be503eb347b8ca2a3508af45586f11e8c8eae7dee0319ce72951848ad6211fd20fd3f4706015ae2e06f8c152c4e3c6a506c0b36a3cf7a0d9c42bc5cf819d560e369e6e22341678c6883762b8f93a32ab57fbe59fba9c9b2268fcaa2f3821b983e919527978661ee5b5d076bcd86a8e26580a8e215e2b2be23056aba0cf347934daca48c077939c061123a050d89a3ec9f578984fbecca7c47661491d8b60f195de6b84aacbc47c8714396e63220a5dc7786fd3ce38b71db7b9b03fcb71d3264eb1652a043a3fa2ead59924e7cc7f233424838513a7c38c71b242228401e1a461f17db18f7f027356cb863d9cdb9645d2ba55eefc629b4f2c7f821cc04ba57fd01b6abc667f9e7d3997ff4f522fa72f5fdff3a1c423aa1f98018a5ee8d1cd4669e4501feaaeefffb178f30f7f1cd29c59decb5d549003d85b8cbbb933a276a49c030ae66c9f723283276f9a48356c848ce5a96aaa0cc0cc47fb48e97af6de35427c39f86c0d6e473089705dbd054625e0348c2d59f7fa7668cd09db04fd4d3985f4b7ac97fb22952d01280c70f54b61e67cdc6a06c110384d34875e72afeb03b6e0a3aa66b769905a3f177686133144706fc537f52bd92145c4a246a678caf8d90aad0f679211b93267cc3ce1ebd883892ae45c6196a4950b305f8ae59378a6a250394b1598150e8ba8380b72335f476b9671d5918ad208d94
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 611993e400000000001c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 78a717e082dcc1cda3458d917e677d14
+        SHA1: 4a872e0e51f9b304469cd1dedb496ee9b8b983a4
+        SHA256: 317fa1d234ebc49040ebc5e8746f8997471496051b185a91bdd9dfbb23fab5f8
+        SHA384: b71052da4eb9157c8c1a5d7f55df19d69b9128598b72fcca608e5b7cc7d64c43c5504b9c86355a6dc22ee40c88cc385c
+    Signer:
+    - SerialNumber: 6b88ee54fe362a0f3eb83754458d8eaf
+      Issuer: C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec
+        Class 3 Extended Validation Code Signing CA , G2
+      Version: 1
+- Filename: MyPortIO_x86.sys
+  MD5: cda61b27e94b5ec1f1cde870e59eeabb
+  SHA1: 26f21762a88b9b6688b151770c4ea6c4723765e6
+  SHA256: 30d5e07d9e88722a5e0eec17d0437b859f782d1c15fc80b5381f3e3eb4221bc7
+  Imphash: 0a0842132bc8991a638c7f0a0567f777
+  Authentihash:
+    MD5: 89245a4c0a30299887888108bcfc49e0
+    SHA1: d234fc0ae8369e3e86f22d274f002d441e36b0a7
+    SHA256: afcafa6f79a93b4dc770b9fd937435575882350d2d8e7916f659384fa9e429b0
+  RichPEHeaderHash:
+    MD5: ad6927eb2fb6bd0f3660a96821905496
+    SHA1: 31d2ad460ad53f1fb224a8a54a0de1bc11941a5a
+    SHA256: 43e6f82e954d4ca3b5bc838f3db22fc304ae52d9669593d1a43795067b1983b8
+  Sections:
+    .text:
+      Entropy: 6.083749400747927
+      Virtual Size: '0x31b2'
+    .rdata:
+      Entropy: 3.139623840687522
+      Virtual Size: '0x16c'
+    .data:
+      Entropy: 2.699513850319965
+      Virtual Size: '0xe'
+    INIT:
+      Entropy: 5.434068331762518
+      Virtual Size: '0x366'
+    .rsrc:
+      Entropy: 3.3747095391611897
+      Virtual Size: '0x468'
+    .reloc:
+      Entropy: 6.360896101267897
+      Virtual Size: '0x20c'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2015-06-22 19:03:30'
+  Description: Port I/O Driver for Win32/64
+  Company: Nuvoton Technology Corp.
+  InternalName: MyPortIO.sys
+  OriginalFilename: MyPortIO.sys
+  FileVersion: 3,0,2009,325
+  Product: Nuvoton Port I/O Driver
+  ProductVersion: 3,0,2009,325
+  Copyright: Copyright (C) 2009 Nuvoton Technology Corp.
+  MachineType: I386
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - MmMapIoSpace
+  - MmUnmapIoSpace
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - KeQuerySystemTime
+  - PoCallDriver
+  - PoStartNextPowerIrp
+  - IoReportResourceUsage
+  - memset
+  - KeBugCheckEx
+  - WRITE_REGISTER_ULONG
+  - WRITE_REGISTER_USHORT
+  - WRITE_REGISTER_UCHAR
+  - READ_REGISTER_ULONG
+  - READ_REGISTER_USHORT
+  - READ_REGISTER_UCHAR
+  - DbgPrint
+  - IoDeleteSymbolicLink
+  - RtlInitUnicodeString
+  - HalSetBusDataByOffset
+  - WRITE_PORT_ULONG
+  - WRITE_PORT_USHORT
+  - WRITE_PORT_UCHAR
+  - READ_PORT_ULONG
+  - READ_PORT_USHORT
+  - READ_PORT_UCHAR
+  - HalGetBusDataByOffset
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services CA
+        , G2
+      ValidFrom: '2012-12-21 00:00:00'
+      ValidTo: '2020-12-30 23:59:59'
+      Signature: 03099b8f79ef7f5930aaef68b5fae3091dbb4f82065d375fa6529f168dea1c9209446ef56deb587c30e8f9698d23730b126f47a9ae3911f82ab19bb01ac38eeb599600adce0c4db2d031a6085c2a7afce27a1d574ca86518e979406225966ec7c7376a8321088e41eaddd9573f1d7749872a16065ea6386a2212a35119837eb6
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 7e93ebfb7cc64e59ea4b9a77d406fc3b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: d0785ad36e427c92b19f6826ab1e8020
+        SHA1: 365b7a9c21bd9373e49052c3e7b3e4646ddd4d43
+        SHA256: c2abb7484da91a658548de089d52436175fdb760a1387d225611dc0613a1e2ff
+        SHA384: eab4fe5ef90e0de4a6aa3a27769a5e879f588df5e4785aa4104debd1f81e19ea56d33e3a16e5facf99f68b5d8e3d287b
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services Signer
+        , G4
+      ValidFrom: '2012-10-18 00:00:00'
+      ValidTo: '2020-12-29 23:59:59'
+      Signature: 783bb4912a004cf08f62303778a38427076f18b2de25dca0d49403aa864e259f9a40031cddcee379cb216806dab632b46dbff42c266333e449646d0de6c3670ef705a4356c7c8916c6e9b2dfb2e9dd20c6710fcd9574dcb65cdebd371f4378e678b5cd280420a3aaf14bc48829910e80d111fcdd5c766e4f5e0e4546416e0db0ea389ab13ada097110fc1c79b4807bac69f4fd9cb60c162bf17f5b093d9b5be216ca13816d002e380da8298f2ce1b2f45aa901af159c2c2f491bdb22bbc3fe789451c386b182885df03db451a179332b2e7bb9dc20091371eb6a195bcfe8a530572c89493fb9cf7fc9bf3e226863539abd6974acc51d3c7f92e0c3bc1cd80475
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0ecff438c8febf356e04d86a981b1a50
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: e9d38360b914c8863f6cba3ee58764d3
+        SHA1: 4cba8eae47b6bf76f20b3504b98b8f062694a89b
+        SHA256: 88901d86a4cc1f1bb193d08e1fb63d27452e63f83e228c657ab1a92e4ade3976
+        SHA384: e9f2a75334a9e336c5a4712eadee88d0374b0fdc273262f4e65c9040ad2793067cc076696db5279a478773485e285652
+    - Subject: C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec
+        Class 3 Extended Validation Code Signing CA , G2
+      ValidFrom: '2014-03-04 00:00:00'
+      ValidTo: '2024-03-03 23:59:59'
+      Signature: 3f5b19f3fa13d575382a5aee9f5aa04ca91dc5cc94eede15fef5106ea41ba56483541858c40b28a185c34e74e5ff897cfed5ed3cba719f5602268f162a88feb0a32722ce4be2388e00a63a865f9de53ea8de644941744121fd07c88417da1d653082cb264f39d60427a481b14b49c3238b7e02321827b7ab0bf31872b6a4ee67066f38a6588de0f17e5da460c6a8e5505fe0e8bae28f9958b6b5a0a876f1a2f11c8841727e52979b0a36998d50f701eb3ce7f0226ae5358c63368a1ab1d967665f971aefa8209df02fba6cced9948500f158f17dc97c22b5075d02c6e60bbfab9393ff27188e33367e5734f1c3af04c184f156b3e8878336f8d30a31dc6e2c6d
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 191a32cb759c97b8cfac118dd5127f49
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 788b61bd26da89253179e3de2cdb527f
+        SHA1: 7d06f16e7bf21bce4f71c2cb7a3e74351451bf69
+        SHA256: b3c925b4048c3f7c444d248a2b101186b57cba39596eb5dce0e17a4ee4b32f19
+        SHA384: 2955e28cb7ec0ea9730b499a0f189f9621eceb02591a9486b583f12bb845885a30d6a871826318a167cc5f06b274e58c
+    - Subject: JURISDICTION_OF_INCORPORATION_C=TW, BUSINESS_CATEGORY=Private Organization,
+        serialNumber=28112646, C=TW, ST=Taiwan, L=Hsinchu, O=Nuvoton Technology Corporation,
+        CN=Nuvoton Technology Corporation
+      ValidFrom: '2015-04-13 00:00:00'
+      ValidTo: '2016-05-05 23:59:59'
+      Signature: 31fed84a3ee07c3ed5e4d94b0962716e669b232727b669344e30ea4f05756c5f9601baf0577e8995dc9a57738cbe5995263100a3ba22513dd85956b9c19440c2c8d2a3aa1f7bb10b3437de92384991940f3a8780f1d0935c46541c3e61f1b5e06c2532353ece6a1818b93a0d90539efb78d81409a4a1bd3e171cad76b54dfac0397d0fff23337c9603f6c0eb0452efef37af579f5158c15843c59dea2788d13d1e2aae5cb8ba7dc60b2906313f490d934ace04bd723fdb1a50686555452c391c1ba49373d1dd283244f58d821bb6a0de87591adb762b01ed53e9d1a1995234cad3fcfd0f157bc27a6ca293241c7358781ea3fdf7657700425bf1293ea8f28b04
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 6b88ee54fe362a0f3eb83754458d8eaf
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 7780155375d561d2713472b9edd96c78
+        SHA1: 7971b8276a764c48ec2fe31879f7f09cdf1c74ba
+        SHA256: 8de7847396dfd0076fd3f90144b21ed06ae807dd2cb5afbc8d2ce999521f5699
+        SHA384: f5d4e47b8fe5100ad638b3ea0b74989d627abe9cbc1355ed29381e7db4b7e8f096bbaffca52efeb271f070f9d53d8c22
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=(c) 2006 VeriSign,
+        Inc. , For authorized use only, CN=VeriSign Class 3 Public Primary Certification
+        Authority , G5
+      ValidFrom: '2011-02-22 19:25:17'
+      ValidTo: '2021-02-22 19:35:17'
+      Signature: 812a82168c34672be503eb347b8ca2a3508af45586f11e8c8eae7dee0319ce72951848ad6211fd20fd3f4706015ae2e06f8c152c4e3c6a506c0b36a3cf7a0d9c42bc5cf819d560e369e6e22341678c6883762b8f93a32ab57fbe59fba9c9b2268fcaa2f3821b983e919527978661ee5b5d076bcd86a8e26580a8e215e2b2be23056aba0cf347934daca48c077939c061123a050d89a3ec9f578984fbecca7c47661491d8b60f195de6b84aacbc47c8714396e63220a5dc7786fd3ce38b71db7b9b03fcb71d3264eb1652a043a3fa2ead59924e7cc7f233424838513a7c38c71b242228401e1a461f17db18f7f027356cb863d9cdb9645d2ba55eefc629b4f2c7f821cc04ba57fd01b6abc667f9e7d3997ff4f522fa72f5fdff3a1c423aa1f98018a5ee8d1cd4669e4501feaaeefffb178f30f7f1cd29c59decb5d549003d85b8cbbb933a276a49c030ae66c9f723283276f9a48356c848ce5a96aaa0cc0cc47fb48e97af6de35427c39f86c0d6e473089705dbd054625e0348c2d59f7fa7668cd09db04fd4d3985f4b7ac97fb22952d01280c70f54b61e67cdc6a06c110384d34875e72afeb03b6e0a3aa66b769905a3f177686133144706fc537f52bd92145c4a246a678caf8d90aad0f679211b93267cc3ce1ebd883892ae45c6196a4950b305f8ae59378a6a250394b1598150e8ba8380b72335f476b9671d5918ad208d94
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 611993e400000000001c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 78a717e082dcc1cda3458d917e677d14
+        SHA1: 4a872e0e51f9b304469cd1dedb496ee9b8b983a4
+        SHA256: 317fa1d234ebc49040ebc5e8746f8997471496051b185a91bdd9dfbb23fab5f8
+        SHA384: b71052da4eb9157c8c1a5d7f55df19d69b9128598b72fcca608e5b7cc7d64c43c5504b9c86355a6dc22ee40c88cc385c
+    Signer:
+    - SerialNumber: 6b88ee54fe362a0f3eb83754458d8eaf
+      Issuer: C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec
+        Class 3 Extended Validation Code Signing CA , G2
+      Version: 1


### PR DESCRIPTION
## Summary
- adds MyPortIO_x64.sys and MyPortIO_x86.sys coverage for issue #380
- documents the Nuvoton/ASRock Polychrome RGB driver IOCTL primitives reported publicly
- adds LFS-backed samples and metadata extracted from both drivers

Closes #380

## Validation
- `python3 bin/validate.py -y yaml -s bin/spec/drivers.spec.json`
- `git diff --check`
- verified both `.bin` files are staged as Git LFS pointers