### PR TITLE
Add AccelLid.sys sample and metadata

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -178,3 +178,4 @@ drivers/23eed24b0a780863df35b500c4ea0733.bin filter=lfs diff=lfs merge=lfs -text
 drivers/96a8b9db2dc9cba8cdf90c7c33fe11c4.bin filter=lfs diff=lfs merge=lfs -text
 drivers/2c10be1aea72b7bdf07c735a4ad68876.bin filter=lfs diff=lfs merge=lfs -text
 drivers/e3c123a2ee4720001ed35d45fa1e57eb.bin filter=lfs diff=lfs merge=lfs -text
+drivers/887e6502a420acb183342c60c396b0e3.bin filter=lfs diff=lfs merge=lfs -text

--- a/drivers/887e6502a420acb183342c60c396b0e3.bin
+++ b/drivers/887e6502a420acb183342c60c396b0e3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08675796b8712e0e4ccbdf7831450b907bb94c2e3e85560d9aba1b24931f0d55
+size 48392

--- a/yaml/d9e9fab2-6b64-4c14-b1ec-7af1923c0773.yaml
+++ b/yaml/d9e9fab2-6b64-4c14-b1ec-7af1923c0773.yaml
@@ -7,33 +7,255 @@ Created: '2024-09-11'
 MitreID: T1068
 Category: vulnerable driver
 Commands:
-    Command: sc.exe create AccelLid.sys binPath=C:\windows\temp\AccelLid.sys type=kernel
-        && sc.exe start AccelLid.sys
-    Description: Northwave Cyber Security contributed this driver based on in-house
-        research. The driver has a CVSSv3 score of 5.5, indicating a localdos impact.
-        This vulnerability could potentially be exploited for privilege escalation
-        or other malicious activities.
-    Usecase: Elevate privileges
-    Privileges: kernel
-    OperatingSystem: Windows 10
-Resources: []
+  Command: sc.exe create AccelLid.sys binPath=C:\windows\temp\AccelLid.sys type=kernel
+    && sc.exe start AccelLid.sys
+  Description: AccelLid.sys is an Elitegroup Computer Systems lid accelerometer kernel
+    driver. Northwave Cyber Security reported a local denial-of-service vulnerability
+    with a CVSSv3 score of 5.5. The driver exposes IOCTL paths for accelerometer
+    commands, keyboard control, event registration, and ACPI method execution.
+    Microsoft's vulnerable driver blocklist denies AccelLid.sys across all file
+    versions for matching Elitegroup publisher and signing roots.
+  Usecase: Trigger vulnerable AccelLid.sys IOCTL handling for local denial of service.
+  Privileges: kernel
+  OperatingSystem: Windows 10
+Resources:
+- https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/design/microsoft-recommended-driver-block-rules
+- https://github.com/magicsword-io/LOLDrivers/issues/355
 Detection: []
 Acknowledgement:
-    Person: Northwave Cyber Security
-    Handle: ''
+  Person: Northwave Cyber Security
+  Handle: ''
 KnownVulnerableSamples:
--   Filename: AccelLid.sys
-    MD5: 833becd0e4abc9cfff8c835694694f80
-    SHA1: ''
-    SHA256: ''
-    Signature: ''
-    Date: ''
-    Publisher: ''
-    Company: ''
-    Description: ''
-    Product: ''
-    ProductVersion: ''
-    FileVersion: ''
-    MachineType: ''
-    OriginalFilename: ''
-    LoadsDespiteHVCI: 'TRUE'
+- Filename: AccelLid.sys
+  MD5: 833becd0e4abc9cfff8c835694694f80
+  SHA1: ''
+  SHA256: ''
+  Signature: ''
+  Date: ''
+  Publisher: ''
+  Company: ''
+  Description: ''
+  Product: ''
+  ProductVersion: ''
+  FileVersion: ''
+  MachineType: ''
+  OriginalFilename: ''
+  LoadsDespiteHVCI: 'TRUE'
+- Filename: AccelLid.sys
+  MD5: 887e6502a420acb183342c60c396b0e3
+  SHA1: 19871a15d483b9be1aa868a31a3384513b05e8ba
+  SHA256: 08675796b8712e0e4ccbdf7831450b907bb94c2e3e85560d9aba1b24931f0d55
+  Imphash: 082b83ad4226208cdab708a369872223
+  Authentihash:
+    MD5: 937cafc2e6f943de27cbc971c063c4f6
+    SHA1: eb4a5a669b4fd35839e28910b35b6f867df35258
+    SHA256: 4592f49005ff752a5a319ad49d11f110d417c3c60ea8d6705fd94945982ae8eb
+  RichPEHeaderHash:
+    MD5: ee914ec0f02e0451440d93d55a162846
+    SHA1: d922d5f5ed6b1327568564b614b3cda68a9b8e44
+    SHA256: 140d8998c636853ec04181b68fb91cee97209780a5567c682b6c5070e0f2b259
+  Sections:
+    .text:
+      Entropy: 6.372794394602811
+      Virtual Size: '0x27c0'
+    .rdata:
+      Entropy: 4.371128319129899
+      Virtual Size: '0xd1c'
+    .data:
+      Entropy: 2.035951263676127
+      Virtual Size: '0x230'
+    .pdata:
+      Entropy: 4.21543200533097
+      Virtual Size: '0x318'
+    .gfids:
+      Entropy: 0.8112781244591328
+      Virtual Size: '0x4'
+    PAGE:
+      Entropy: 6.465168032546454
+      Virtual Size: '0x27a3'
+    INIT:
+      Entropy: 5.249468479250558
+      Virtual Size: '0x8e0'
+    .rsrc:
+      Entropy: 3.2246495461083584
+      Virtual Size: '0x398'
+    .reloc:
+      Entropy: 3.7372853115732676
+      Virtual Size: '0x2c'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2017-12-20 18:20:53'
+  Description: Lid Accelerometer Driver
+  Company: ECSl (E) Education
+  InternalName: AccelLid
+  OriginalFilename: AccelLid.sys
+  FileVersion: 1.0.0.1
+  Product: Lid Accelerometer Driver
+  ProductVersion: 1.0.0.1
+  Copyright: Elitegroup Computer Systems. All rights reserved.
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - RtlInitUnicodeString
+  - RtlFreeUnicodeString
+  - DbgPrint
+  - KeInitializeEvent
+  - KeSetEvent
+  - KeInitializeMutex
+  - KeReleaseMutex
+  - KeWaitForSingleObject
+  - ExAllocatePoolWithTag
+  - ExFreePoolWithTag
+  - ExAcquireFastMutex
+  - ExReleaseFastMutex
+  - IoAttachDeviceToDeviceStack
+  - IofCallDriver
+  - IofCompleteRequest
+  - IoDeleteDevice
+  - IoDetachDevice
+  - IoInitializeRemoveLockEx
+  - IoAcquireRemoveLockEx
+  - IoReleaseRemoveLockEx
+  - IoReleaseRemoveLockAndWaitEx
+  - IoRegisterDeviceInterface
+  - IoSetDeviceInterfaceState
+  - IoSetDeviceInterfacePropertyData
+  - PoCallDriver
+  - PoStartNextPowerIrp
+  - memcpy_s
+  - KeLowerIrql
+  - KfRaiseIrql
+  - KeAcquireSpinLockRaiseToDpc
+  - KeReleaseSpinLock
+  - KeAcquireGuardedMutex
+  - KeReleaseGuardedMutex
+  - IoAllocateIrp
+  - IoBuildDeviceIoControlRequest
+  - IoFreeIrp
+  - IoIs32bitProcess
+  - ObReferenceObjectByHandle
+  - ObfDereferenceObject
+  - IoGetLowerDeviceObject
+  - ExEventObjectType
+  - MmGetSystemRoutineAddress
+  - ZwClose
+  - ZwSetSecurityObject
+  - IoDeviceObjectType
+  - IoCreateDevice
+  - ObOpenObjectByPointer
+  - RtlGetDaclSecurityDescriptor
+  - RtlGetGroupSecurityDescriptor
+  - RtlGetOwnerSecurityDescriptor
+  - RtlGetSaclSecurityDescriptor
+  - SeCaptureSecurityDescriptor
+  - _snwprintf
+  - RtlLengthSecurityDescriptor
+  - SeExports
+  - RtlCreateSecurityDescriptor
+  - _wcsnicmp
+  - wcschr
+  - RtlAbsoluteToSelfRelativeSD
+  - RtlAddAccessAllowedAce
+  - RtlLengthSid
+  - IoIsWdmVersionAvailable
+  - RtlSetDaclSecurityDescriptor
+  - ZwOpenKey
+  - ZwSetValueKey
+  - ZwQueryValueKey
+  - ZwCreateKey
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services CA
+        , G2
+      ValidFrom: '2012-12-21 00:00:00'
+      ValidTo: '2020-12-30 23:59:59'
+      Signature: 03099b8f79ef7f5930aaef68b5fae3091dbb4f82065d375fa6529f168dea1c9209446ef56deb587c30e8f9698d23730b126f47a9ae3911f82ab19bb01ac38eeb599600adce0c4db2d031a6085c2a7afce27a1d574ca86518e979406225966ec7c7376a8321088e41eaddd9573f1d7749872a16065ea6386a2212a35119837eb6
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 7e93ebfb7cc64e59ea4b9a77d406fc3b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: d0785ad36e427c92b19f6826ab1e8020
+        SHA1: 365b7a9c21bd9373e49052c3e7b3e4646ddd4d43
+        SHA256: c2abb7484da91a658548de089d52436175fdb760a1387d225611dc0613a1e2ff
+        SHA384: eab4fe5ef90e0de4a6aa3a27769a5e879f588df5e4785aa4104debd1f81e19ea56d33e3a16e5facf99f68b5d8e3d287b
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services Signer
+        , G4
+      ValidFrom: '2012-10-18 00:00:00'
+      ValidTo: '2020-12-29 23:59:59'
+      Signature: 783bb4912a004cf08f62303778a38427076f18b2de25dca0d49403aa864e259f9a40031cddcee379cb216806dab632b46dbff42c266333e449646d0de6c3670ef705a4356c7c8916c6e9b2dfb2e9dd20c6710fcd9574dcb65cdebd371f4378e678b5cd280420a3aaf14bc48829910e80d111fcdd5c766e4f5e0e4546416e0db0ea389ab13ada097110fc1c79b4807bac69f4fd9cb60c162bf17f5b093d9b5be216ca13816d002e380da8298f2ce1b2f45aa901af159c2c2f491bdb22bbc3fe789451c386b182885df03db451a179332b2e7bb9dc20091371eb6a195bcfe8a530572c89493fb9cf7fc9bf3e226863539abd6974acc51d3c7f92e0c3bc1cd80475
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0ecff438c8febf356e04d86a981b1a50
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: e9d38360b914c8863f6cba3ee58764d3
+        SHA1: 4cba8eae47b6bf76f20b3504b98b8f062694a89b
+        SHA256: 88901d86a4cc1f1bb193d08e1fb63d27452e63f83e228c657ab1a92e4ade3976
+        SHA384: e9f2a75334a9e336c5a4712eadee88d0374b0fdc273262f4e65c9040ad2793067cc076696db5279a478773485e285652
+    - Subject: C=TW, ST=Taiwan, L=Taipei, O=Elitegroup Computer Systems Co Ltd, CN=Elitegroup
+        Computer Systems Co Ltd
+      ValidFrom: '2015-08-18 00:00:00'
+      ValidTo: '2018-07-06 23:59:59'
+      Signature: 8523dbbc4988df62513a65168c2248adada26552d90ff02ef0e6a376f1ccca5e82dceaa958144fb85d46b04804502f33e28cda7688c77b1a104f7ef34aa15028a16d57527461d0a2abcb54217b42cb8e700569811386ec3a282048ae72656fe63c8468843a69b9497c5a72381bf3080abe785575588e88d3ecb96c9bec09ff77e4bac299eccd9fb60714b9ae6ba13f9270dee83953f346dadb56767412677ee180614343708a50c3da3b46c89ce7b860bb8a71ab593e491a53e1b8d0e4ff0c119307e8d0b338531d7ccfadba36ca1b80c907edf2b377b81e2224561f5b729a481573c3301d5dee5a6cea3cc6d76153b7b6041aa6622cdda4822a7d37ec9acfb7
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 485f40b07aa4819096a44a73dcfa34b0
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: ab020c9b05cc99889cabdee78fde0729
+        SHA1: c89a4ecbd0c7cf1e7e0f76d6b6267da44137285b
+        SHA256: 49e67f0d473043822141e2a942adba90b351a38aff0df5924447ffee8bfbdc0f
+        SHA384: 67cb8b9a3d38b123aed1ab8890780b96b9a619b7267570f181f99ea7eb958e279857cfa6b72faa832e5189f6f3d40ea1
+    - Subject: C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec
+        Class 3 SHA256 Code Signing CA
+      ValidFrom: '2013-12-10 00:00:00'
+      ValidTo: '2023-12-09 23:59:59'
+      Signature: 13851a1e69a937f7a0bda4af7e1d6153fe9d8c5e0ca6751e781723ddfdec1a035539fb7195c7655aa78e30d2445a61db706fda2105c22e73ba49f1d193fe5dc9cd5e03e0899e3f741ed7f7388ba9d6cfbb352f3358a89256d1c84d3b82e6798416fc28b0b147f31da23eee87d9a67fa456a53fad842e29de7cbca8aaa33d0401eaba93a20e502229174c87e43a115fd6a425899b056b2fb4c9014c277b0bac190522a060153fdac9fb4d4c8ffb726777fd2794c7ba350e8849fe8dfd28af4a12bd0db39705de440c15fa362b03dcc15001f1a1115d14e5e2bd274b54be2b845e0fa6c374050aef97c38922b11f77f3bdcd43d4f14ca93fb58b84af64f2d01421
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 3d78d7f9764960b2617df4f01eca862a
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 1f056ff7d5f874984dc605402b7cb042
+        SHA1: bdb348353a2203deb4b767914fa1bd7248dd728b
+        SHA256: a08e79c386083d875014c409c13d144e0a24386132980df11ff59737c8489eb1
+        SHA384: fa2729064b49e0d77540c1ee95d5f74acaf8eaf55197851a3a40383335f8113e51190bc48b552196edf8ac5cf0c89278
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=(c) 2006 VeriSign,
+        Inc. , For authorized use only, CN=VeriSign Class 3 Public Primary Certification
+        Authority , G5
+      ValidFrom: '2011-02-22 19:25:17'
+      ValidTo: '2021-02-22 19:35:17'
+      Signature: 812a82168c34672be503eb347b8ca2a3508af45586f11e8c8eae7dee0319ce72951848ad6211fd20fd3f4706015ae2e06f8c152c4e3c6a506c0b36a3cf7a0d9c42bc5cf819d560e369e6e22341678c6883762b8f93a32ab57fbe59fba9c9b2268fcaa2f3821b983e919527978661ee5b5d076bcd86a8e26580a8e215e2b2be23056aba0cf347934daca48c077939c061123a050d89a3ec9f578984fbecca7c47661491d8b60f195de6b84aacbc47c8714396e63220a5dc7786fd3ce38b71db7b9b03fcb71d3264eb1652a043a3fa2ead59924e7cc7f233424838513a7c38c71b242228401e1a461f17db18f7f027356cb863d9cdb9645d2ba55eefc629b4f2c7f821cc04ba57fd01b6abc667f9e7d3997ff4f522fa72f5fdff3a1c423aa1f98018a5ee8d1cd4669e4501feaaeefffb178f30f7f1cd29c59decb5d549003d85b8cbbb933a276a49c030ae66c9f723283276f9a48356c848ce5a96aaa0cc0cc47fb48e97af6de35427c39f86c0d6e473089705dbd054625e0348c2d59f7fa7668cd09db04fd4d3985f4b7ac97fb22952d01280c70f54b61e67cdc6a06c110384d34875e72afeb03b6e0a3aa66b769905a3f177686133144706fc537f52bd92145c4a246a678caf8d90aad0f679211b93267cc3ce1ebd883892ae45c6196a4950b305f8ae59378a6a250394b1598150e8ba8380b72335f476b9671d5918ad208d94
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 611993e400000000001c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 78a717e082dcc1cda3458d917e677d14
+        SHA1: 4a872e0e51f9b304469cd1dedb496ee9b8b983a4
+        SHA256: 317fa1d234ebc49040ebc5e8746f8997471496051b185a91bdd9dfbb23fab5f8
+        SHA384: b71052da4eb9157c8c1a5d7f55df19d69b9128598b72fcca608e5b7cc7d64c43c5504b9c86355a6dc22ee40c88cc385c
+    Signer:
+    - SerialNumber: 485f40b07aa4819096a44a73dcfa34b0
+      Issuer: C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec
+        Class 3 SHA256 Code Signing CA
+      Version: 1


### PR DESCRIPTION
## Summary
- Adds a verified `AccelLid.sys` 1.0.0.1 sample to the existing entry while preserving the original MD5-only sample record.
- Includes the driver binary as a Git LFS object and enriches it with PE metadata, authentihashes, imports, and certificate details.
- Updates the driver description and references to reflect the Elitegroup product metadata and Microsoft vulnerable driver blocklist coverage.

## Verification
- The sample has embedded original filename `AccelLid.sys`, product `Lid Accelerometer Driver`, and an Elitegroup Computer Systems code-signing certificate.
- Microsoft's current vulnerable driver blocklist names this SHA256 in the `AccelLid.sys` file attribute and applies the matching Elitegroup signer rules across the full file-version range.

## Validation
- Recomputed MD5, SHA1, and SHA256.
- Ran `python3 bin/metadata-extractor.py` against the sample.
- Ran `python3 bin/validate.py` successfully.
- Confirmed the binary is staged as a Git LFS object.

Closes #355