### PR TITLE
Add QIOMem.sys driver

### DIFF
--- a/drivers/43252ab49c9a43d22aa583c15e96f7b7.bin
+++ b/drivers/43252ab49c9a43d22aa583c15e96f7b7.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6abd8d0d541bcf9e257c65122216b1d2ae92cbf8a3a3cb7ce340846e66c449ca
+size 22736

--- a/yaml/6eca187c-8fb2-4eae-9c80-fd9ef9d8c91e.yaml
+++ b/yaml/6eca187c-8fb2-4eae-9c80-fd9ef9d8c91e.yaml
@@ -1,0 +1,129 @@
+Id: 6eca187c-8fb2-4eae-9c80-fd9ef9d8c91e
+Tags:
+    - QIOMem.sys
+Author: valium
+Created: '2026-07-10'
+MitreID: T1068
+CVE:
+    - CVE-2026-56129
+Category: vulnerable driver
+Verified: 'TRUE'
+Commands:
+    Command: 'sc.exe create qiomem binPath=C:\windows\temp\qiomem.sys type=kernel && sc.exe start qiomem'
+    Description: 'Exposes arbitrary physical memory read/write access through six IOCTLs (0x08012000, 0x08012004, 0x08012008, 0x0801200C, 0x08012010, 0x08012014) via MmMapIoSpace. Can be exploited by unprivileged processes to achieve local privilege escalation, modify kernel data, and bypass security.'
+    Usecase: Elevate Privileges
+    Privileges: kernel
+    OperatingSystem: Windows 10
+Resources:
+    - 'https://github.com/valium007/qiomem'
+    - 'https://jvn.jp/vu/JVNVU91051826/'
+Acknowledgement:
+    Person: 'valium'
+    Handle: '@valium007'
+Detection: []
+KnownVulnerableSamples:
+-   Filename: QIOMem.sys
+    Libraries:
+        - ntoskrnl.exe
+    ImportedFunctions:
+        - RtlFreeUnicodeString
+        - KeInitializeSpinLock
+        - IoAttachDeviceToDeviceStack
+        - IofCallDriver
+        - IofCompleteRequest
+        - IoCreateDevice
+        - IoDeleteDevice
+        - IoRegisterDeviceInterface
+        - KeInitializeEvent
+        - KeSetEvent
+        - KeWaitForSingleObject
+        - IoDetachDevice
+        - IoSetDeviceInterfaceState
+        - ExAllocatePoolWithTag
+        - ExFreePoolWithTag
+        - MmMapIoSpace
+        - MmUnmapIoSpace
+        - IoWMIOpenBlock
+        - IoWMIQuerySingleInstance
+        - IoWMISetSingleInstance
+        - IoReportTargetDeviceChangeAsynchronous
+        - PoRequestPowerIrp
+        - PoSetPowerState
+        - PoCallDriver
+        - PoStartNextPowerIrp
+        - IoAllocateIrp
+        - IoBuildDeviceIoControlRequest
+        - IoFreeIrp
+        - IoGetAttachedDeviceReference
+        - ObfDereferenceObject
+    ExportedFunctions: []
+    MD5: 43252ab49c9a43d22aa583c15e96f7b7
+    SHA1: ee37a040b6ec7882b4e240e70da67bc0900fd799
+    SHA256: 6abd8d0d541bcf9e257c65122216b1d2ae92cbf8a3a3cb7ce340846e66c449ca
+    Imphash: 25adb8efbc15f349a1e3578fb2b9bf8f
+    Machine: AMD64
+    MagicHeader: 50 45 0 0
+    CreationTimestamp: '2015-05-05 11:10:35'
+    RichPEHeaderMD5: b06ee72c38688c22e116ef8109e4c6c8
+    RichPEHeaderSHA1: 6fb19cea0bf673048937137ae021785a3c50f51b
+    RichPEHeaderSHA256: acace1751c5a54f5b9a1906ac66d24a79e8c8fa9148b50b2b8ebd4861ca91f10
+    AuthentihashMD5: e7d3aa85b456b305803472f276dd29f0
+    AuthentihashSHA1: 927108063af531702e54c89d3beb395f715f9706
+    AuthentihashSHA256: de7b59f676aadcc0173e5a8d6b22f74f6a7f9c0ed906e5cc5f3e0fd821adb813
+    Sections:
+        LOCKED:
+            Entropy: 5.271371694056955
+            VirtualSize: '0xe4'
+        .text:
+            Entropy: 6.014337560743019
+            VirtualSize: '0x940'
+        .rdata:
+            Entropy: 3.953261012966467
+            VirtualSize: '0x3fc'
+        .data:
+            Entropy: 3.75
+            VirtualSize: '0x10'
+        .pdata:
+            Entropy: 3.6653809535148123
+            VirtualSize: '0x15c'
+        PAGE:
+            Entropy: 6.139767828139948
+            VirtualSize: '0xb50'
+        INIT:
+            Entropy: 5.206628139229045
+            VirtualSize: '0x4ba'
+        .rsrc:
+            Entropy: 3.2321549912698786
+            VirtualSize: '0x330'
+        .reloc:
+            Entropy: 2.3954618442383215
+            VirtualSize: '0x14'
+    CompanyName: ''
+    FileDescription: ''
+    InternalName: ''
+    OriginalFilename: ''
+    FileVersion: ''
+    ProductName: ''
+    LegalCopyright: ''
+    ProductVersion: ''
+    Signatures:
+        - CertificatesInfo: ''
+          SignerInfo: ''
+          Certificates:
+              - Subject: CN=WDKTestCert 1,130752733198717037
+                ValidFrom: '2015-05-05 04:22:00'
+                ValidTo: '2025-05-05 00:00:00'
+                Signature: 37263cc0f54f52c4e64f0c6352d5ace94b517ef3603ec03fe1d1f319d6e21e92f09dec78062be4bb8bd8bbd186b0244ac737c36a71c1369711ed41d33d3df12ea4e101cf87513257cce90d77b5b2c11124481b2c7af558bfe326909638bcd33dd2b5740db59e314b43e22ccb7bc6b12e66ab8a72a50d818e5beb1e897ae3b43e5f4437a4dccb05ab96ec5a3ea2315325c0399ce0854f14f2e2dbd0a64dc0abcd8b25be28d18eb93b96ee2f661ed467c51b5ae696e55ca46b123ae8c900bdee2124f210ad640a040eac4a6222ba1f880a2e8c214a81c4251ed1b3c33ca7d5f6ce77400f5f20a84fb39e0d27d9e57626fa3acc17e6f387852c461eeac29cd7e738
+                SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+                IsCertificateAuthority: true
+                SerialNumber: 1fa194ec05480faf4587210ed5dadd0e
+                Version: '3'
+                TBS:
+                    MD5: 320eaa8b2d51fe81279df22ddf8ad432
+                    SHA1: c4cd618c351fb3ebeb4a311be5309c63c3b9a4c1
+                    SHA256: f6b8e27adc02bc59edb9eba387c5e063ff0c3260567c5ab714e397ad8d916551
+                    SHA384: e30ec578d02909be1d8cd6a5b7b3d405ccd4422531d8dcd9e738ecdd8155cd4c1216e66ed5e4b96e09f61aed4021bf37
+          Signer:
+              - SerialNumber: 1fa194ec05480faf4587210ed5dadd0e
+                Issuer: CN=WDKTestCert 1,130752733198717037
+                Version: '1'

--- a/yaml/6eca187c-8fb2-4eae-9c80-fd9ef9d8c91e.yaml
+++ b/yaml/6eca187c-8fb2-4eae-9c80-fd9ef9d8c91e.yaml
@@ -1,129 +1,151 @@
 Id: 6eca187c-8fb2-4eae-9c80-fd9ef9d8c91e
 Tags:
-    - QIOMem.sys
+- QIOMem.sys
 Author: valium
 Created: '2026-07-10'
 MitreID: T1068
 CVE:
-    - CVE-2026-56129
+- CVE-2026-56129
 Category: vulnerable driver
 Verified: 'TRUE'
 Commands:
-    Command: 'sc.exe create qiomem binPath=C:\windows\temp\qiomem.sys type=kernel && sc.exe start qiomem'
-    Description: 'Exposes arbitrary physical memory read/write access through six IOCTLs (0x08012000, 0x08012004, 0x08012008, 0x0801200C, 0x08012010, 0x08012014) via MmMapIoSpace. Can be exploited by unprivileged processes to achieve local privilege escalation, modify kernel data, and bypass security.'
-    Usecase: Elevate Privileges
-    Privileges: kernel
-    OperatingSystem: Windows 10
+  Command: acpi.exe
+  Description: QIOMem.sys is the Generic IO & Memory Access driver included with
+    Toshiba and Dynabook password utilities. It binds to ACPI\QCI0701; on systems
+    without that firmware device, the public proof of concept creates a matching
+    software PnP device to trigger loading of an already-installed driver package.
+    Six IOCTLs (0x08012000 through 0x08012014) pass an unvalidated 32-bit physical
+    address to MmMapIoSpace, allowing a low-privileged process to read or write
+    one, two, or four bytes of physical memory below 4 GiB.
+  Usecase: Read or write physical memory from a low-privileged process.
+  Privileges: User
+  OperatingSystem: Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
 Resources:
-    - 'https://github.com/valium007/qiomem'
-    - 'https://jvn.jp/vu/JVNVU91051826/'
+- https://github.com/valium007/qiomem
+- https://valium007.github.io/posts/toshiba-vuln/
+- https://jvn.jp/vu/JVNVU91051826/
+- https://www.cve.org/CVERecord?id=CVE-2026-56129
+- https://dynabook.com/assistpc/info/2026/20260619_security.htm
 Acknowledgement:
-    Person: 'valium'
-    Handle: '@valium007'
+  Person: Akshit Yadav
+  Handle: '@valium007'
 Detection: []
 KnownVulnerableSamples:
--   Filename: QIOMem.sys
-    Libraries:
-        - ntoskrnl.exe
-    ImportedFunctions:
-        - RtlFreeUnicodeString
-        - KeInitializeSpinLock
-        - IoAttachDeviceToDeviceStack
-        - IofCallDriver
-        - IofCompleteRequest
-        - IoCreateDevice
-        - IoDeleteDevice
-        - IoRegisterDeviceInterface
-        - KeInitializeEvent
-        - KeSetEvent
-        - KeWaitForSingleObject
-        - IoDetachDevice
-        - IoSetDeviceInterfaceState
-        - ExAllocatePoolWithTag
-        - ExFreePoolWithTag
-        - MmMapIoSpace
-        - MmUnmapIoSpace
-        - IoWMIOpenBlock
-        - IoWMIQuerySingleInstance
-        - IoWMISetSingleInstance
-        - IoReportTargetDeviceChangeAsynchronous
-        - PoRequestPowerIrp
-        - PoSetPowerState
-        - PoCallDriver
-        - PoStartNextPowerIrp
-        - IoAllocateIrp
-        - IoBuildDeviceIoControlRequest
-        - IoFreeIrp
-        - IoGetAttachedDeviceReference
-        - ObfDereferenceObject
-    ExportedFunctions: []
-    MD5: 43252ab49c9a43d22aa583c15e96f7b7
-    SHA1: ee37a040b6ec7882b4e240e70da67bc0900fd799
-    SHA256: 6abd8d0d541bcf9e257c65122216b1d2ae92cbf8a3a3cb7ce340846e66c449ca
-    Imphash: 25adb8efbc15f349a1e3578fb2b9bf8f
-    Machine: AMD64
-    MagicHeader: 50 45 0 0
-    CreationTimestamp: '2015-05-05 11:10:35'
-    RichPEHeaderMD5: b06ee72c38688c22e116ef8109e4c6c8
-    RichPEHeaderSHA1: 6fb19cea0bf673048937137ae021785a3c50f51b
-    RichPEHeaderSHA256: acace1751c5a54f5b9a1906ac66d24a79e8c8fa9148b50b2b8ebd4861ca91f10
-    AuthentihashMD5: e7d3aa85b456b305803472f276dd29f0
-    AuthentihashSHA1: 927108063af531702e54c89d3beb395f715f9706
-    AuthentihashSHA256: de7b59f676aadcc0173e5a8d6b22f74f6a7f9c0ed906e5cc5f3e0fd821adb813
-    Sections:
-        LOCKED:
-            Entropy: 5.271371694056955
-            VirtualSize: '0xe4'
-        .text:
-            Entropy: 6.014337560743019
-            VirtualSize: '0x940'
-        .rdata:
-            Entropy: 3.953261012966467
-            VirtualSize: '0x3fc'
-        .data:
-            Entropy: 3.75
-            VirtualSize: '0x10'
-        .pdata:
-            Entropy: 3.6653809535148123
-            VirtualSize: '0x15c'
-        PAGE:
-            Entropy: 6.139767828139948
-            VirtualSize: '0xb50'
-        INIT:
-            Entropy: 5.206628139229045
-            VirtualSize: '0x4ba'
-        .rsrc:
-            Entropy: 3.2321549912698786
-            VirtualSize: '0x330'
-        .reloc:
-            Entropy: 2.3954618442383215
-            VirtualSize: '0x14'
-    CompanyName: ''
-    FileDescription: ''
-    InternalName: ''
-    OriginalFilename: ''
-    FileVersion: ''
-    ProductName: ''
-    LegalCopyright: ''
-    ProductVersion: ''
-    Signatures:
-        - CertificatesInfo: ''
-          SignerInfo: ''
-          Certificates:
-              - Subject: CN=WDKTestCert 1,130752733198717037
-                ValidFrom: '2015-05-05 04:22:00'
-                ValidTo: '2025-05-05 00:00:00'
-                Signature: 37263cc0f54f52c4e64f0c6352d5ace94b517ef3603ec03fe1d1f319d6e21e92f09dec78062be4bb8bd8bbd186b0244ac737c36a71c1369711ed41d33d3df12ea4e101cf87513257cce90d77b5b2c11124481b2c7af558bfe326909638bcd33dd2b5740db59e314b43e22ccb7bc6b12e66ab8a72a50d818e5beb1e897ae3b43e5f4437a4dccb05ab96ec5a3ea2315325c0399ce0854f14f2e2dbd0a64dc0abcd8b25be28d18eb93b96ee2f661ed467c51b5ae696e55ca46b123ae8c900bdee2124f210ad640a040eac4a6222ba1f880a2e8c214a81c4251ed1b3c33ca7d5f6ce77400f5f20a84fb39e0d27d9e57626fa3acc17e6f387852c461eeac29cd7e738
-                SignatureAlgorithmOID: 1.2.840.113549.1.1.5
-                IsCertificateAuthority: true
-                SerialNumber: 1fa194ec05480faf4587210ed5dadd0e
-                Version: '3'
-                TBS:
-                    MD5: 320eaa8b2d51fe81279df22ddf8ad432
-                    SHA1: c4cd618c351fb3ebeb4a311be5309c63c3b9a4c1
-                    SHA256: f6b8e27adc02bc59edb9eba387c5e063ff0c3260567c5ab714e397ad8d916551
-                    SHA384: e30ec578d02909be1d8cd6a5b7b3d405ccd4422531d8dcd9e738ecdd8155cd4c1216e66ed5e4b96e09f61aed4021bf37
-          Signer:
-              - SerialNumber: 1fa194ec05480faf4587210ed5dadd0e
-                Issuer: CN=WDKTestCert 1,130752733198717037
-                Version: '1'
+- Filename: QIOMem.sys
+  Libraries:
+  - ntoskrnl.exe
+  ImportedFunctions:
+  - RtlFreeUnicodeString
+  - KeInitializeSpinLock
+  - IoAttachDeviceToDeviceStack
+  - IofCallDriver
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoDeleteDevice
+  - IoRegisterDeviceInterface
+  - KeInitializeEvent
+  - KeSetEvent
+  - KeWaitForSingleObject
+  - IoDetachDevice
+  - IoSetDeviceInterfaceState
+  - ExAllocatePoolWithTag
+  - ExFreePoolWithTag
+  - MmMapIoSpace
+  - MmUnmapIoSpace
+  - IoWMIOpenBlock
+  - IoWMIQuerySingleInstance
+  - IoWMISetSingleInstance
+  - IoReportTargetDeviceChangeAsynchronous
+  - PoRequestPowerIrp
+  - PoSetPowerState
+  - PoCallDriver
+  - PoStartNextPowerIrp
+  - IoAllocateIrp
+  - IoBuildDeviceIoControlRequest
+  - IoFreeIrp
+  - IoGetAttachedDeviceReference
+  - ObfDereferenceObject
+  ExportedFunctions: ''
+  MD5: 43252ab49c9a43d22aa583c15e96f7b7
+  SHA1: ee37a040b6ec7882b4e240e70da67bc0900fd799
+  SHA256: 6abd8d0d541bcf9e257c65122216b1d2ae92cbf8a3a3cb7ce340846e66c449ca
+  Imphash: 25adb8efbc15f349a1e3578fb2b9bf8f
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2015-05-05 05:40:35'
+  Sections:
+    LOCKED:
+      Entropy: 5.271371694056955
+      Virtual Size: '0xe4'
+    .text:
+      Entropy: 6.014337560743019
+      Virtual Size: '0x940'
+    .rdata:
+      Entropy: 3.953261012966467
+      Virtual Size: '0x3fc'
+    .data:
+      Entropy: 3.75
+      Virtual Size: '0x10'
+    .pdata:
+      Entropy: 3.6653809535148123
+      Virtual Size: '0x15c'
+    PAGE:
+      Entropy: 6.139767828139949
+      Virtual Size: '0xb50'
+    INIT:
+      Entropy: 5.2066281392290445
+      Virtual Size: '0x4ba'
+    .rsrc:
+      Entropy: 3.2321549912698786
+      Virtual Size: '0x330'
+    .reloc:
+      Entropy: 2.395461844238322
+      Virtual Size: '0x14'
+  InternalName: QIOMem
+  OriginalFilename: QIOMem.sys
+  FileVersion: 5.0.0.0
+  ProductVersion: 5.0.0.0
+  Signature:
+  - WDKTestCert 1,130752733198717037
+  - Microsoft Windows Hardware Compatibility Publisher
+  - Microsoft Windows Third Party Component CA 2012
+  - Microsoft Root Certificate Authority 2010
+  Publisher: Microsoft Windows Hardware Compatibility Publisher
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: CN=WDKTestCert 1,130752733198717037
+      ValidFrom: '2015-05-05 04:22:00'
+      ValidTo: '2025-05-05 00:00:00'
+      Signature: 37263cc0f54f52c4e64f0c6352d5ace94b517ef3603ec03fe1d1f319d6e21e92f09dec78062be4bb8bd8bbd186b0244ac737c36a71c1369711ed41d33d3df12ea4e101cf87513257cce90d77b5b2c11124481b2c7af558bfe326909638bcd33dd2b5740db59e314b43e22ccb7bc6b12e66ab8a72a50d818e5beb1e897ae3b43e5f4437a4dccb05ab96ec5a3ea2315325c0399ce0854f14f2e2dbd0a64dc0abcd8b25be28d18eb93b96ee2f661ed467c51b5ae696e55ca46b123ae8c900bdee2124f210ad640a040eac4a6222ba1f880a2e8c214a81c4251ed1b3c33ca7d5f6ce77400f5f20a84fb39e0d27d9e57626fa3acc17e6f387852c461eeac29cd7e738
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 1fa194ec05480faf4587210ed5dadd0e
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 320eaa8b2d51fe81279df22ddf8ad432
+        SHA1: c4cd618c351fb3ebeb4a311be5309c63c3b9a4c1
+        SHA256: f6b8e27adc02bc59edb9eba387c5e063ff0c3260567c5ab714e397ad8d916551
+        SHA384: e30ec578d02909be1d8cd6a5b7b3d405ccd4422531d8dcd9e738ecdd8155cd4c1216e66ed5e4b96e09f61aed4021bf37
+    Signer:
+    - SerialNumber: 1fa194ec05480faf4587210ed5dadd0e
+      Issuer: CN=WDKTestCert 1,130752733198717037
+      Version: 1
+  Authentihash:
+    MD5: e7d3aa85b456b305803472f276dd29f0
+    SHA1: 927108063af531702e54c89d3beb395f715f9706
+    SHA256: de7b59f676aadcc0173e5a8d6b22f74f6a7f9c0ed906e5cc5f3e0fd821adb813
+  RichPEHeaderHash:
+    MD5: b06ee72c38688c22e116ef8109e4c6c8
+    SHA1: 6fb19cea0bf673048937137ae021785a3c50f51b
+    SHA256: acace1751c5a54f5b9a1906ac66d24a79e8c8fa9148b50b2b8ebd4861ca91f10
+  Description: Generic IO & Memory Access
+  Company: TOSHIBA
+  Product: ''
+  Copyright: Copyright(C) 2009-2016 TOSHIBA. All rights reserved.
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe


### PR DESCRIPTION
## Summary

Adds QIOMem.sys, the Generic IO & Memory Access driver included with Toshiba and Dynabook password utilities, as a vulnerable driver associated with CVE-2026-56129.

The driver exposes six insufficiently protected IOCTLs that pass a caller-controlled 32-bit physical address to `MmMapIoSpace`. A low-privileged process with access to the device can read or write one, two, or four bytes of physical memory below 4 GiB.

## Technical details

- **Driver:** QIOMem.sys 5.0.0.0
- **CVE:** CVE-2026-56129
- **Hardware ID:** `ACPI\QCI0701`
- **Read IOCTLs:** `0x08012000`, `0x08012004`, `0x08012008`
- **Write IOCTLs:** `0x0801200C`, `0x08012010`, `0x08012014`
- **SHA-256:** `6abd8d0d541bcf9e257c65122216b1d2ae92cbf8a3a3cb7ce340846e66c449ca`
- **Affected platforms:** Windows 7, 8, 8.1, 10, and 11

QIOMem.sys is a PnP driver. The public proof of concept creates a matching software device when the ACPI device is absent, then demonstrates end-to-end physical-memory reads and writes. The primitive could support further kernel compromise, but the published proof of concept does not itself implement a privilege-escalation or EDR-bypass chain.

## References

- https://github.com/valium007/qiomem
- https://valium007.github.io/posts/toshiba-vuln/
- https://jvn.jp/vu/JVNVU91051826/
- https://www.cve.org/CVERecord?id=CVE-2026-56129
- https://dynabook.com/assistpc/info/2026/20260619_security.htm

Reported by Akshit Yadav ([@valium007](https://github.com/valium007)).
