### PR TITLE
Add EnTech PowerStrip pstrip64.sys driver (CVE-2026-29923)

### DIFF
--- a/yaml/1db2dd90-5b8e-43c3-a39b-61e0614fb2ab.yaml
+++ b/yaml/1db2dd90-5b8e-43c3-a39b-61e0614fb2ab.yaml
@@ -1,0 +1,201 @@
+Id: 1db2dd90-5b8e-43c3-a39b-61e0614fb2ab
+Tags:
+- pstrip64.sys
+Verified: 'TRUE'
+Author: Aryu-RU
+Created: '2026-06-25'
+MitreID: T1068
+CVE:
+- CVE-2026-29923
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create pstrip64 binPath=C:\windows\temp\pstrip64.sys type=kernel
+    && sc.exe start pstrip64
+  Description: pstrip64.sys is the EnTech Taiwan PowerStrip x64 kernel-mode driver,
+    signed by EnTech Taiwan. In PowerStrip version 3.90.736 and earlier, the driver's
+    IOCTL dispatcher exposes code 0x80002008, which maps caller-supplied physical
+    memory directly into the requesting user-mode process and returns the mapped virtual
+    base address, giving a local user an arbitrary physical read/write primitive.
+    Public exploitation of CVE-2026-29923 uses this to scan physical memory for the
+    EPROCESS 'Proc' pool tag, copy the SYSTEM process token, and overwrite the caller's
+    token to escalate to NT AUTHORITY\SYSTEM.
+  Usecase: Arbitrary physical memory read/write from user mode, abused for local privilege
+    escalation to SYSTEM via token theft.
+  Privileges: User
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://nvd.nist.gov/vuln/detail/CVE-2026-29923
+- https://github.com/athenasec16/CVE-2026-29923
+Detection: []
+Acknowledgement:
+  Person: athenasec16
+  Handle: '@athenasec16'
+KnownVulnerableSamples:
+- Filename: pstrip64.sys
+  MD5: 23eed24b0a780863df35b500c4ea0733
+  SHA1: af413e76094f8a60d06d161a270427c6c2e3c018
+  SHA256: ab01485bb7c8bc1a9c86096eeea6d31d8fad557bf4d44072b46373d2203faa6e
+  Imphash: 9c9e46c46aee658661dab538a361b117
+  Authentihash:
+    MD5: 7b3dd9835689db0ccd3741e6023d0f11
+    SHA1: 3cba01d9fd8670a12ce987f17c16a1c05fed80b7
+    SHA256: fd826f76a840c23d643611ab94d39b86aed4da221cdd7bfc688aaaf7cc8b64d7
+  RichPEHeaderHash:
+    MD5: 8931fe7954847589edf231b9a19a1779
+    SHA1: 6f108b4bb46086de8085b46c408384510a947adf
+    SHA256: 45c397ea58efc8ba6e4f0488202506434a67c1e5acf00f60108425f8a6a6ff47
+  Sections:
+    .text:
+      Entropy: 5.821237442380178
+      Virtual Size: '0x778'
+    .rdata:
+      Entropy: 4.155104465087849
+      Virtual Size: '0x12c'
+    .data:
+      Entropy: 0.0
+      Virtual Size: '0x8'
+    .pdata:
+      Entropy: 2.8635633350977345
+      Virtual Size: '0x3c'
+    INIT:
+      Entropy: 4.351237602400712
+      Virtual Size: '0x1da'
+    .rsrc:
+      Entropy: 3.336239926097096
+      Virtual Size: '0x354'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2004-04-14 12:07:40'
+  Description: EnTech x64 kernel-mode driver
+  Company: EnTech Taiwan
+  InternalName: pstrip64.sys
+  OriginalFilename: pstrip64.sys
+  FileVersion: '1.0'
+  Product: PowerStrip
+  ProductVersion: '2.1'
+  Copyright: Copyright (c) EnTech Taiwan, 2004-2006.
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ObReferenceObjectByHandle
+  - ZwOpenSection
+  - RtlInitUnicodeString
+  - DbgPrint
+  - IofCompleteRequest
+  - ZwMapViewOfSection
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoCreateSymbolicLink
+  - IoCreateDevice
+  - ZwUnmapViewOfSection
+  - ZwClose
+  - HalTranslateBusAddress
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=TW, O=EnTech Taiwan, CN=EnTech Taiwan, emailAddress=support@entechtaiwan.com
+      ValidFrom: '2006-09-25 13:13:42'
+      ValidTo: '2007-09-25 13:13:42'
+      Signature: 739a954688a5bb20b2eb536c3f48cd6e12268b1f20d7c8919b33fe01a7bce0f1b635aa818464902885ff85b54359fc618e27daed7251ddd7b69aadfa93934e4984a4df006169520d8153e467cdda6346d13de5534c458dc65d8cee53d40449ddf07c0141baaf5c5027a3ffa82282697be813b8bfd97f2ba1ca2cfb12a20c6962e5bd556fb794d67bd6d3d6f8db113a64833073294431ed9bfa94dd7d62ec07c6093c7fbdba8663fcff1b5d8c6f6322d236abfacc681f9aaf5711fb415e1622d125175ea225f785983e05f56cd7f3dede31c4faea8272570ea3079a8085a8333d348780b35d671479caef0f7d1c23da8bf317ca12b50da33f87f24a4c1b9766b5
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 0100000000010de51c0971
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: 2fa8071fc8b4266de6fbcd201437b3a5
+        SHA1: 4b937982ab09b70f8676542f39a883a4294d3fca
+        SHA256: 6934f8f9093cbf62b6af5802405c022d546a33427b98b882522ce29190ae082f
+        SHA384: 11c9878017cbfd40b61344b4b9106d38c1a5660c9192257a58921828c9f216a3e4d5ec36af3924f75cff64499cc9f0f5
+    - Subject: C=US, O=VeriSign, Inc., CN=VeriSign Time Stamping Services CA
+      ValidFrom: '2003-12-04 00:00:00'
+      ValidTo: '2013-12-03 23:59:59'
+      Signature: 4a6bf9ea58c2441c318979992b96bf82ac01d61c4ccdb08a586edf0829a35ec8ca9313e704520def47272f0038b0e4c9934e9ad4226215f73f37214f703180f18b3887b3e8e89700fecf55964e24d2a9274e7aaeb76141f32acee7c9d95eddbb2b853eb59db5d9e157ffbeb4c57ef5cf0c9ef097fe2bd33b521b1b3827f73f4a
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 47bf1995df8d524643f7db6d480d31a4
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 518d2ea8a21e879c942d504824ac211c
+        SHA1: 21ce87d827077e61abddf2beba69fde5432ea031
+        SHA256: 1ec3b4f02e03930a470020e0e48d24b84678bb558f46182888d870541f5e25c7
+        SHA384: 53e346bbde23779a5d116cc9d86fdd71c97b1f1b343439f8a11aa1d3c87af63864bb8488a5aeb2d0c26a6a1e0b15f03f
+    - Subject: C=BE, O=GlobalSign nv,sa, OU=Primary Object Publishing CA, CN=GlobalSign
+        Primary Object Publishing CA
+      ValidFrom: '1999-01-28 12:00:00'
+      ValidTo: '2014-01-27 11:00:00'
+      Signature: a0422eb876a7427186404d464d5b26b0b074f93f89a87b7cb7f1c697e08239999d43fe60823642b55b878df55df4bbffa91044a871d3c7f12241f29aa4a5ec63fae5eb654a19309d8bc7b6fddc3fe16cfdd5521407fc6d24ccb3cc81a2c052f327b96d9e063dd8a849023269c7054294d0bbe3bba908c393501bdb846dc0ba1e5298659c1376bdb3d567292f1f7baa2c51a0fd854f263c48a38127a6feee7f7899c245cf9d1f527ed7958bfde1d020c3af7e51a22f663bab2dcf2d8e8c4d7d18392128fbdcae6d6581d0e0d7184be7b5f774d784e6522aac3b68fd3b4ab80154849132bb95d28e6330a69ece2396feab2eb86a8b74dcde21a114c2fbbf53af10
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 04000000000108d9611cd6
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 698f075151097d84c0b1f3e7bc3d6fca
+        SHA1: 041750993d7c9e063f02dfe74699598640911aab
+        SHA256: a8622cca0913a20477be8313b8d16fcad5d83088b46b36ddac10b31e96abb5e8
+        SHA384: a50291d3b15caf28d96e972cefcb88455a58ce1c802920fdcc2f4feafb1553510fd9b464d25e81635f4ad37570225a67
+    - Subject: C=US, O=VeriSign, Inc., CN=VeriSign Time Stamping Services Signer
+      ValidFrom: '2003-12-04 00:00:00'
+      ValidTo: '2008-12-03 23:59:59'
+      Signature: 877870da4e5201205be079c98230c4fdb91996bd9100c3bdcdcdc6f40ed8fff94dc033623011c5f5741bd492de5f9c2013b17c45be50cd83e7801783a72793671346fbcab8984103cc9b515b058b7fa86ff31b501b242ef2698d6c22f7bbca1695ed0c74c06877d9eb996287c17390f889747a23aba3987b97b1f78f29714d2e751b4841daf0b50d2054d677a097826369fd09cf8af075bb099bd9f91155269a6132be7a02b07b86bea2c38b222c78d13576bc92735cf9b9e64c150a23cce4d2d4342e4940153c0f607a24c6a566ef96cf70eb3ee7f40d7edcd17ca3767169c19c4f47303521b1a2af1a623c2bd98eaa2a077bd818b35c7be29da56ffe3c89ad
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0de92bf0d4d82988183205095e9a7688
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: 45c204b8a20f6abb0188d2d38a3fb0c9
+        SHA1: cdf3a3c5c2eda4c29621f30fd3154f9f8c765739
+        SHA256: e32839dddc0f4ed2474efaf37f59d46db400c700fd19533cb0895a111124bc77
+        SHA384: ee9c75832cb252218b3201619852209df490d2ef7a5f7a28afdb37f1c1dd56f4604898838e558f615b1c798d4a488223
+    - Subject: C=BE, O=GlobalSign nv,sa, OU=ObjectSign CA, CN=GlobalSign ObjectSign
+        CA
+      ValidFrom: '2004-01-22 09:00:00'
+      ValidTo: '2014-01-27 10:00:00'
+      Signature: 11d45d8af43d0d9d7e4fa70071610b56b34caa70e1b2d1dec7886d1d897c2ba946e58b1f8e4cc26695911fe34d394ae31b70b7446edc068a4d6d25e89812dcbca0dd864eae8f81130540905a542529944acaf165b4ef0679dae7cb86f004c918dcee72b320015748dfe333e12ccd9c077f9447278d888d340ca67c5c20c17d07b3736b648c26d29bd7e87965a6a891a174862a050282c1847cf279cd3c2a2b0f99291eea8c8a1ab16aeaa266380e65e1add8c6c91f888d3976ee1782c4138d97ce6341e77af5b4b66c15c33813b3930b620688dde1447f10a950248b60dc05f75ba514b27b56720b96eabffc057090659e051ca4dd07af4b57dec639673bc574
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 04000000000108d9612448
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 2fc76031fc24eec1ef3db2d246d21d6a
+        SHA1: 75c3a1f76b9dfa31ef6bf56325e7bd0bf6e4779d
+        SHA256: 9238292d441c56dc89684c253343c17de3ed9cecd7f83d1d8f793b5ebc91f7b9
+        SHA384: 9279c1377eb701fdd79ef85038ff151cd8902169ba55fca84b9850f003563f73a1daaf869544252a2e42f06f58d2275f
+    - Subject: C=BE, O=GlobalSign nv,sa, OU=Root CA, CN=GlobalSign Root CA
+      ValidFrom: '2006-05-23 17:00:51'
+      ValidTo: '2016-05-23 17:10:51'
+      Signature: 13c56c5e077f3c57ff9b315f3fbd955425c679f92c31034d64694b56d95b976f7cf3f0d024657538639813701613f7a701f1c623e085866c0bf080945a75e87ce41e92b473bfc1b3a7b00bd31884cbcc09a35c9c4f3eb03a9c2d1bc404ef9737966fe5ecbaac6ab3d4e23cdf8b25e7acbc624531dda40a72e41bf8784301ccba3914de5d90aed85acf5eca46815133d5a60e5867d3d8665888169beeb11acaad91138421da9a6e20efda007428bac95ff34d5dc3da25692554ea44bcc39b29331cd63c961f8781c553d72a2733d42e197c08586ddb4e1999a9ea5ff39a9d8c513a5a5cbd2fa908359b54a7db351a521633343aa380046afdb4838cad90cf0c3a6596ec334e1826b849bbeb8192ff134d324b23c733e7b6716b15f69c80e6bcb76cbe41d5033a7133150050743b0e5df996aaed903eab134c809926bc38a5eb0236891db620be83ab10f8199ed76379d4aeb12f6136f94a4ba833c70e7241f9f1b1907eae46efde397b75a0411459041d42bc4788b8130e05fa1df0808dff70c677d84bdc460e231a72d5bfdefeaaae69583cfc5c46e4d5819a8b6e6559771a32a590a6b6649364fd0753c9a0de28ad2a6cc638d181ce98f54019e92c1743a4265fd3443053e41d02baa40a2f16dd7a60275242bbad98372897e4b8d27911e3108c48d5305d0a0c52def588ea8d1a2d67c9f4801484b7850cd16628a5c66f2461
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 610b7f6b000000000019
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 4798d55be7663a75649cda4dedc686ef
+        SHA1: 0f1ab2937b245d9466ea6f9bf056a5942e3989cf
+        SHA256: ef14ea05bb066ee9f4188196dd69cd769b283ac4d7555db52f5e76922d3456e1
+        SHA384: 6e7450a139856aeda6fa6284ff89b3752a9b646e096b4d33dd7e8e727742a2111481531581c0aa2cda0338e22cfdbad3
+    Signer:
+    - SerialNumber: 0100000000010de51c0971
+      Issuer: C=BE, O=GlobalSign nv,sa, OU=ObjectSign CA, CN=GlobalSign ObjectSign
+        CA
+      Version: 1


### PR DESCRIPTION
## Summary

Adds a new `vulnerable driver` entry for **`pstrip64.sys`**, the EnTech Taiwan **PowerStrip** x64 kernel-mode driver, covered by **CVE-2026-29923** (CVSS 3.1 **7.8 High**, CWE-269).

The driver's IOCTL dispatcher exposes code **`0x80002008`**, which maps caller-supplied physical memory directly into the requesting user-mode process and returns the mapped virtual base address — an arbitrary physical read/write primitive available to a local user. Public exploitation scans physical memory for the EPROCESS `Proc` pool tag, copies the SYSTEM process token, and overwrites the caller's token to escalate to `NT AUTHORITY\SYSTEM`. This is a classic BYOVD local-privilege-escalation primitive in a legitimately signed driver. MITRE: **T1068**.

## Sample

| Field | Value |
|-------|-------|
| Filename | `pstrip64.sys` |
| SHA256 | `ab01485bb7c8bc1a9c86096eeea6d31d8fad557bf4d44072b46373d2203faa6e` |
| MD5 | `23eed24b0a780863df35b500c4ea0733` |
| SHA1 | `af413e76094f8a60d06d161a270427c6c2e3c018` |
| Signature | EnTech Taiwan (GlobalSign ObjectSign CA; VeriSign timestamp) |
| Product / Company | PowerStrip / EnTech Taiwan |

## References

- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-29923
- PoC + write-up: https://github.com/athenasec16/CVE-2026-29923

## Verification performed

- **Sample retrieved and hashes recomputed locally** — the binary was downloaded from the public PoC repo and its SHA256 matches the disclosed hash byte-for-byte; MD5/SHA1/SHA256 were recomputed from the actual sample.
- **Metadata enriched from the sample** via `bin/metadata-extractor.py` (Imphash, Authentihash, RichPEHeaderHash, sections, imports, full certificate chain / TBS hashes).
- **Signature inspected** — validly signed by EnTech Taiwan; the `ZwMapViewOfSection` / `ZwOpenSection` / `HalTranslateBusAddress` imports corroborate the physical-memory-mapping primitive described in the CVE.
- `bin/validate.py` → **No Errors found**.

## Novelty / dedup

Hash, filename (`pstrip64.sys`), and CVE-2026-29923 are all absent from the current `yaml/` catalog, and no open or closed PR references them.

## Reviewer considerations

- **Category** set to `vulnerable driver`: legitimate, validly signed EnTech Taiwan driver abused via BYOVD (not purpose-built malware).
- **Related sibling entry:** EnTech's `TVicPort64.sys` (`b4f3a1c2-…`) shares the same direct-I/O engine and the identical IOCTL `0x80002008` primitive. PowerStrip and TVicPort are distinct products with distinct binaries/hashes/CVEs, so this is filed as a separate entry consistent with the existing per-driver convention — happy to fold it in differently if you prefer.
- Driver `.bin` not committed (LFS handled maintainer-side); this PR is YAML-only.
