### PR TITLE
Add HONOR MonProcessEX.sys

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -173,3 +173,4 @@ drivers/e2bfb13653b0569e4c3ddbde10f89493.bin filter=lfs diff=lfs merge=lfs -text
 drivers/b316425d6f200244a25bd7b9998d9c43.bin filter=lfs diff=lfs merge=lfs -text
 drivers/0b5c4cd701956b332e60ae85b8c3a7ea.bin filter=lfs diff=lfs merge=lfs -text
 drivers/297a9b187c6897749bc7bb92d02e95c0.bin filter=lfs diff=lfs merge=lfs -text
+drivers/b32a250d1ef99bb62dd66cea60311f43.bin filter=lfs diff=lfs merge=lfs -text

--- a/drivers/b32a250d1ef99bb62dd66cea60311f43.bin
+++ b/drivers/b32a250d1ef99bb62dd66cea60311f43.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72d0b5615b996cbb01b1ca139e627079094f734da48a0435ffd8480a25d0a258
+size 57576

--- a/yaml/c3c083d2-e9bd-4891-8582-46086de2b2b4.yaml
+++ b/yaml/c3c083d2-e9bd-4891-8582-46086de2b2b4.yaml
@@ -1,0 +1,194 @@
+Id: c3c083d2-e9bd-4891-8582-46086de2b2b4
+Tags:
+- MonProcessEX.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-07-08'
+MitreID: T1562.001
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create MonProcessEX binPath=C:\windows\temp\MonProcessEX.sys type=kernel
+    && sc.exe start MonProcessEX
+  Description: MonProcessEX.sys is a HONOR MagicAnimation and HONOR PCManager kernel
+    driver that exposes IOCTL 0x22400C to reach ZwTerminateProcess. The device is
+    accessible to LocalSystem and local administrators, and the process-termination
+    path does not verify the caller, allowing an administrator-accessible client to
+    terminate arbitrary user-mode processes except PID 0 and PID 4 from kernel mode.
+  Usecase: Terminate arbitrary processes through an insufficiently protected kernel
+    IOCTL handler.
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/384
+Detection: []
+Acknowledgement:
+  Person: ''
+  Handle: '@wwwab123'
+KnownVulnerableSamples:
+- Filename: MonProcessEX.sys
+  MD5: b32a250d1ef99bb62dd66cea60311f43
+  SHA1: e674c507ca0c61854c61e316acdf711c790f5d24
+  SHA256: 72d0b5615b996cbb01b1ca139e627079094f734da48a0435ffd8480a25d0a258
+  Imphash: e5c2e380d0150ab25a79920138b8cc4b
+  Authentihash:
+    MD5: 8816668de83718556497b2e45d169689
+    SHA1: 2b703146815077e6c4a593e547f2dc55f3484b7f
+    SHA256: 7a2b0415957f71aa019d1ce9e8f399130d71dfe5d1b6c83cc8b1182109f414eb
+  RichPEHeaderHash:
+    MD5: 28612c9470f7b566c40af71b9de570ab
+    SHA1: 588de5abff6b71159b5f61d841bdff99fd5c181d
+    SHA256: f16ab0fe8e460c2de466990d813a88f12325d9fb412a6bd7eb49e089ab441a0d
+  Sections:
+    .text:
+      Entropy: 5.9122556940049495
+      Virtual Size: '0x3405'
+    .rdata:
+      Entropy: 4.247553088234589
+      Virtual Size: '0xe78'
+    .data:
+      Entropy: 1.2579539201441403
+      Virtual Size: '0x2340'
+    .pdata:
+      Entropy: 4.250563853445473
+      Virtual Size: '0x438'
+    PAGE:
+      Entropy: 6.210698068394262
+      Virtual Size: '0x2506'
+    INIT:
+      Entropy: 5.574531045581285
+      Virtual Size: '0x8ba'
+    .rsrc:
+      Entropy: 3.2609922309279487
+      Virtual Size: '0x390'
+    .reloc:
+      Entropy: 3.7299010728563298
+      Virtual Size: '0x3c'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2026-02-13 01:03:04'
+  Description: MonProcess
+  Company: Honor Device Co., Ltd.
+  InternalName: MonProcess
+  OriginalFilename: MonProcess.sys
+  FileVersion: 1.0.0.1
+  Product: Honor
+  ProductVersion: 1.0.0.1
+  Copyright: Copyright (C) Honor Device Co., Ltd. 2016-2020. All rights reserved.
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - DbgPrint
+  - KeGetCurrentIrql
+  - ZwClose
+  - ZwOpenProcess
+  - ZwSetInformationProcess
+  - RtlInitUnicodeString
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - InitSafeBootMode
+  - MmGetSystemRoutineAddress
+  - RtlFreeUnicodeString
+  - RtlGetVersion
+  - ExAllocatePool2
+  - ExFreePoolWithTag
+  - ObReferenceObjectByHandle
+  - ZwTerminateProcess
+  - __C_specific_handler
+  - RtlCompareUnicodeStrings
+  - KeInitializeEvent
+  - KeSetEvent
+  - ExAcquireFastMutex
+  - ExReleaseFastMutex
+  - ObfDereferenceObject
+  - PsSetCreateProcessNotifyRoutineEx
+  - ExEventObjectType
+  - RtlEqualUnicodeString
+  - ZwQueryValueKey
+  - ZwSetSecurityObject
+  - IoDeviceObjectType
+  - IoCreateDevice
+  - ObOpenObjectByPointer
+  - RtlGetDaclSecurityDescriptor
+  - RtlGetGroupSecurityDescriptor
+  - RtlGetOwnerSecurityDescriptor
+  - RtlGetSaclSecurityDescriptor
+  - SeCaptureSecurityDescriptor
+  - _snwprintf
+  - RtlLengthSecurityDescriptor
+  - SeExports
+  - RtlCreateSecurityDescriptor
+  - _wcsnicmp
+  - ExAllocatePoolWithTag
+  - wcschr
+  - RtlAbsoluteToSelfRelativeSD
+  - RtlAddAccessAllowedAce
+  - RtlLengthSid
+  - IoIsWdmVersionAvailable
+  - RtlSetDaclSecurityDescriptor
+  - ZwOpenKey
+  - ZwSetValueKey
+  - ZwCreateKey
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=BE, O=GlobalSign nv,sa, CN=GlobalSign Code Signing Root R45
+      ValidFrom: '2020-07-28 00:00:00'
+      ValidTo: '2029-03-18 00:00:00'
+      Signature: acf7cc158b3079a81d0b28881909d71c7ffe86bd7b5a336e0d670e7b62d9e1185cb0bd135d1d23ae39507637aa44fd5f01235986564cccadbc64131430a420a8e03fe89c72dc7ef3d80c23baa82daa3cf6ec9f87310765f539a7518275e1f22f97f6d1e165968364fea11d51fbb5249bf5d27769bc852c5cfa5877d1aea7b10be2d677bba9b4344aa96f3df4f30d955de6f97a45b02517312edbf70f68e6831fa9f7e5d49d988cd3614b2fc3287e7ade930eb47da00a6d92c4b4663f7da758eeacf7ecc30801ab38fc0a1ca9c597b288c8090219f65c9a1af14d6c30d4b306ab0060480d78abcf17ad9293622077756cbdc832b4dc4debd9dfc1909629bdc17f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 7803184245708a41cf6f01b8eeb4a954
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: a33260428269bc902bc1cd280e4b1837
+        SHA1: 254209ca172cffcc67bd2a88996556d2f09538f0
+        SHA256: a67411358594f2cf016741a63fd49f36de917f86531b3e3a43eb6a421c654868
+        SHA384: fec727af43d1569995cea26e8eb97167165842a5b185304425a92c03b71254c5d51222837515f33e60cb8ed2e8c625ba
+    - Subject: C=BE, O=GlobalSign nv,sa, CN=GlobalSign GCC R45 EV CodeSigning CA 2020
+      ValidFrom: '2020-07-28 00:00:00'
+      ValidTo: '2030-07-28 00:00:00'
+      Signature: 2575a009c939bab7a139892f189fabd6eb1d4be8947c0d07689b1c9def71b6176a6b024fb33f864587cc659b4ce35806022266d56102c5638fd4a2f1b65e250b7796e9cd7140338829eceef3a26dbc4db53e064bc97333ca08142d3d4ce8b0ba75a6742da4583a6c1349f8a5150a149685b16a68342542af9656f410fa247df12b72c116e16bebe6a998c73e5af4d0189dfd74978677462a3d237d28738aaeef2b1b9abf6c53a7149e3c8771c05e8ec8fbd32a9233ea574d5e075ecac118ac812d1a21fa6ecf97617bdf717a3aca63f7d530443732febb4385dcbafca6ca33192b776ddbcb05f07e5f752ea2b6bf35aa3663c9ce64d9bdfcbc2cf3495600c8122bc627bb37af57efc4cf1e29c4f4e22dce2a61cf57edf50a40e2f518d61ee9902fcad3875f938a481a111de537859f2e66629a5e814e95ac555743dc538b257e3c610f8a0bbaf53fa6d78ef704565e21bb9fd76a7180bf96de7203d8d8222bf327164f38e851400cae92efbe3d7df780c64c36578495a7841548300e5227088d8ea2bd22c719c9a6ca0ea87a36db6aba615f112495a4e28e68ee19a949995ed0b434bdd6f940c710973152393529118724d3c4fba963cb7748d5fa62fc24e0047a4ed0e46edece9e385026f4217165d70925d4c907007ab8c7f377e8c5d4e255d0d31ef67f52e2498db911720c88442633660144dfe4330e21de62894807daf5
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 77bd0e05b7590bb61d4761531e3f75ed
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 65fd1dac1f115d9507f4e1840c8cb36a
+        SHA1: c7cf5607e19b22fe60c055e71d9b555d70f71f66
+        SHA256: d9c7db0b704f07089440c56e69a0f31d730edf77cfbf7514630e8b5390a270fe
+        SHA384: defe810317bd1215b4d1ee0ec8a5fb38b21d094ef1173cae670956cd899232638e4f9473fd947bd550a4a77300bbb2ab
+    - Subject: "BUSINESS_CATEGORY=Private Organization, serialNumber=91440300MA5G49LC9K,\
+        \ JURISDICTION_OF_INCORPORATION_C=CN, JURISDICTION_OF_INCORPORATION_SP=Guangdong,\
+        \ JURISDICTION_OF_INCORPORATION_L=Shenzhen, C=CN, ST=Guangdong, L=Shenzhen,\
+        \ STREET_ADDRESS=\u798F\u7530\u533A\u9999\u871C\u6E56\u8857\u9053\u4E1C\u6D77\
+        \u793E\u533A\u7EA2\u8354\u897F\u8DEF8089\u53F7\u6DF1\u4E1A\u4E2D\u57CE6\u53F7\
+        \u697CA\u5355\u51433401, O=Honor Device Co., Ltd., CN=Honor Device Co., Ltd."
+      ValidFrom: '2023-12-14 09:34:53'
+      ValidTo: '2026-11-28 09:15:10'
+      Signature: 598eeb133d94263336a451a0458319572beb8b2d511efb9e4bc1c4b44afa7464883693bb8833df77189bae91d01a5a7bf3837e0fc3eec457b294a071c93ebf719b48a8ca2d095f0d73f670c8b7081096d969e8af368c91d3c814f38c5f8b8a0da78e803c22f973b83fa17167d492ce3190be35c356ea290a2241b540220b4b33b47cea8870827cc08cdb9557cd66a75082a086ec40d0318d65c28c2051b2baadded9eb47332107c1a03d8346e540d3d6bd0d3dac8b3108f6a0ddb236cb716c0ac16c6160d23d14487ae4d8d535b07645394b4619793f62a704608d8cbd097ca169d085d18c8e776617e7a7be94968e662ac998890b491080950b6cca7f425ac05147910b579a53dae0dad1576d80cdd73c51318f27c42aaa11cf684602009c98f7fddcd33130cc7533963cf4913cf577943ec98e4053083226906ead774db80c23aa7721805e6b0004606f10e676ba165e969ca9b3c1eaba944ad920457f31f46e234c7b5af7fac14df216f148f6d9df08bf38be5a4e19aa2b45c48956e5075663cd455e942d8847c370c15affb6e6691b280d6b7606ff33e9fcbd58cbfbafdba14d6c7336fd7d77fddae2b309286ea3dc5cec07935b39128605d26bec11ff70a05f4f5e861c886597208e698d6dcf46c02761d6eeaebe4c1c2c3a96f77d093853a0574da8f09379a02c84c3a07770491489b255ac3ed86d1a5372a0d41eaadb
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 032fba56284f12315bb78036
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: b7fc4b809e20b3f13cc3ba9957e7604b
+        SHA1: 99db55c393dbc2e903f0355bf1350c005b8ab1c7
+        SHA256: 7febf29a3eca70c31f18a3fd3136f9dd4be2a580d4a7bb4e280851bcf217e565
+        SHA384: 5a9dbc083f686dfd54d7081f089bc2eadb97ad6dce45b6d2654310332cd084b221c109f3d04472280bfb31a873aad280
+    Signer:
+    - SerialNumber: 032fba56284f12315bb78036
+      Issuer: C=BE, O=GlobalSign nv,sa, CN=GlobalSign GCC R45 EV CodeSigning CA 2020
+      Version: 1


### PR DESCRIPTION
## Summary
- Adds HONOR MonProcessEX.sys from #384 as a vulnerable driver entry.
- Includes the LFS-tracked driver binary under the standard MD5-based name.
- Enriches the sample with PE metadata, authentihash values, imports, and signature details.

## Validation
- Ran metadata extraction against the attached sample.
- Ran `python3 bin/validate.py -v`.

Closes #384