### PR TITLE
Add Kontron KTAPI vulnerable drivers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -175,3 +175,6 @@ drivers/0b5c4cd701956b332e60ae85b8c3a7ea.bin filter=lfs diff=lfs merge=lfs -text
 drivers/297a9b187c6897749bc7bb92d02e95c0.bin filter=lfs diff=lfs merge=lfs -text
 drivers/b32a250d1ef99bb62dd66cea60311f43.bin filter=lfs diff=lfs merge=lfs -text
 drivers/23eed24b0a780863df35b500c4ea0733.bin filter=lfs diff=lfs merge=lfs -text
+drivers/96a8b9db2dc9cba8cdf90c7c33fe11c4.bin filter=lfs diff=lfs merge=lfs -text
+drivers/2c10be1aea72b7bdf07c735a4ad68876.bin filter=lfs diff=lfs merge=lfs -text
+drivers/e3c123a2ee4720001ed35d45fa1e57eb.bin filter=lfs diff=lfs merge=lfs -text

--- a/drivers/2c10be1aea72b7bdf07c735a4ad68876.bin
+++ b/drivers/2c10be1aea72b7bdf07c735a4ad68876.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ca9432b0d29204cb5420a1a6b01533d4552130c2a8a5ecd7837efadefb4a046
+size 14728

--- a/drivers/96a8b9db2dc9cba8cdf90c7c33fe11c4.bin
+++ b/drivers/96a8b9db2dc9cba8cdf90c7c33fe11c4.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ee17efef04bb7c9de90d5210263ed6993f867e5a11f86e65e3bb1362c7de237
+size 14288

--- a/drivers/e3c123a2ee4720001ed35d45fa1e57eb.bin
+++ b/drivers/e3c123a2ee4720001ed35d45fa1e57eb.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89ba754861e11d9db4440b2b5db61fd5bee16752e4623c4271b8fdd0a666c677
+size 13704

--- a/yaml/8a6aebaa-34aa-46e8-a864-4189a55fd17b.yaml
+++ b/yaml/8a6aebaa-34aa-46e8-a864-4189a55fd17b.yaml
@@ -1,0 +1,494 @@
+Id: 8a6aebaa-34aa-46e8-a864-4189a55fd17b
+Tags:
+- ktapi.sys
+Verified: 'TRUE'
+Author: Aaron Walton
+Created: '2026-07-10'
+MitreID: T1562.001
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create ktapi binPath=C:\windows\temp\ktapi.sys type=kernel && sc.exe
+    start ktapi
+  Description: ktapi.sys is a legacy cross-signed Kontron Technology Application Programming
+    Interface driver that exposes the \\.\ktapi device to user mode. IOCTL 0x82007000
+    accepts a caller-controlled interface type, bus address, and size before using
+    HalTranslateBusAddress, ZwOpenSection, and ZwMapViewOfSection to map physical
+    memory into the calling process. Certain interface types cause HalTranslateBusAddress
+    to return the supplied address unchanged, allowing an attacker to map arbitrary
+    system RAM for physical-memory read and write. Expel documented this primitive
+    in an EDR-killer exploit used by The Gentlemen ransomware group to obtain kernel
+    code execution and terminate security processes.
+  Usecase: Map arbitrary physical memory from user mode for kernel read/write and
+    defense impairment.
+  Privileges: kernel
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://expel.com/blog/not-very-gentlemanly-analyzing-a-zero-day-exploit-used-by-the-gentlemen-ransomware-to-disable-targets-edrs/
+- https://github.com/magicsword-io/LOLDrivers/issues/386
+Detection: []
+Acknowledgement:
+  Person: Aaron Walton
+  Handle: '@AaronWalton'
+KnownVulnerableSamples:
+- Filename: ktapi.sys
+  MD5: 96a8b9db2dc9cba8cdf90c7c33fe11c4
+  SHA1: 86c85f4cbc36377d6fdb3f2af7d3049d5174c62c
+  SHA256: 7ee17efef04bb7c9de90d5210263ed6993f867e5a11f86e65e3bb1362c7de237
+  Imphash: 70988f60e2fd3f3d7776089a737aece5
+  Authentihash:
+    MD5: 7b6216d216bfa67fd891f220599768ee
+    SHA1: fb2670420e6096cda9c873d7dc4199de3b2ea870
+    SHA256: 5936c769202e628091702af98691e8ee838bf0acbefba7731322457f254665de
+  RichPEHeaderHash:
+    MD5: 9e9050c5d551831f95b27a51a264c2c2
+    SHA1: 85c45cb76547293a9ab7e801090fd5d9b84c06e5
+    SHA256: 57cf70125e3a29f39428a109dc641cb6418177a4bcdca2745272715562d4e362
+  Sections:
+    .text:
+      Entropy: 6.038500501863033
+      Virtual Size: '0xb4e'
+    .rdata:
+      Entropy: 4.464433347079781
+      Virtual Size: '0x194'
+    .data:
+      Entropy: 0.49172118383425784
+      Virtual Size: '0x120'
+    .pdata:
+      Entropy: 3.3869938940456152
+      Virtual Size: '0x78'
+    INIT:
+      Entropy: 5.0637688000792265
+      Virtual Size: '0x282'
+    .rsrc:
+      Entropy: 3.342301335368188
+      Virtual Size: '0x3e0'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2012-11-08 01:13:30'
+  Description: Kontron Technology Application Programming Interface
+  Company: Kontron Technology A/S
+  InternalName: ktapi.sys
+  OriginalFilename: ktapi.sys
+  FileVersion: '1.0.1899 built by: WinDDK'
+  Product: KTAPI System Driver
+  ProductVersion: 1.0.1899
+  Copyright: "Copyright \xA9 Kontron Technology A/S. 2010"
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - ZwUnmapViewOfSection
+  - ZwClose
+  - IofCompleteRequest
+  - ObReferenceObjectByHandle
+  - ZwMapViewOfSection
+  - IoCreateSymbolicLink
+  - IoCreateDevice
+  - ZwOpenSection
+  - KeBugCheckEx
+  - IoDeleteSymbolicLink
+  - KeStallExecutionProcessor
+  - HalTranslateBusAddress
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services Signer
+        , G3
+      ValidFrom: '2012-05-01 00:00:00'
+      ValidTo: '2012-12-31 23:59:59'
+      Signature: 1e98aa27b778b508b5c9726db7dfc00e98a635c488c9d2f66df14b1afbd5f92d99009ed1e79b8be13fbd39800c66cd07bc5c9854a694ba10d14e8babf56f65cc6709a2807c52e80e03d66b7ac60518ecc8ac427c072ca73d0866dc00edfd941d73f2729893b111d68fef8eeaacf496510cd08ddf31524f5eaf7da74a75e64ece2b9f292be7cf5d9f037e6e277b23ad622966af92e82ccebd9c7fdccd173c43c2093f7545c79ee4d7607f97c6e4aac769f5fccd74ac2cb048c1504e70561eb535d38ebeb1edacbdfe0cec857dd5bb856644195d9f93eb82ba639ed37c61ffc81bd923587f30a366a139265e92c33ccb3732faf5a38ddcd5b0a3e9253655d781fa
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 79a2a585f9d1154213d9b83ef6b68ded
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: e6d820afb23af20a65cf0b03247ea05e
+        SHA1: 7a8f7c37453f99390ee1e94bb5d3d1cba3a0eea7
+        SHA256: 7e722dc40e6b9abf8c20aa4d887e34b6d2c6b8cbe53a055d49bf9f5e946e0d27
+        SHA384: 7e14609969a388d38d227df1dbb9ce086c9a820142c94fd1a28ef2835a8aa528aef4c6399bce344d79adb5f3dad86afa
+    - Subject: C=US, O=VeriSign, Inc., CN=VeriSign Time Stamping Services CA
+      ValidFrom: '2003-12-04 00:00:00'
+      ValidTo: '2013-12-03 23:59:59'
+      Signature: 4a6bf9ea58c2441c318979992b96bf82ac01d61c4ccdb08a586edf0829a35ec8ca9313e704520def47272f0038b0e4c9934e9ad4226215f73f37214f703180f18b3887b3e8e89700fecf55964e24d2a9274e7aaeb76141f32acee7c9d95eddbb2b853eb59db5d9e157ffbeb4c57ef5cf0c9ef097fe2bd33b521b1b3827f73f4a
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 47bf1995df8d524643f7db6d480d31a4
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 518d2ea8a21e879c942d504824ac211c
+        SHA1: 21ce87d827077e61abddf2beba69fde5432ea031
+        SHA256: 1ec3b4f02e03930a470020e0e48d24b84678bb558f46182888d870541f5e25c7
+        SHA384: 53e346bbde23779a5d116cc9d86fdd71c97b1f1b343439f8a11aa1d3c87af63864bb8488a5aeb2d0c26a6a1e0b15f03f
+    - Subject: C=BE, O=GlobalSign nv,sa, CN=GlobalSign CodeSigning CA , G2
+      ValidFrom: '2011-04-13 10:00:00'
+      ValidTo: '2019-04-13 10:00:00'
+      Signature: 225cc5dd3df40b70d8e3f5e7c58e0901bbb196365c5a07adc7a8444951257aae0da4193b929ccfb94226bb3b6c97e7c7ce116d6891da8d6df1534d54388c61f3c8827669be81320b31c36cc99e200a582ff048fe7e4807aad743589473540431a9780d3b8cb070c13d7ed7bd2f2ac3e2f58f0c90dc6ba5c8be685e5d6df878d2be49951e15780891fb34c8be84adbce0c6dd18dbf3caf07bc2143c18b803ba953e211e3f60697a7f6a039e8d4af9f0282c30845eec267242b16dcb64c3128cd6844b67417cb103177809e3ada8b6962da47e80034f88f7c16b5a4615cd2c198bd8709ce52d49886072a8a4195270435edad64603b0680e24ef4af60b2524ef24
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 0400000000012f4ee1355c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: f6a9e8eb8784f3f694b4e353c08a0ff5
+        SHA1: 589a7d4df869395601ba7538a65afae8c4616385
+        SHA256: cbdc9a0ad785d0c2013211746b42234e18bdc7d54a7a260647badc1c9e712ed4
+        SHA384: dcec542f242317863d0b3d23947e17d6982e381003831777b07ed75b46fb18bd0392a89c9beb6862981cd05f3f2fb77b
+    - Subject: C=DE, ST=Bayern, L=Eching, O=Kontron AG, CN=Kontron AG
+      ValidFrom: '2012-01-25 16:18:08'
+      ValidTo: '2015-01-25 16:18:08'
+      Signature: 3cd002b164a77998a577b5209e13c77ac743c6c177b0ad88df5e43cbb51bed56c4da20b87eae68a3eb616303efdab682494593b2c784872ec57fb5762e8c37bc176bbc83879f17308b2a3c7d9a3c2a2c0d3535795d335e0e8d8c473c154a37e271470a772ebc7c1d950bad1511d63a7334429744770bbbb48f21f22957585c022ac207d03fb36fd4567a690e483e97c73ea315e93d625f08e4a9a7e2f9892ca6058e6bd66f032c97455738ee66c49f721ac1cfd403d70927b6b3d58ac352513cc96fc1c27da9979bb9bf5223585921944ba31b506f8e18eff973f3ed1b8c4a2835a9b0d52664975e8e43c9e729d86a45a43f395502965fc2627e215f5c6f8b09
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 112124891f00678b52f93b9c375bd8913a62
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 7a1cc84cea09e254149a703f91b63e83
+        SHA1: 9543ac93e47b5b93c567bd096259ea9eb55fb506
+        SHA256: c6f0b9a617b86b7df7543dbe82e14c0fafaa1f275e91d4b84ad0e1b7aa0452cb
+        SHA384: cff04b53b4c972534b6d7ffe2b51e9b6779f4430c3a5b66d6d6d72908324843587c67d9207510cad8bb1d4bcbb30f29c
+    - Subject: C=BE, O=GlobalSign nv,sa, OU=Root CA, CN=GlobalSign Root CA
+      ValidFrom: '2006-05-23 17:00:51'
+      ValidTo: '2016-05-23 17:10:51'
+      Signature: 13c56c5e077f3c57ff9b315f3fbd955425c679f92c31034d64694b56d95b976f7cf3f0d024657538639813701613f7a701f1c623e085866c0bf080945a75e87ce41e92b473bfc1b3a7b00bd31884cbcc09a35c9c4f3eb03a9c2d1bc404ef9737966fe5ecbaac6ab3d4e23cdf8b25e7acbc624531dda40a72e41bf8784301ccba3914de5d90aed85acf5eca46815133d5a60e5867d3d8665888169beeb11acaad91138421da9a6e20efda007428bac95ff34d5dc3da25692554ea44bcc39b29331cd63c961f8781c553d72a2733d42e197c08586ddb4e1999a9ea5ff39a9d8c513a5a5cbd2fa908359b54a7db351a521633343aa380046afdb4838cad90cf0c3a6596ec334e1826b849bbeb8192ff134d324b23c733e7b6716b15f69c80e6bcb76cbe41d5033a7133150050743b0e5df996aaed903eab134c809926bc38a5eb0236891db620be83ab10f8199ed76379d4aeb12f6136f94a4ba833c70e7241f9f1b1907eae46efde397b75a0411459041d42bc4788b8130e05fa1df0808dff70c677d84bdc460e231a72d5bfdefeaaae69583cfc5c46e4d5819a8b6e6559771a32a590a6b6649364fd0753c9a0de28ad2a6cc638d181ce98f54019e92c1743a4265fd3443053e41d02baa40a2f16dd7a60275242bbad98372897e4b8d27911e3108c48d5305d0a0c52def588ea8d1a2d67c9f4801484b7850cd16628a5c66f2461
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 610b7f6b000000000019
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 4798d55be7663a75649cda4dedc686ef
+        SHA1: 0f1ab2937b245d9466ea6f9bf056a5942e3989cf
+        SHA256: ef14ea05bb066ee9f4188196dd69cd769b283ac4d7555db52f5e76922d3456e1
+        SHA384: 6e7450a139856aeda6fa6284ff89b3752a9b646e096b4d33dd7e8e727742a2111481531581c0aa2cda0338e22cfdbad3
+    Signer:
+    - SerialNumber: 112124891f00678b52f93b9c375bd8913a62
+      Issuer: C=BE, O=GlobalSign nv,sa, CN=GlobalSign CodeSigning CA , G2
+      Version: 1
+- Filename: ktapi.sys
+  MD5: 2c10be1aea72b7bdf07c735a4ad68876
+  SHA1: 8b5cf43fba2c2226e6146ee065490dad17acc820
+  SHA256: 9ca9432b0d29204cb5420a1a6b01533d4552130c2a8a5ecd7837efadefb4a046
+  Imphash: 70988f60e2fd3f3d7776089a737aece5
+  Authentihash:
+    MD5: 8f02305dfbeb3df6ee48156fde37ab2f
+    SHA1: da72619db2843aa91e5ba8b3467386e194f93c18
+    SHA256: 646a91c588bd5f0f2e7649723297211efec1fcbe92f44f4b3b8858350beaa402
+  RichPEHeaderHash:
+    MD5: 9e9050c5d551831f95b27a51a264c2c2
+    SHA1: 85c45cb76547293a9ab7e801090fd5d9b84c06e5
+    SHA256: 57cf70125e3a29f39428a109dc641cb6418177a4bcdca2745272715562d4e362
+  Sections:
+    .text:
+      Entropy: 6.038500501863033
+      Virtual Size: '0xb4e'
+    .rdata:
+      Entropy: 4.461209832849224
+      Virtual Size: '0x194'
+    .data:
+      Entropy: 0.49172118383425784
+      Virtual Size: '0x120'
+    .pdata:
+      Entropy: 3.3869938940456152
+      Virtual Size: '0x78'
+    INIT:
+      Entropy: 5.0637688000792265
+      Virtual Size: '0x282'
+    .rsrc:
+      Entropy: 3.335817259253743
+      Virtual Size: '0x3e0'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2013-05-07 06:22:23'
+  Description: Kontron Technology Application Programming Interface
+  Company: Kontron Technology A/S
+  InternalName: ktapi.sys
+  OriginalFilename: ktapi.sys
+  FileVersion: '1.0.2118 built by: WinDDK'
+  Product: KTAPI System Driver
+  ProductVersion: 1.0.2118
+  Copyright: "Copyright \xA9 Kontron Technology A/S. 2010"
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - ZwUnmapViewOfSection
+  - ZwClose
+  - IofCompleteRequest
+  - ObReferenceObjectByHandle
+  - ZwMapViewOfSection
+  - IoCreateSymbolicLink
+  - IoCreateDevice
+  - ZwOpenSection
+  - KeBugCheckEx
+  - IoDeleteSymbolicLink
+  - KeStallExecutionProcessor
+  - HalTranslateBusAddress
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services CA
+        , G2
+      ValidFrom: '2012-12-21 00:00:00'
+      ValidTo: '2020-12-30 23:59:59'
+      Signature: 03099b8f79ef7f5930aaef68b5fae3091dbb4f82065d375fa6529f168dea1c9209446ef56deb587c30e8f9698d23730b126f47a9ae3911f82ab19bb01ac38eeb599600adce0c4db2d031a6085c2a7afce27a1d574ca86518e979406225966ec7c7376a8321088e41eaddd9573f1d7749872a16065ea6386a2212a35119837eb6
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 7e93ebfb7cc64e59ea4b9a77d406fc3b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: d0785ad36e427c92b19f6826ab1e8020
+        SHA1: 365b7a9c21bd9373e49052c3e7b3e4646ddd4d43
+        SHA256: c2abb7484da91a658548de089d52436175fdb760a1387d225611dc0613a1e2ff
+        SHA384: eab4fe5ef90e0de4a6aa3a27769a5e879f588df5e4785aa4104debd1f81e19ea56d33e3a16e5facf99f68b5d8e3d287b
+    - Subject: C=BE, O=GlobalSign nv,sa, CN=GlobalSign CodeSigning CA , G2
+      ValidFrom: '2011-04-13 10:00:00'
+      ValidTo: '2019-04-13 10:00:00'
+      Signature: 225cc5dd3df40b70d8e3f5e7c58e0901bbb196365c5a07adc7a8444951257aae0da4193b929ccfb94226bb3b6c97e7c7ce116d6891da8d6df1534d54388c61f3c8827669be81320b31c36cc99e200a582ff048fe7e4807aad743589473540431a9780d3b8cb070c13d7ed7bd2f2ac3e2f58f0c90dc6ba5c8be685e5d6df878d2be49951e15780891fb34c8be84adbce0c6dd18dbf3caf07bc2143c18b803ba953e211e3f60697a7f6a039e8d4af9f0282c30845eec267242b16dcb64c3128cd6844b67417cb103177809e3ada8b6962da47e80034f88f7c16b5a4615cd2c198bd8709ce52d49886072a8a4195270435edad64603b0680e24ef4af60b2524ef24
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 0400000000012f4ee1355c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: f6a9e8eb8784f3f694b4e353c08a0ff5
+        SHA1: 589a7d4df869395601ba7538a65afae8c4616385
+        SHA256: cbdc9a0ad785d0c2013211746b42234e18bdc7d54a7a260647badc1c9e712ed4
+        SHA384: dcec542f242317863d0b3d23947e17d6982e381003831777b07ed75b46fb18bd0392a89c9beb6862981cd05f3f2fb77b
+    - Subject: C=DE, ST=Bayern, L=Eching, O=Kontron AG, CN=Kontron AG
+      ValidFrom: '2012-01-25 16:18:08'
+      ValidTo: '2015-01-25 16:18:08'
+      Signature: 3cd002b164a77998a577b5209e13c77ac743c6c177b0ad88df5e43cbb51bed56c4da20b87eae68a3eb616303efdab682494593b2c784872ec57fb5762e8c37bc176bbc83879f17308b2a3c7d9a3c2a2c0d3535795d335e0e8d8c473c154a37e271470a772ebc7c1d950bad1511d63a7334429744770bbbb48f21f22957585c022ac207d03fb36fd4567a690e483e97c73ea315e93d625f08e4a9a7e2f9892ca6058e6bd66f032c97455738ee66c49f721ac1cfd403d70927b6b3d58ac352513cc96fc1c27da9979bb9bf5223585921944ba31b506f8e18eff973f3ed1b8c4a2835a9b0d52664975e8e43c9e729d86a45a43f395502965fc2627e215f5c6f8b09
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 112124891f00678b52f93b9c375bd8913a62
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 7a1cc84cea09e254149a703f91b63e83
+        SHA1: 9543ac93e47b5b93c567bd096259ea9eb55fb506
+        SHA256: c6f0b9a617b86b7df7543dbe82e14c0fafaa1f275e91d4b84ad0e1b7aa0452cb
+        SHA384: cff04b53b4c972534b6d7ffe2b51e9b6779f4430c3a5b66d6d6d72908324843587c67d9207510cad8bb1d4bcbb30f29c
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services Signer
+        , G4
+      ValidFrom: '2012-10-18 00:00:00'
+      ValidTo: '2020-12-29 23:59:59'
+      Signature: 783bb4912a004cf08f62303778a38427076f18b2de25dca0d49403aa864e259f9a40031cddcee379cb216806dab632b46dbff42c266333e449646d0de6c3670ef705a4356c7c8916c6e9b2dfb2e9dd20c6710fcd9574dcb65cdebd371f4378e678b5cd280420a3aaf14bc48829910e80d111fcdd5c766e4f5e0e4546416e0db0ea389ab13ada097110fc1c79b4807bac69f4fd9cb60c162bf17f5b093d9b5be216ca13816d002e380da8298f2ce1b2f45aa901af159c2c2f491bdb22bbc3fe789451c386b182885df03db451a179332b2e7bb9dc20091371eb6a195bcfe8a530572c89493fb9cf7fc9bf3e226863539abd6974acc51d3c7f92e0c3bc1cd80475
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0ecff438c8febf356e04d86a981b1a50
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: e9d38360b914c8863f6cba3ee58764d3
+        SHA1: 4cba8eae47b6bf76f20b3504b98b8f062694a89b
+        SHA256: 88901d86a4cc1f1bb193d08e1fb63d27452e63f83e228c657ab1a92e4ade3976
+        SHA384: e9f2a75334a9e336c5a4712eadee88d0374b0fdc273262f4e65c9040ad2793067cc076696db5279a478773485e285652
+    - Subject: C=BE, O=GlobalSign nv,sa, OU=Root CA, CN=GlobalSign Root CA
+      ValidFrom: '2006-05-23 17:00:51'
+      ValidTo: '2016-05-23 17:10:51'
+      Signature: 13c56c5e077f3c57ff9b315f3fbd955425c679f92c31034d64694b56d95b976f7cf3f0d024657538639813701613f7a701f1c623e085866c0bf080945a75e87ce41e92b473bfc1b3a7b00bd31884cbcc09a35c9c4f3eb03a9c2d1bc404ef9737966fe5ecbaac6ab3d4e23cdf8b25e7acbc624531dda40a72e41bf8784301ccba3914de5d90aed85acf5eca46815133d5a60e5867d3d8665888169beeb11acaad91138421da9a6e20efda007428bac95ff34d5dc3da25692554ea44bcc39b29331cd63c961f8781c553d72a2733d42e197c08586ddb4e1999a9ea5ff39a9d8c513a5a5cbd2fa908359b54a7db351a521633343aa380046afdb4838cad90cf0c3a6596ec334e1826b849bbeb8192ff134d324b23c733e7b6716b15f69c80e6bcb76cbe41d5033a7133150050743b0e5df996aaed903eab134c809926bc38a5eb0236891db620be83ab10f8199ed76379d4aeb12f6136f94a4ba833c70e7241f9f1b1907eae46efde397b75a0411459041d42bc4788b8130e05fa1df0808dff70c677d84bdc460e231a72d5bfdefeaaae69583cfc5c46e4d5819a8b6e6559771a32a590a6b6649364fd0753c9a0de28ad2a6cc638d181ce98f54019e92c1743a4265fd3443053e41d02baa40a2f16dd7a60275242bbad98372897e4b8d27911e3108c48d5305d0a0c52def588ea8d1a2d67c9f4801484b7850cd16628a5c66f2461
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 610b7f6b000000000019
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 4798d55be7663a75649cda4dedc686ef
+        SHA1: 0f1ab2937b245d9466ea6f9bf056a5942e3989cf
+        SHA256: ef14ea05bb066ee9f4188196dd69cd769b283ac4d7555db52f5e76922d3456e1
+        SHA384: 6e7450a139856aeda6fa6284ff89b3752a9b646e096b4d33dd7e8e727742a2111481531581c0aa2cda0338e22cfdbad3
+    Signer:
+    - SerialNumber: 112124891f00678b52f93b9c375bd8913a62
+      Issuer: C=BE, O=GlobalSign nv,sa, CN=GlobalSign CodeSigning CA , G2
+      Version: 1
+- Filename: ktapi.sys
+  MD5: e3c123a2ee4720001ed35d45fa1e57eb
+  SHA1: 92f5c4fd5791db408fa801fd3d887870691af1f8
+  SHA256: 89ba754861e11d9db4440b2b5db61fd5bee16752e4623c4271b8fdd0a666c677
+  Imphash: ec4687bc52f296b7dcdfa7967aecbc0c
+  Authentihash:
+    MD5: fe3896c6129dd0b564f5051dbc80fb79
+    SHA1: cc7b39806e076b266aabff1a7ca1e8cb62ca19dc
+    SHA256: 11101d0bf398ae0631904fff00431e0f23c0b13ca47055cafd797b2b48a6d44e
+  RichPEHeaderHash:
+    MD5: bcda68debf2c179676d7131e4c5cf728
+    SHA1: cf045ab3ba2e726dace870dc0cab8382eb9c8c1d
+    SHA256: 4b3d4acb3000fb9f67717df99d1a3a21b684ade043f1ddf8a791bebccfdd23aa
+  Sections:
+    .text:
+      Entropy: 6.069191109583957
+      Virtual Size: '0x60c'
+    .rdata:
+      Entropy: 4.746522425987596
+      Virtual Size: '0xf1'
+    .data:
+      Entropy: 2.170950594454669
+      Virtual Size: '0x14'
+    INIT:
+      Entropy: 5.354613293797563
+      Virtual Size: '0x2ac'
+    .rsrc:
+      Entropy: 3.3341946378077383
+      Virtual Size: '0x3e0'
+    .reloc:
+      Entropy: 3.5506914087537527
+      Virtual Size: '0x100'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2013-05-07 06:22:18'
+  Description: Kontron Technology Application Programming Interface
+  Company: Kontron Technology A/S
+  InternalName: ktapi.sys
+  OriginalFilename: ktapi.sys
+  FileVersion: '1.0.2118 built by: WinDDK'
+  Product: KTAPI System Driver
+  ProductVersion: 1.0.2118
+  Copyright: "Copyright \xA9 Kontron Technology A/S. 2010"
+  MachineType: I386
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - IofCompleteRequest
+  - ZwUnmapViewOfSection
+  - IoCreateDevice
+  - KeTickCount
+  - KeBugCheckEx
+  - ZwOpenSection
+  - ObReferenceObjectByHandle
+  - ZwMapViewOfSection
+  - ZwClose
+  - RtlInitUnicodeString
+  - IoDeleteSymbolicLink
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - READ_PORT_ULONG
+  - READ_PORT_UCHAR
+  - READ_PORT_USHORT
+  - WRITE_PORT_UCHAR
+  - WRITE_PORT_USHORT
+  - WRITE_PORT_ULONG
+  - KeStallExecutionProcessor
+  - HalTranslateBusAddress
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services CA
+        , G2
+      ValidFrom: '2012-12-21 00:00:00'
+      ValidTo: '2020-12-30 23:59:59'
+      Signature: 03099b8f79ef7f5930aaef68b5fae3091dbb4f82065d375fa6529f168dea1c9209446ef56deb587c30e8f9698d23730b126f47a9ae3911f82ab19bb01ac38eeb599600adce0c4db2d031a6085c2a7afce27a1d574ca86518e979406225966ec7c7376a8321088e41eaddd9573f1d7749872a16065ea6386a2212a35119837eb6
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 7e93ebfb7cc64e59ea4b9a77d406fc3b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: d0785ad36e427c92b19f6826ab1e8020
+        SHA1: 365b7a9c21bd9373e49052c3e7b3e4646ddd4d43
+        SHA256: c2abb7484da91a658548de089d52436175fdb760a1387d225611dc0613a1e2ff
+        SHA384: eab4fe5ef90e0de4a6aa3a27769a5e879f588df5e4785aa4104debd1f81e19ea56d33e3a16e5facf99f68b5d8e3d287b
+    - Subject: C=BE, O=GlobalSign nv,sa, CN=GlobalSign CodeSigning CA , G2
+      ValidFrom: '2011-04-13 10:00:00'
+      ValidTo: '2019-04-13 10:00:00'
+      Signature: 225cc5dd3df40b70d8e3f5e7c58e0901bbb196365c5a07adc7a8444951257aae0da4193b929ccfb94226bb3b6c97e7c7ce116d6891da8d6df1534d54388c61f3c8827669be81320b31c36cc99e200a582ff048fe7e4807aad743589473540431a9780d3b8cb070c13d7ed7bd2f2ac3e2f58f0c90dc6ba5c8be685e5d6df878d2be49951e15780891fb34c8be84adbce0c6dd18dbf3caf07bc2143c18b803ba953e211e3f60697a7f6a039e8d4af9f0282c30845eec267242b16dcb64c3128cd6844b67417cb103177809e3ada8b6962da47e80034f88f7c16b5a4615cd2c198bd8709ce52d49886072a8a4195270435edad64603b0680e24ef4af60b2524ef24
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 0400000000012f4ee1355c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: f6a9e8eb8784f3f694b4e353c08a0ff5
+        SHA1: 589a7d4df869395601ba7538a65afae8c4616385
+        SHA256: cbdc9a0ad785d0c2013211746b42234e18bdc7d54a7a260647badc1c9e712ed4
+        SHA384: dcec542f242317863d0b3d23947e17d6982e381003831777b07ed75b46fb18bd0392a89c9beb6862981cd05f3f2fb77b
+    - Subject: C=DE, ST=Bayern, L=Eching, O=Kontron AG, CN=Kontron AG
+      ValidFrom: '2012-01-25 16:18:08'
+      ValidTo: '2015-01-25 16:18:08'
+      Signature: 3cd002b164a77998a577b5209e13c77ac743c6c177b0ad88df5e43cbb51bed56c4da20b87eae68a3eb616303efdab682494593b2c784872ec57fb5762e8c37bc176bbc83879f17308b2a3c7d9a3c2a2c0d3535795d335e0e8d8c473c154a37e271470a772ebc7c1d950bad1511d63a7334429744770bbbb48f21f22957585c022ac207d03fb36fd4567a690e483e97c73ea315e93d625f08e4a9a7e2f9892ca6058e6bd66f032c97455738ee66c49f721ac1cfd403d70927b6b3d58ac352513cc96fc1c27da9979bb9bf5223585921944ba31b506f8e18eff973f3ed1b8c4a2835a9b0d52664975e8e43c9e729d86a45a43f395502965fc2627e215f5c6f8b09
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 112124891f00678b52f93b9c375bd8913a62
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 7a1cc84cea09e254149a703f91b63e83
+        SHA1: 9543ac93e47b5b93c567bd096259ea9eb55fb506
+        SHA256: c6f0b9a617b86b7df7543dbe82e14c0fafaa1f275e91d4b84ad0e1b7aa0452cb
+        SHA384: cff04b53b4c972534b6d7ffe2b51e9b6779f4430c3a5b66d6d6d72908324843587c67d9207510cad8bb1d4bcbb30f29c
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services Signer
+        , G4
+      ValidFrom: '2012-10-18 00:00:00'
+      ValidTo: '2020-12-29 23:59:59'
+      Signature: 783bb4912a004cf08f62303778a38427076f18b2de25dca0d49403aa864e259f9a40031cddcee379cb216806dab632b46dbff42c266333e449646d0de6c3670ef705a4356c7c8916c6e9b2dfb2e9dd20c6710fcd9574dcb65cdebd371f4378e678b5cd280420a3aaf14bc48829910e80d111fcdd5c766e4f5e0e4546416e0db0ea389ab13ada097110fc1c79b4807bac69f4fd9cb60c162bf17f5b093d9b5be216ca13816d002e380da8298f2ce1b2f45aa901af159c2c2f491bdb22bbc3fe789451c386b182885df03db451a179332b2e7bb9dc20091371eb6a195bcfe8a530572c89493fb9cf7fc9bf3e226863539abd6974acc51d3c7f92e0c3bc1cd80475
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0ecff438c8febf356e04d86a981b1a50
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: e9d38360b914c8863f6cba3ee58764d3
+        SHA1: 4cba8eae47b6bf76f20b3504b98b8f062694a89b
+        SHA256: 88901d86a4cc1f1bb193d08e1fb63d27452e63f83e228c657ab1a92e4ade3976
+        SHA384: e9f2a75334a9e336c5a4712eadee88d0374b0fdc273262f4e65c9040ad2793067cc076696db5279a478773485e285652
+    - Subject: C=BE, O=GlobalSign nv,sa, OU=Root CA, CN=GlobalSign Root CA
+      ValidFrom: '2006-05-23 17:00:51'
+      ValidTo: '2016-05-23 17:10:51'
+      Signature: 13c56c5e077f3c57ff9b315f3fbd955425c679f92c31034d64694b56d95b976f7cf3f0d024657538639813701613f7a701f1c623e085866c0bf080945a75e87ce41e92b473bfc1b3a7b00bd31884cbcc09a35c9c4f3eb03a9c2d1bc404ef9737966fe5ecbaac6ab3d4e23cdf8b25e7acbc624531dda40a72e41bf8784301ccba3914de5d90aed85acf5eca46815133d5a60e5867d3d8665888169beeb11acaad91138421da9a6e20efda007428bac95ff34d5dc3da25692554ea44bcc39b29331cd63c961f8781c553d72a2733d42e197c08586ddb4e1999a9ea5ff39a9d8c513a5a5cbd2fa908359b54a7db351a521633343aa380046afdb4838cad90cf0c3a6596ec334e1826b849bbeb8192ff134d324b23c733e7b6716b15f69c80e6bcb76cbe41d5033a7133150050743b0e5df996aaed903eab134c809926bc38a5eb0236891db620be83ab10f8199ed76379d4aeb12f6136f94a4ba833c70e7241f9f1b1907eae46efde397b75a0411459041d42bc4788b8130e05fa1df0808dff70c677d84bdc460e231a72d5bfdefeaaae69583cfc5c46e4d5819a8b6e6559771a32a590a6b6649364fd0753c9a0de28ad2a6cc638d181ce98f54019e92c1743a4265fd3443053e41d02baa40a2f16dd7a60275242bbad98372897e4b8d27911e3108c48d5305d0a0c52def588ea8d1a2d67c9f4801484b7850cd16628a5c66f2461
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 610b7f6b000000000019
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 4798d55be7663a75649cda4dedc686ef
+        SHA1: 0f1ab2937b245d9466ea6f9bf056a5942e3989cf
+        SHA256: ef14ea05bb066ee9f4188196dd69cd769b283ac4d7555db52f5e76922d3456e1
+        SHA384: 6e7450a139856aeda6fa6284ff89b3752a9b646e096b4d33dd7e8e727742a2111481531581c0aa2cda0338e22cfdbad3
+    Signer:
+    - SerialNumber: 112124891f00678b52f93b9c375bd8913a62
+      Issuer: C=BE, O=GlobalSign nv,sa, CN=GlobalSign CodeSigning CA , G2
+      Version: 1


### PR DESCRIPTION
## Summary
- Adds three signed `ktapi.sys` variants documented in #386 and Expel's analysis of The Gentlemen ransomware EDR-killer exploit.
- Documents the `0x82007000` physical-memory mapping primitive exposed through `\\.\ktapi`.
- Includes all three driver binaries as Git LFS objects and enriches each sample with PE metadata, authentihashes, imports, and certificate details.

## Validation
- Recomputed MD5, SHA1, and SHA256 for each sample.
- Ran `python3 bin/metadata-extractor.py` against the three samples.
- Ran `python3 bin/validate.py` successfully.
- Confirmed all three binaries are staged as Git LFS objects.

Closes #386