### PR TITLE
Expand Tower of Fantasy anti-cheat driver samples

### DIFF
--- a/drivers/0d9bbed76c17b954ec9120bdfb144ec9.bin
+++ b/drivers/0d9bbed76c17b954ec9120bdfb144ec9.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d396b83647f5233cd93f47caa05e0a0d0dd5dd2f17ba2b0ae5cd1afc0afa69d
+size 60288

--- a/drivers/1f06e06a9e64bad05ba9cccfffa92421.bin
+++ b/drivers/1f06e06a9e64bad05ba9cccfffa92421.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca22e593362a8fa4f728e83f6861f983373f61480d0384e26ed149e507706d6a
+size 64480

--- a/drivers/3b1c40c32b92696d192d846ab4ca2b45.bin
+++ b/drivers/3b1c40c32b92696d192d846ab4ca2b45.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0db95a62e50f3a2c757ac264534ef17340bf8b8aa94b98fcb7663c493b2d569
+size 57560

--- a/drivers/3d2a9d56b16831b18de4b4dfd26603c9.bin
+++ b/drivers/3d2a9d56b16831b18de4b4dfd26603c9.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e55bfbb979143c6d1bc97129c9b5663639b895f1db605cef578b7f06633c08f6
+size 58104

--- a/drivers/9a1cd3071888ba68fb131f36bcc000e9.bin
+++ b/drivers/9a1cd3071888ba68fb131f36bcc000e9.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ea893c2da9f60590c6223b3c71b13e071d5f700cc3b93f4508b90187ef6091a
+size 9986168

--- a/drivers/af036499a90e70e9ec4121ac4da9f5e2.bin
+++ b/drivers/af036499a90e70e9ec4121ac4da9f5e2.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f90cab0c3b8159162be3103fcca5bafc27fbf4ec24620900acedaf84b7c0cf30
+size 59728

--- a/drivers/e1787057703c662e07f022f1bd67d008.bin
+++ b/drivers/e1787057703c662e07f022f1bd67d008.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd08ac95226585436c03b01745c608035bfb15a3a832135589a049cb243cefd9
+size 57648

--- a/drivers/ff3351f67270b2021937cb8a54af3d25.bin
+++ b/drivers/ff3351f67270b2021937cb8a54af3d25.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2005e9afa51b7918dd1d0143d181641529c488e945fc6bfe1db48805aabdedb3
+size 9966728

--- a/yaml/271ace20-2f68-4695-9579-0d4de8cb4fe6.yaml
+++ b/yaml/271ace20-2f68-4695-9579-0d4de8cb4fe6.yaml
@@ -1,6 +1,7 @@
 Id: 271ace20-2f68-4695-9579-0d4de8cb4fe6
 Tags:
 - GameDriverX64.sys
+- KSophon_x64.sys
 Verified: 'TRUE'
 Author: Michael Haag
 Created: '2026-06-16'
@@ -11,22 +12,33 @@ Category: vulnerable driver
 Commands:
   Command: sc.exe create GameDriverX64 binPath=C:\windows\temp\GameDriverX64.sys type=kernel
     && sc.exe start GameDriverX64
-  Description: GameDriverX64.sys is a signed game driver reported in public DragonForce
-    intrusion tradecraft and BlackSnufkin BYOVD research as an abused vulnerable driver.
-    Public research identifies vulnerable builds that can be used as process-killer
-    providers, including CVE-2025-61155 context.
-  Usecase: Load a vulnerable signed kernel driver
-  Privileges: kernel
-  OperatingSystem: Windows 10, Windows 11
+  Description: GameDriverX64.sys is a signed Hotta Studio anti-cheat driver affected
+    by CVE-2025-61155. Its device-access and IOCTL checks rely on spoofable module
+    names, process names, PE checksums, and the hardcoded value 0xFA123456. A local
+    user can reach kernel routines that terminate arbitrary processes, register a
+    process for handle protection, and strip existing handle rights. KSophon_x64.sys
+    is the VMProtect-packed predecessor shipped with Tower of Fantasy; public reverse
+    engineering reports that it retains the same weak authentication and IOCTL capabilities.
+    The tracked files are legitimate vendor-signed drivers, not malicious drivers,
+    although GameDriverX64.sys has been abused for defense evasion in ransomware intrusions.
+  Usecase: Terminate security processes and protect a caller-controlled process from
+    existing or future handle access.
+  Privileges: User
+  OperatingSystem: Windows 7, Windows 10, Windows 11
 Resources:
 - https://www.security.com/blog-post/dragonforce-msteams-backdoor
 - https://github.com/magicsword-io/LOLDrivers/issues/360
+- https://github.com/magicsword-io/LOLDrivers/issues/362
 - https://github.com/BlackSnufkin/BYOVD/tree/main/GameDriverX64-Killer
 - https://www.security.com/threat-intelligence/dragonforce-msteams-backdoor
+- https://nvd.nist.gov/vuln/detail/CVE-2025-61155
+- https://github.com/pollotherunner/CVE-2025-61155/blob/main/advisory.md
+- https://vespalec.com/blog/tower-of-flaws/
+- https://github.com/svespalec/TowerOfFlaws
 Detection: []
 Acknowledgement:
-  Person: ''
-  Handle: tobias-richter323
+  Person: Tobias Richter, Samuel (Vespalec), Gabriel Maciel Ramos, Anthony Sforzin
+  Handle: tobias-richter323 / @svespalec / @pollotherunner / @sys0xFF
 KnownVulnerableSamples:
 - Filename: GameDriverX64.sys
   MD5: cb34be5126520f4c402be3c6f09e11cf
@@ -36,16 +48,177 @@ KnownVulnerableSamples:
   - Shanghai Yuelong IE Culture Technology Co., Ltd.
   Date: 07:08 AM 08/10/2023
   Publisher: Shanghai Yuelong IE Culture Technology Co., Ltd.
-  Company: ''
+  Company: GameDriver
   Description: GameDriverX64
   Product: GameDriverX64
-  ProductVersion: ''
+  ProductVersion: 7.23.04.07
   FileVersion: 7.23.04.07
   MachineType: AMD64
   OriginalFilename: GameDriverX64.sys
-  InternalName: GameDriverX64.sys
+  InternalName: ''
   Copyright: ''
   Imphash: b615e95f5fb9f4b26a7d238fcdd00e79
+  Authentihash:
+    MD5: aaf2c8be531e06919898a44600b6d9c9
+    SHA1: bd9bc87c0aaeaeef6c4b8b6fa5752a6998aaccaa
+    SHA256: 46f2db2a8012348eadc02d2eff62e521326be22cab79e4ebb5fe738ff7255324
+  RichPEHeaderHash:
+    MD5: f2d76afd2f231551558bcf27fcfe5301
+    SHA1: 51ad2459282c637fb625bb08d2c767d2214fa543
+    SHA256: 7188536c55a55cfb4b1d4887584f0b5b87e1cca1cfe244bc5ec133a9dcc0c54a
+  Sections:
+    .text:
+      Entropy: 6.213209958870949
+      Virtual Size: '0x454d'
+    .rdata:
+      Entropy: 4.529806418953954
+      Virtual Size: '0xd74'
+    .data:
+      Entropy: 7.239255600120258
+      Virtual Size: '0x168c'
+    .pdata:
+      Entropy: 7.786781204873859
+      Virtual Size: '0x390'
+    PAGE:
+      Entropy: 0.7613548174449117
+      Virtual Size: '0x510'
+    INIT:
+      Entropy: 4.701430352419779
+      Virtual Size: '0xd74'
+    .uo10:
+      Entropy: 6.6424366296706685
+      Virtual Size: '0x25f0'
+    .reloc:
+      Entropy: 3.368241561497932
+      Virtual Size: '0x24'
+    .rsrc:
+      Entropy: 3.1932668998911167
+      Virtual Size: '0x2ac'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2023-04-10 07:40:34'
+  Imports:
+  - ntoskrnl.exe
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ObReferenceObjectByHandle
+  - ObfDereferenceObject
+  - ZwCreateFile
+  - ZwWriteFile
+  - ZwClose
+  - FsRtlGetFileSize
+  - ZwDeleteFile
+  - _vsnprintf
+  - IoFileObjectType
+  - MmIsAddressValid
+  - RtlImageNtHeader
+  - __chkstk
+  - MmHighestUserAddress
+  - _stricmp
+  - DbgPrint
+  - IoGetCurrentProcess
+  - PsLookupProcessByProcessId
+  - IoThreadToProcess
+  - PsGetProcessImageFileName
+  - _vsnwprintf
+  - PsProcessType
+  - PsThreadType
+  - KeInitializeEvent
+  - ExAllocatePoolWithTag
+  - ExFreePoolWithTag
+  - ExAcquireFastMutex
+  - ExReleaseFastMutex
+  - _strnicmp
+  - RtlUnicodeStringToInteger
+  - RtlInitAnsiString
+  - RtlAnsiStringToUnicodeString
+  - RtlCompareUnicodeString
+  - RtlFreeUnicodeString
+  - RtlGetVersion
+  - KeDelayExecutionThread
+  - KeWaitForSingleObject
+  - ExSystemTimeToLocalTime
+  - ZwQueryInformationFile
+  - ZwReadFile
+  - ZwTerminateProcess
+  - ZwOpenProcess
+  - ExEnumHandleTable
+  - ExfUnblockPushLock
+  - PsAcquireProcessExitSynchronization
+  - PsReleaseProcessExitSynchronization
+  - PsGetProcessPeb
+  - PsGetProcessWow64Process
+  - RtlCopyUnicodeString
+  - KdDisableDebugger
+  - KdChangeOption
+  - PsCreateSystemThread
+  - PsTerminateSystemThread
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoAllocateWorkItem
+  - IoFreeWorkItem
+  - IoQueueWorkItem
+  - ZwUnloadDriver
+  - PsSetCreateProcessNotifyRoutine
+  - PsGetProcessDebugPort
+  - KdDebuggerEnabled
+  - KeBugCheckEx
+  - RtlTimeToTimeFields
+  - __C_specific_handler
+  - MmGetSystemRoutineAddress
+  - RtlInitUnicodeString
+  - WdfVersionBind
+  - WdfVersionUnbind
+  - WdfVersionUnbindClass
+  - WdfVersionBindClass
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      ValidFrom: '2021-04-29 00:00:00'
+      ValidTo: '2036-04-28 23:59:59'
+      Signature: 3a23443d8d0876ee8fbc3a99d356e0021aa5f84834f32cb6e67466f79472b100caaf6c302713129e90449f4bfd9ea37c26d537bc3a5d486d95d53f49f427bb16814550fd9cbdb685e0767e3771cb22f75aaa90cff5936ae3eb20d1d55079889a8a8ac1b6bda148187edcd8801a111918cd61998156f6c9e376e7c4e41b5f43f83e94ff76393d9ed499cf4add28eb5f26a1955848d51afed7273ffd90d17686dd1cb0605cf30da8eee089a1bd39e1384eda6ebb369dfbe521535ac3cae96af1a23edb43b833c84f38149299f5ddce546dd95d02141f40337c03e295b2c221757352cb46d8c4341ca2a54b8dcd6f76372c853f1ace26e918be9007b0437f9588208270f0cccaeffd29355c1f893855f7378a8b09a1cb0be9311aff2e195c3971e1be9ca70a06d62667b792e64e5fde7aac49cf2ea47492addb3ca49c861fe3c1561b2b23ff8fb5ea887b706be6a0bafd3a3f45a6c4e81691528b41c048844b964dab4440e38df01528ceedf11856072a2f10c40c08643c338fae288c3ccb8f880b0dbf3bf4ce1e7b8eefb5ebcbb7f07713e6e7283fac12aea52f226c41f9825c1566cc6c0ecac586c3f626330c074ba0d307026a6a4030484b34a85120bbad1b8508e2590d6dca05502bea4a1c9ea5fda0a71f0674e7f2d65290fdaf854821f9573bb49c03ed8645f4b4616ebf68e2266086eac8afa9fe941de7631b3a8656784e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 08ad40b260d29c4c9f5ecda9bd93aed9
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 5d8003a64dfa5a4d88365da1566038cb
+        SHA1: 79465b56bc7ad55a37bdf633943da8bfc84db228
+        SHA256: 84bdc82e2f2a7f7aaa782667dac556ffcb2b33240c1f9c0a00a3264526a98332
+        SHA384: 65b1d4076a89ae273f57e6eeedecb3eae129b4168f76fa7671914cdf461d542255c59d9b85b916ae0ca6fc0fcf7a8e64
+    - Subject: JURISDICTION_OF_INCORPORATION_C=CN, JURISDICTION_OF_INCORPORATION_SP=Shanghai,
+        BUSINESS_CATEGORY=Private Organization, serialNumber=91120222MA0690HC8N, C=CN,
+        ST=shanghai, O=Shanghai Yuelong IE Culture Technology Co., Ltd., CN=Shanghai
+        Yuelong IE Culture Technology Co., Ltd.
+      ValidFrom: '2023-06-05 00:00:00'
+      ValidTo: '2026-06-07 23:59:59'
+      Signature: 84c7ab5eed0d4aa1542410a9047bc44bfc02af1983a21a5dc94eb2b351e3bddcdd4ef000d0312beebcf0a7becd8ea0dc9c9b6daafde2314e24adabdfdb993aba64f3208d43d313db0f91971fbde42ddf8e0f25a47480f1ad4f1d55b059e3df845954375ff9b630e7649248b4ab62d9f3b2406d9bbc6fddb907723188cf88d5a1b6bcd4bdcdd5dac7b0254e04ac55be79b8980d4bc87e0da7546fd3f59d626ac2d356249edd7a3582edc63580e92a3f2091b9c3998a251ea9c23d2282b2a4a07cdca7e63da4a4a459d283cb9ec87e56a6ec14dd6a69d8a120e7d6e12c16f22e569b3f15d9bd5f0a92cfa1fd803182a8cf5191cfee7da9d6be62fba2dac2827948f85a6db1ca91b05a20abe4787fd29f8e8736bfc5b0a292e8910a3e2e520659a1f352ec8ed886cea58f78cbba9296a3f4e8fefef6559c48ead6e9ba176610113664e48ceef02e3ed070c2adaf061cead24deb12cbe75562c0125e86dacfce39ad29b8878ae80c2b82d392d1a49a1d139e6a34c8b5536453c8657176662fc4b72817db965e80cb81c0043275ae21f071545cede0b3eb5e032de19924a4a79ac5de01e5e1748f1838ba428c4f7b7676b1ce8c852354c09a7730400bf1b3e27d03239cb8d0a784891399780f126d698ef277281f8421c599cf7de1cdfb095ced4b6ecef4b9fd8b7c59ee3aab52fe25ed56d609970af78384960c6b0c11988456f692
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 0579023018d0416afbd65a2d76ba2ec6
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 860a03285c68939a441939a0c201938b
+        SHA1: 20f6fb1366a38f5d81b0863c1899db61f6e4c66e
+        SHA256: b2e30b3eca02e1ffab445c5808f6072a889f45552c7bdd611dd226c9acd4d65a
+        SHA384: f3160541bb92f04a9c450ffb7c7131b7f7e85fb4241f8e6d02004b9e9f477709eeefc830501c70adf88bfa7386629b8c
+    Signer:
+    - SerialNumber: 0579023018d0416afbd65a2d76ba2ec6
+      Issuer: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      Version: 1
 - Filename: GameDriverX64.sys
   SHA256: 9ddae47ff968343a8c32a5344060257fdc08e2a7bdb9a227c8b3a584ee3c9f1e
   MD5: 8f0577d28c4ff5f71b149f444bfaba8e
@@ -88,7 +261,7 @@ KnownVulnerableSamples:
       Entropy: 3.201288637173654
       Virtual Size: '0x2ac'
   MagicHeader: 50 45 0 0
-  CreationTimestamp: '2023-04-10 01:40:34'
+  CreationTimestamp: '2023-04-10 07:40:34'
   Description: GameDriverX64
   Company: GameDriver
   InternalName: ''
@@ -217,6 +390,1300 @@ KnownVulnerableSamples:
         SHA384: 4876e1cc9c414afe90a7c75275035a2ec8f4c6fed123b51817f7946fcf128df22b189768c9af762945b60bb99a719528
     Signer:
     - SerialNumber: 020641782828aeae70a776bee350cba2
+      Issuer: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      Version: 1
+- Filename: GameDriverX64.sys
+  MD5: 0d9bbed76c17b954ec9120bdfb144ec9
+  SHA1: 1b648ce9b743bf2d9c8da10143f4995ffd055b50
+  SHA256: 9d396b83647f5233cd93f47caa05e0a0d0dd5dd2f17ba2b0ae5cd1afc0afa69d
+  Imphash: b615e95f5fb9f4b26a7d238fcdd00e79
+  Authentihash:
+    MD5: aaf2c8be531e06919898a44600b6d9c9
+    SHA1: bd9bc87c0aaeaeef6c4b8b6fa5752a6998aaccaa
+    SHA256: 46f2db2a8012348eadc02d2eff62e521326be22cab79e4ebb5fe738ff7255324
+  RichPEHeaderHash:
+    MD5: f2d76afd2f231551558bcf27fcfe5301
+    SHA1: 51ad2459282c637fb625bb08d2c767d2214fa543
+    SHA256: 7188536c55a55cfb4b1d4887584f0b5b87e1cca1cfe244bc5ec133a9dcc0c54a
+  Sections:
+    .text:
+      Entropy: 6.213209958870949
+      Virtual Size: '0x454d'
+    .rdata:
+      Entropy: 4.529806418953954
+      Virtual Size: '0xd74'
+    .data:
+      Entropy: 7.239255600120258
+      Virtual Size: '0x168c'
+    .pdata:
+      Entropy: 7.786781204873859
+      Virtual Size: '0x390'
+    PAGE:
+      Entropy: 0.7613548174449117
+      Virtual Size: '0x510'
+    INIT:
+      Entropy: 4.701430352419779
+      Virtual Size: '0xd74'
+    .uo10:
+      Entropy: 6.6424366296706685
+      Virtual Size: '0x25f0'
+    .reloc:
+      Entropy: 3.368241561497932
+      Virtual Size: '0x24'
+    .rsrc:
+      Entropy: 3.1932668998911167
+      Virtual Size: '0x2ac'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2023-04-10 07:40:34'
+  Description: GameDriverX64
+  Company: GameDriver
+  InternalName: ''
+  OriginalFilename: GameDriverX64.sys
+  FileVersion: 7.23.04.07
+  Product: GameDriverX64
+  ProductVersion: 7.23.04.07
+  Copyright: ''
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ObReferenceObjectByHandle
+  - ObfDereferenceObject
+  - ZwCreateFile
+  - ZwWriteFile
+  - ZwClose
+  - FsRtlGetFileSize
+  - ZwDeleteFile
+  - _vsnprintf
+  - IoFileObjectType
+  - MmIsAddressValid
+  - RtlImageNtHeader
+  - __chkstk
+  - MmHighestUserAddress
+  - _stricmp
+  - DbgPrint
+  - IoGetCurrentProcess
+  - PsLookupProcessByProcessId
+  - IoThreadToProcess
+  - PsGetProcessImageFileName
+  - _vsnwprintf
+  - PsProcessType
+  - PsThreadType
+  - KeInitializeEvent
+  - ExAllocatePoolWithTag
+  - ExFreePoolWithTag
+  - ExAcquireFastMutex
+  - ExReleaseFastMutex
+  - _strnicmp
+  - RtlUnicodeStringToInteger
+  - RtlInitAnsiString
+  - RtlAnsiStringToUnicodeString
+  - RtlCompareUnicodeString
+  - RtlFreeUnicodeString
+  - RtlGetVersion
+  - KeDelayExecutionThread
+  - KeWaitForSingleObject
+  - ExSystemTimeToLocalTime
+  - ZwQueryInformationFile
+  - ZwReadFile
+  - ZwTerminateProcess
+  - ZwOpenProcess
+  - ExEnumHandleTable
+  - ExfUnblockPushLock
+  - PsAcquireProcessExitSynchronization
+  - PsReleaseProcessExitSynchronization
+  - PsGetProcessPeb
+  - PsGetProcessWow64Process
+  - RtlCopyUnicodeString
+  - KdDisableDebugger
+  - KdChangeOption
+  - PsCreateSystemThread
+  - PsTerminateSystemThread
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoAllocateWorkItem
+  - IoFreeWorkItem
+  - IoQueueWorkItem
+  - ZwUnloadDriver
+  - PsSetCreateProcessNotifyRoutine
+  - PsGetProcessDebugPort
+  - KdDebuggerEnabled
+  - KeBugCheckEx
+  - RtlTimeToTimeFields
+  - __C_specific_handler
+  - MmGetSystemRoutineAddress
+  - RtlInitUnicodeString
+  - WdfVersionBind
+  - WdfVersionUnbind
+  - WdfVersionUnbindClass
+  - WdfVersionBindClass
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      ValidFrom: '2021-04-29 00:00:00'
+      ValidTo: '2036-04-28 23:59:59'
+      Signature: 3a23443d8d0876ee8fbc3a99d356e0021aa5f84834f32cb6e67466f79472b100caaf6c302713129e90449f4bfd9ea37c26d537bc3a5d486d95d53f49f427bb16814550fd9cbdb685e0767e3771cb22f75aaa90cff5936ae3eb20d1d55079889a8a8ac1b6bda148187edcd8801a111918cd61998156f6c9e376e7c4e41b5f43f83e94ff76393d9ed499cf4add28eb5f26a1955848d51afed7273ffd90d17686dd1cb0605cf30da8eee089a1bd39e1384eda6ebb369dfbe521535ac3cae96af1a23edb43b833c84f38149299f5ddce546dd95d02141f40337c03e295b2c221757352cb46d8c4341ca2a54b8dcd6f76372c853f1ace26e918be9007b0437f9588208270f0cccaeffd29355c1f893855f7378a8b09a1cb0be9311aff2e195c3971e1be9ca70a06d62667b792e64e5fde7aac49cf2ea47492addb3ca49c861fe3c1561b2b23ff8fb5ea887b706be6a0bafd3a3f45a6c4e81691528b41c048844b964dab4440e38df01528ceedf11856072a2f10c40c08643c338fae288c3ccb8f880b0dbf3bf4ce1e7b8eefb5ebcbb7f07713e6e7283fac12aea52f226c41f9825c1566cc6c0ecac586c3f626330c074ba0d307026a6a4030484b34a85120bbad1b8508e2590d6dca05502bea4a1c9ea5fda0a71f0674e7f2d65290fdaf854821f9573bb49c03ed8645f4b4616ebf68e2266086eac8afa9fe941de7631b3a8656784e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 08ad40b260d29c4c9f5ecda9bd93aed9
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 5d8003a64dfa5a4d88365da1566038cb
+        SHA1: 79465b56bc7ad55a37bdf633943da8bfc84db228
+        SHA256: 84bdc82e2f2a7f7aaa782667dac556ffcb2b33240c1f9c0a00a3264526a98332
+        SHA384: 65b1d4076a89ae273f57e6eeedecb3eae129b4168f76fa7671914cdf461d542255c59d9b85b916ae0ca6fc0fcf7a8e64
+    - Subject: JURISDICTION_OF_INCORPORATION_C=CN, JURISDICTION_OF_INCORPORATION_SP=Shanghai,
+        BUSINESS_CATEGORY=Private Organization, serialNumber=91120222MA0690HC8N, C=CN,
+        ST=shanghai, O=Shanghai Yuelong IE Culture Technology Co., Ltd., CN=Shanghai
+        Yuelong IE Culture Technology Co., Ltd.
+      ValidFrom: '2023-06-05 00:00:00'
+      ValidTo: '2026-06-07 23:59:59'
+      Signature: 84c7ab5eed0d4aa1542410a9047bc44bfc02af1983a21a5dc94eb2b351e3bddcdd4ef000d0312beebcf0a7becd8ea0dc9c9b6daafde2314e24adabdfdb993aba64f3208d43d313db0f91971fbde42ddf8e0f25a47480f1ad4f1d55b059e3df845954375ff9b630e7649248b4ab62d9f3b2406d9bbc6fddb907723188cf88d5a1b6bcd4bdcdd5dac7b0254e04ac55be79b8980d4bc87e0da7546fd3f59d626ac2d356249edd7a3582edc63580e92a3f2091b9c3998a251ea9c23d2282b2a4a07cdca7e63da4a4a459d283cb9ec87e56a6ec14dd6a69d8a120e7d6e12c16f22e569b3f15d9bd5f0a92cfa1fd803182a8cf5191cfee7da9d6be62fba2dac2827948f85a6db1ca91b05a20abe4787fd29f8e8736bfc5b0a292e8910a3e2e520659a1f352ec8ed886cea58f78cbba9296a3f4e8fefef6559c48ead6e9ba176610113664e48ceef02e3ed070c2adaf061cead24deb12cbe75562c0125e86dacfce39ad29b8878ae80c2b82d392d1a49a1d139e6a34c8b5536453c8657176662fc4b72817db965e80cb81c0043275ae21f071545cede0b3eb5e032de19924a4a79ac5de01e5e1748f1838ba428c4f7b7676b1ce8c852354c09a7730400bf1b3e27d03239cb8d0a784891399780f126d698ef277281f8421c599cf7de1cdfb095ced4b6ecef4b9fd8b7c59ee3aab52fe25ed56d609970af78384960c6b0c11988456f692
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 0579023018d0416afbd65a2d76ba2ec6
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 860a03285c68939a441939a0c201938b
+        SHA1: 20f6fb1366a38f5d81b0863c1899db61f6e4c66e
+        SHA256: b2e30b3eca02e1ffab445c5808f6072a889f45552c7bdd611dd226c9acd4d65a
+        SHA384: f3160541bb92f04a9c450ffb7c7131b7f7e85fb4241f8e6d02004b9e9f477709eeefc830501c70adf88bfa7386629b8c
+    Signer:
+    - SerialNumber: 0579023018d0416afbd65a2d76ba2ec6
+      Issuer: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      Version: 1
+- Filename: GameDriverX64.sys
+  MD5: 1f06e06a9e64bad05ba9cccfffa92421
+  SHA1: edf005b78104c208d05d2ea01fe747a8b8999bb9
+  SHA256: ca22e593362a8fa4f728e83f6861f983373f61480d0384e26ed149e507706d6a
+  Imphash: b615e95f5fb9f4b26a7d238fcdd00e79
+  Authentihash:
+    MD5: 833347fb0f9b505f92c1bf01e3d5d006
+    SHA1: bc38c092b2478d5b67bc51fefd18705401af9bef
+    SHA256: a9c149018c802d3f982d3b3857495e29fd231df7ed030588f163b329024a6865
+  RichPEHeaderHash:
+    MD5: f2d76afd2f231551558bcf27fcfe5301
+    SHA1: 51ad2459282c637fb625bb08d2c767d2214fa543
+    SHA256: 7188536c55a55cfb4b1d4887584f0b5b87e1cca1cfe244bc5ec133a9dcc0c54a
+  Sections:
+    .text:
+      Entropy: 6.212805809836754
+      Virtual Size: '0x454d'
+    .rdata:
+      Entropy: 4.530606328217067
+      Virtual Size: '0xd74'
+    .data:
+      Entropy: 7.239255600120258
+      Virtual Size: '0x168c'
+    .pdata:
+      Entropy: 7.766327103788549
+      Virtual Size: '0x390'
+    PAGE:
+      Entropy: 0.762898027321455
+      Virtual Size: '0x510'
+    INIT:
+      Entropy: 4.70103447229036
+      Virtual Size: '0xd74'
+    .uo10:
+      Entropy: 6.633970720857814
+      Virtual Size: '0x2650'
+    .reloc:
+      Entropy: 3.368241561497932
+      Virtual Size: '0x24'
+    .rsrc:
+      Entropy: 3.1932668998911167
+      Virtual Size: '0x2ac'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2023-04-10 07:40:34'
+  Description: GameDriverX64
+  Company: GameDriver
+  InternalName: ''
+  OriginalFilename: GameDriverX64.sys
+  FileVersion: 7.23.04.07
+  Product: GameDriverX64
+  ProductVersion: 7.23.04.07
+  Copyright: ''
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ObReferenceObjectByHandle
+  - ObfDereferenceObject
+  - ZwCreateFile
+  - ZwWriteFile
+  - ZwClose
+  - FsRtlGetFileSize
+  - ZwDeleteFile
+  - _vsnprintf
+  - IoFileObjectType
+  - MmIsAddressValid
+  - RtlImageNtHeader
+  - __chkstk
+  - MmHighestUserAddress
+  - _stricmp
+  - DbgPrint
+  - IoGetCurrentProcess
+  - PsLookupProcessByProcessId
+  - IoThreadToProcess
+  - PsGetProcessImageFileName
+  - _vsnwprintf
+  - PsProcessType
+  - PsThreadType
+  - KeInitializeEvent
+  - ExAllocatePoolWithTag
+  - ExFreePoolWithTag
+  - ExAcquireFastMutex
+  - ExReleaseFastMutex
+  - _strnicmp
+  - RtlUnicodeStringToInteger
+  - RtlInitAnsiString
+  - RtlAnsiStringToUnicodeString
+  - RtlCompareUnicodeString
+  - RtlFreeUnicodeString
+  - RtlGetVersion
+  - KeDelayExecutionThread
+  - KeWaitForSingleObject
+  - ExSystemTimeToLocalTime
+  - ZwQueryInformationFile
+  - ZwReadFile
+  - ZwTerminateProcess
+  - ZwOpenProcess
+  - ExEnumHandleTable
+  - ExfUnblockPushLock
+  - PsAcquireProcessExitSynchronization
+  - PsReleaseProcessExitSynchronization
+  - PsGetProcessPeb
+  - PsGetProcessWow64Process
+  - RtlCopyUnicodeString
+  - KdDisableDebugger
+  - KdChangeOption
+  - PsCreateSystemThread
+  - PsTerminateSystemThread
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoAllocateWorkItem
+  - IoFreeWorkItem
+  - IoQueueWorkItem
+  - ZwUnloadDriver
+  - PsSetCreateProcessNotifyRoutine
+  - PsGetProcessDebugPort
+  - KdDebuggerEnabled
+  - KeBugCheckEx
+  - RtlTimeToTimeFields
+  - __C_specific_handler
+  - MmGetSystemRoutineAddress
+  - RtlInitUnicodeString
+  - WdfVersionBind
+  - WdfVersionUnbind
+  - WdfVersionUnbindClass
+  - WdfVersionBindClass
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Entrust, Inc., CN=Entrust Code Signing Root Certification Authority
+        , CSBR1
+      ValidFrom: '2021-05-07 15:43:45'
+      ValidTo: '2030-11-07 16:13:45'
+      Signature: 1f5e4104b6837024532c55731d653ac0ecb47b04985e59381309a45994425e50bf4f6c6e2520909358400df519b462ee245ec2015815021d10096fa8d4fb927e37383e2f147d8f1d433664b366135f14cca571f75b214bc697bedc95fc707d111cd321ddd0243929c5fe0a1aa5cf7b79ee3a6fdedcbfe911dd168308d32c8d7f4da814792f05615238eb60f314687dcbb28aadc0945ce4260e2c8add46c3cee45651c556e385b84d9b45728b07f18afb49b85fd1f296815d695224f10823d2d6230feb8bd77e8bc1936bfaf1627b58e9509b976e17880de1c64398d78161b6859d47ecb19eae3f203b439dd8a21ce0d47c08c2af7606f862667ab6f7fac8af35
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 4e40e43754ede68c0000000051d3947f
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: a0aedb08ebbac1058afe83a035d0242d
+        SHA1: cea6a62304cd027179eeb575ab85bbbfbfefdfb3
+        SHA256: f89f7ea86830083d285a316e68f23fe53b4d3031237987231ae889f6792e6d04
+        SHA384: c35463b7269ca5c61ce83bc0dd9b84298ca4a8be11394473b0e45069b6bcd77d984f79a23dd28ece4a8c05d4d4135be8
+    - Subject: C=US, O=Entrust, Inc., CN=Entrust Extended Validation Code Signing
+        CA , EVCS2
+      ValidFrom: '2021-05-07 19:19:52'
+      ValidTo: '2040-12-29 23:59:00'
+      Signature: 3e0054b82af38f66af6116c4589364f4418b64558d1b3533a19b91d8ab46caab5fbcbe7e70e4d2d707a89607d786d1570a08d0d0784df82adfb204f39ae1d77cf0c1007ac140a1df8a8cb7cbb41d0161f2989aa6ddb88305caa92c16dc9c2d0efea797e450a99795c14b2a8c51e3c402e06b7c354d53bc4b94138b5318165ea60aa7b834c16cb1eb2ce4317d0c2cc67ce1a456e82d76d5b21375ea8300ae0077c66fa93dee6314815016fc5b4f12190e5b0f8dea4bce064c894bae20cc8e47a675d665ee2f30e85d348f1f824d5c42a6f2144c50209c09a274245c39d88932853caf8ce56a9ee6043aa513ffaa1dcd474b2e0205b46a8feb854f81ef0adb7d9f298fa5c23f52385241953bbc3e5b543042230963de508d893545faabb80f8fa2ad7b7a1193f18f28847b6879476ae864294d1ff41d2f6d1ec894863cd35a997a6b7cab35f72b394b4fb93f1692ef298c8dabac011acc714439cb403e2012ce0870e347fedc80d70800d10b6aea21b5796617e96aaa56ddcd1578b103c014ad3e471875ed0a534b3293cdff80b190d613e5e4417822ed4182e50edfb0ce952145e68b01d319f7f42b55acd956736310e0b8a06dcb549698a099215106aaa60c3a2b63cb79da43b9d212ccde8f557ae909f3e29ad325c17b3692dae0e55267cde3e6540aa59dd473a3d32f5d06648503777f60d8c2bc74c9959168b7b77e611975
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.13
+      IsCertificateAuthority: true
+      SerialNumber: 35afb77b9d341f6afc8f8446ab31352b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: a60ca3cf0c2cf22af6d401f9b8a4b90d
+        SHA1: 8a227377a552d38a032d8d1a8074ae225221ada0
+        SHA256: d714505624c235d001a2c8ebece399b1ef55c0de108d71664c5509ff77c5d6fe
+        SHA384: a13af8dc76116e81887c9539e67af8d9c60da3ae7c57e5092c024f182f2a26f64b5f943ccc29cb17badb8669eb90393c
+    - Subject: C=US, ST=California, L=Culver City, JURISDICTION_OF_INCORPORATION_C=US,
+        JURISDICTION_OF_INCORPORATION_SP=Delaware, O=Crunchyroll, LLC, BUSINESS_CATEGORY=Private
+        Organization, serialNumber=6551580, CN=Crunchyroll, LLC
+      ValidFrom: '2023-09-29 19:14:12'
+      ValidTo: '2024-09-29 19:14:10'
+      Signature: 90c747b684b166ec2a29a26dca9cbdb693a96eaad5dff0b22698c8ef779e8be2a1140c1a245174816d5bfb6e56b1bdd43d9f47f2d67c17c086ad92231140cb9d671d2f172205769fe5921a36b3996b8b771ef4672c7b82dcd9d5ee1589e0a35af19198a9730092b5cb52254f366644801a42ebc6cf45f67a8ed5e001ffc991bf472755f245551efaa4b67a443af1ba3f514a04c73fc968700856b23637a6fa60b4dbd3894b681d256686c3be0af00623c6aa2cde6dddd49feb8ec102d40b96ff2d2fc296249bfdc4cf1351c04cd508ed033b9c624f2e9a7747de51f953a3680c89b3642c2eaaebb53ded8d0b3a7b0098fdbd9e007c35c622d33fa4e0d0c0b340a86a398c35b187a5c0bbdf8a46e6308acc509d1a78a23e180f8e5e74b89aee1b1001adc43d2616256fcad9a88315fa362fef92a09266b52934b0fd3aac49b780e14501d993c95f128aa497bcaa9500c087cdacb5c459fd198a3e26a6ef2084c2c316a83541426c667e4ef2100c99e85b8ee40f46b471d33baa2e0daf5215b3b9db7978780adf295fe2b35fa62dfc6a7b4147b6ac082978b67bd123e6a15aca09582a5f6bccb9fe5fb235d70dced4e77a3ca69a089da96617d9e52b04b95848ac42d72282b2b022cfdb1128c99eab649e137fd5adcc07338c8a5e7019a8c10045b4ed0c9f4310d7f91d02cb68b246f329cd2f6f218938b7ef82aa1bbf5135374e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 4134d19fb6a66417129ffbb68cb29c3b
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: d99231a40e83f57daa9011622772b70c
+        SHA1: f113939e8b71209a8e9fb80246a937213cb0f3da
+        SHA256: c30d8575374f2cfcab60bd63d2e2e7b84122c556d391417b10e266fed25d0e1b
+        SHA384: 5f7bf29b30b681c8617d48b607d463197d420108a54fe4317e072ceeb645bd42e2767884cdc3e206af85b2d483077ada
+    Signer:
+    - SerialNumber: 4134d19fb6a66417129ffbb68cb29c3b
+      Issuer: C=US, O=Entrust, Inc., CN=Entrust Extended Validation Code Signing CA
+        , EVCS2
+      Version: 1
+- Filename: GameDriverX64.sys
+  MD5: 3b1c40c32b92696d192d846ab4ca2b45
+  SHA1: 6fa02c7d563be45d0f615c3c170ce2b425629d6c
+  SHA256: c0db95a62e50f3a2c757ac264534ef17340bf8b8aa94b98fcb7663c493b2d569
+  Imphash: b615e95f5fb9f4b26a7d238fcdd00e79
+  Authentihash:
+    MD5: f032db974bc4fa06e5fd4117e8e381b8
+    SHA1: ae691f567a67998e921f13d697c79f89eb6584b7
+    SHA256: 6fa8262990fbc2a1370a94c5c6e700183a5619a0d8de4b6e783215907c4b2d68
+  RichPEHeaderHash:
+    MD5: f2d76afd2f231551558bcf27fcfe5301
+    SHA1: 51ad2459282c637fb625bb08d2c767d2214fa543
+    SHA256: 7188536c55a55cfb4b1d4887584f0b5b87e1cca1cfe244bc5ec133a9dcc0c54a
+  Sections:
+    .text:
+      Entropy: 6.544231951157247
+      Virtual Size: '0x454d'
+    .rdata:
+      Entropy: 4.723942224689453
+      Virtual Size: '0xd74'
+    .data:
+      Entropy: 7.239255600120258
+      Virtual Size: '0x168c'
+    .pdata:
+      Entropy: 7.761658515597363
+      Virtual Size: '0x390'
+    PAGE:
+      Entropy: 7.676453251014581
+      Virtual Size: '0x510'
+    INIT:
+      Entropy: 6.076721294518338
+      Virtual Size: '0xd74'
+    .uo10:
+      Entropy: 5.870907820528687
+      Virtual Size: '0x1b30'
+    .reloc:
+      Entropy: 3.368241561497932
+      Virtual Size: '0x24'
+    .rsrc:
+      Entropy: 3.201288637173654
+      Virtual Size: '0x2ac'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2023-04-10 07:40:34'
+  Description: GameDriverX64
+  Company: GameDriver
+  InternalName: ''
+  OriginalFilename: GameDriverX64.sys
+  FileVersion: 7.23.04.07
+  Product: GameDriverX64
+  ProductVersion: 7.23.04.07
+  Copyright: ''
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ObReferenceObjectByHandle
+  - ObfDereferenceObject
+  - ZwCreateFile
+  - ZwWriteFile
+  - ZwClose
+  - FsRtlGetFileSize
+  - ZwDeleteFile
+  - _vsnprintf
+  - IoFileObjectType
+  - MmIsAddressValid
+  - RtlImageNtHeader
+  - __chkstk
+  - MmHighestUserAddress
+  - _stricmp
+  - DbgPrint
+  - IoGetCurrentProcess
+  - PsLookupProcessByProcessId
+  - IoThreadToProcess
+  - PsGetProcessImageFileName
+  - _vsnwprintf
+  - PsProcessType
+  - PsThreadType
+  - KeInitializeEvent
+  - ExAllocatePoolWithTag
+  - ExFreePoolWithTag
+  - ExAcquireFastMutex
+  - ExReleaseFastMutex
+  - _strnicmp
+  - RtlUnicodeStringToInteger
+  - RtlInitAnsiString
+  - RtlAnsiStringToUnicodeString
+  - RtlCompareUnicodeString
+  - RtlFreeUnicodeString
+  - RtlGetVersion
+  - KeDelayExecutionThread
+  - KeWaitForSingleObject
+  - ExSystemTimeToLocalTime
+  - ZwQueryInformationFile
+  - ZwReadFile
+  - ZwTerminateProcess
+  - ZwOpenProcess
+  - ExEnumHandleTable
+  - ExfUnblockPushLock
+  - PsAcquireProcessExitSynchronization
+  - PsReleaseProcessExitSynchronization
+  - PsGetProcessPeb
+  - PsGetProcessWow64Process
+  - RtlCopyUnicodeString
+  - KdDisableDebugger
+  - KdChangeOption
+  - PsCreateSystemThread
+  - PsTerminateSystemThread
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoAllocateWorkItem
+  - IoFreeWorkItem
+  - IoQueueWorkItem
+  - ZwUnloadDriver
+  - PsSetCreateProcessNotifyRoutine
+  - PsGetProcessDebugPort
+  - KdDebuggerEnabled
+  - KeBugCheckEx
+  - RtlTimeToTimeFields
+  - __C_specific_handler
+  - MmGetSystemRoutineAddress
+  - RtlInitUnicodeString
+  - WdfVersionBind
+  - WdfVersionUnbind
+  - WdfVersionUnbindClass
+  - WdfVersionBindClass
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      ValidFrom: '2021-04-29 00:00:00'
+      ValidTo: '2036-04-28 23:59:59'
+      Signature: 3a23443d8d0876ee8fbc3a99d356e0021aa5f84834f32cb6e67466f79472b100caaf6c302713129e90449f4bfd9ea37c26d537bc3a5d486d95d53f49f427bb16814550fd9cbdb685e0767e3771cb22f75aaa90cff5936ae3eb20d1d55079889a8a8ac1b6bda148187edcd8801a111918cd61998156f6c9e376e7c4e41b5f43f83e94ff76393d9ed499cf4add28eb5f26a1955848d51afed7273ffd90d17686dd1cb0605cf30da8eee089a1bd39e1384eda6ebb369dfbe521535ac3cae96af1a23edb43b833c84f38149299f5ddce546dd95d02141f40337c03e295b2c221757352cb46d8c4341ca2a54b8dcd6f76372c853f1ace26e918be9007b0437f9588208270f0cccaeffd29355c1f893855f7378a8b09a1cb0be9311aff2e195c3971e1be9ca70a06d62667b792e64e5fde7aac49cf2ea47492addb3ca49c861fe3c1561b2b23ff8fb5ea887b706be6a0bafd3a3f45a6c4e81691528b41c048844b964dab4440e38df01528ceedf11856072a2f10c40c08643c338fae288c3ccb8f880b0dbf3bf4ce1e7b8eefb5ebcbb7f07713e6e7283fac12aea52f226c41f9825c1566cc6c0ecac586c3f626330c074ba0d307026a6a4030484b34a85120bbad1b8508e2590d6dca05502bea4a1c9ea5fda0a71f0674e7f2d65290fdaf854821f9573bb49c03ed8645f4b4616ebf68e2266086eac8afa9fe941de7631b3a8656784e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 08ad40b260d29c4c9f5ecda9bd93aed9
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 5d8003a64dfa5a4d88365da1566038cb
+        SHA1: 79465b56bc7ad55a37bdf633943da8bfc84db228
+        SHA256: 84bdc82e2f2a7f7aaa782667dac556ffcb2b33240c1f9c0a00a3264526a98332
+        SHA384: 65b1d4076a89ae273f57e6eeedecb3eae129b4168f76fa7671914cdf461d542255c59d9b85b916ae0ca6fc0fcf7a8e64
+    - Subject: JURISDICTION_OF_INCORPORATION_C=HK, BUSINESS_CATEGORY=Private Organization,
+        serialNumber=2147741, C=HK, L=Kwun Tong, O=Fedeen Games Limited, CN=Fedeen
+        Games Limited
+      ValidFrom: '2022-07-21 00:00:00'
+      ValidTo: '2025-07-17 23:59:59'
+      Signature: 2e436cef00e94eb70af4b4362eb2df91a4ee941866c1fedb1d6911764b0501afa628307677cc68c6671c0601515fa158d542a961a17ff7465573f6f2946d71d8101bc9384234c83dd983d43354d4262ef68b5e03f69417afca20e36554b798fbfcadcbbe76b9789bcbd9766eb229ceca810e7468f17c1cad7c74f9f6c351d0a495c39d6308e4c34b96e418cd8b56fc1a2291c8f67cb6c8f320b263657876c401a10e1d0ac0bb203823f8d0d02d4138db236d616c102f7c43950c53ff9cfcc2a0a9594e37115ae44bd084f1ef851da1db6bb105e34023b90dd68f7eacbabf7fcf635516c2ea7a9f3f5eae6e51439f8f202c9bc16129118e7cf65c8e6d44b055cf41ed5322948a689caa506f7caf14fec8025ace35d8ebbf5f54edc9fa8aa20b9d418cf8d3ca17427f3a4b34c92a8b6e95e67c507a199fc763bd30d10ca326cec58386f06c42926c7cc2612647d0faecabce91525517c6e10085b4d1a85bb0a8dc033d1a7dd84694b15ad5c0d5a030301e237a991918ec191640eb3c3e48bca0bbec77faf235aeca08407e4f56ab45e67c26eadb7e36a57958076ba405e0407c3016c51de5ba43e5570a92788c9cc850bbf5d66d55746adb6e6c8a44cf616080b7d341abd218c25b6a530b58617c1d5e779f61e2d3a999eebc31dfdf13d6e4a81329725deddb247ad364838189229e60e6548f08a3045e30eef675486b188785dd
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 020641782828aeae70a776bee350cba2
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 053b0a8ba5681faaf22b671cbcf74b5c
+        SHA1: 025b14b061d02d8123d3a15470ed64a2054358f2
+        SHA256: 3c1f16d0ebdd0b0eb134e3acc54046e1b89098810096ca9b52c39d689d60e597
+        SHA384: 4876e1cc9c414afe90a7c75275035a2ec8f4c6fed123b51817f7946fcf128df22b189768c9af762945b60bb99a719528
+    Signer:
+    - SerialNumber: 020641782828aeae70a776bee350cba2
+      Issuer: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      Version: 1
+- Filename: GameDriverX64.sys
+  MD5: 3d2a9d56b16831b18de4b4dfd26603c9
+  SHA1: 0d4f0196e0ed8c5c346f9c612ea2847215483a66
+  SHA256: e55bfbb979143c6d1bc97129c9b5663639b895f1db605cef578b7f06633c08f6
+  Imphash: 3ce472198cabef134ebbd7e847218cf4
+  Authentihash:
+    MD5: f3886a8a82e22830ec255c496854e78d
+    SHA1: 95efb5085aca242d892324c3a1a87ed7634f7d85
+    SHA256: 80ddb4d95feb9a00a880d578171f8bb9eff1c49446d54eadc700d140e961a121
+  RichPEHeaderHash:
+    MD5: 51531fc4f099e3d0d2f4334e2bbaf6fa
+    SHA1: bce9e1939dd364371a74a7de762ccb212f8e1d4f
+    SHA256: d3d6d026af68d4386ea78afb00035b52def4a0b92066cc974162939b5d25ab56
+  Sections:
+    .text:
+      Entropy: 6.497616611384268
+      Virtual Size: '0x4bcd'
+    .rdata:
+      Entropy: 4.7908148311751395
+      Virtual Size: '0xd84'
+    .data:
+      Entropy: 7.238699120320601
+      Virtual Size: '0x16ec'
+    .pdata:
+      Entropy: 7.77238968938705
+      Virtual Size: '0x39c'
+    PAGE:
+      Entropy: 7.6943369243265005
+      Virtual Size: '0x520'
+    INIT:
+      Entropy: 6.471017168122607
+      Virtual Size: '0xcfa'
+    .uo10:
+      Entropy: 5.791221495043027
+      Virtual Size: '0x1d1c'
+    .reloc:
+      Entropy: 3.2015748948312654
+      Virtual Size: '0x24'
+    .rsrc:
+      Entropy: 3.2303212256969345
+      Virtual Size: '0x2ac'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2023-11-15 03:07:55'
+  Description: GameDriverX64
+  Company: GameDriver
+  InternalName: ''
+  OriginalFilename: GameDriverX64.sys
+  FileVersion: 7.23.11.15
+  Product: GameDriverX64
+  ProductVersion: 7.23.11.15
+  Copyright: ''
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ObReferenceObjectByHandle
+  - ObfDereferenceObject
+  - ZwCreateFile
+  - ZwWriteFile
+  - ZwClose
+  - FsRtlGetFileSize
+  - ZwDeleteFile
+  - _vsnprintf
+  - IoFileObjectType
+  - MmIsAddressValid
+  - RtlImageNtHeader
+  - MmHighestUserAddress
+  - _stricmp
+  - DbgPrint
+  - IoGetCurrentProcess
+  - PsLookupProcessByProcessId
+  - IoThreadToProcess
+  - PsGetProcessImageFileName
+  - _vsnwprintf
+  - PsProcessType
+  - PsThreadType
+  - KeInitializeEvent
+  - ExAllocatePoolWithTag
+  - ExFreePoolWithTag
+  - ExAcquireFastMutex
+  - ExReleaseFastMutex
+  - _strnicmp
+  - RtlUnicodeStringToInteger
+  - RtlInitAnsiString
+  - RtlAnsiStringToUnicodeString
+  - RtlCompareUnicodeString
+  - ExSystemTimeToLocalTime
+  - RtlGetVersion
+  - KeDelayExecutionThread
+  - KeWaitForSingleObject
+  - ZwQueryInformationFile
+  - ZwReadFile
+  - ZwTerminateProcess
+  - ZwOpenProcess
+  - ExEnumHandleTable
+  - ExfUnblockPushLock
+  - PsAcquireProcessExitSynchronization
+  - PsReleaseProcessExitSynchronization
+  - PsGetProcessPeb
+  - PsGetProcessWow64Process
+  - RtlCopyUnicodeString
+  - IofCompleteRequest
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoAllocateWorkItem
+  - IoFreeWorkItem
+  - ZwUnloadDriver
+  - KdDebuggerEnabled
+  - KeBugCheckEx
+  - RtlTimeToTimeFields
+  - __C_specific_handler
+  - MmGetSystemRoutineAddress
+  - RtlFreeUnicodeString
+  - RtlInitUnicodeString
+  - WdfVersionBind
+  - WdfVersionUnbind
+  - WdfVersionUnbindClass
+  - WdfVersionBindClass
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: "JURISDICTION_OF_INCORPORATION_C=CN, JURISDICTION_OF_INCORPORATION_SP=\u5317\
+        \u4EAC\u5E02, JURISDICTION_OF_INCORPORATION_L=\u6D77\u6DC0\u533A, BUSINESS_CATEGORY=Private\
+        \ Organization, serialNumber=91110108MA00EPX28C, C=CN, ST=\u5317\u4EAC\u5E02\
+        , O=Beijing Beingfungames Technology Co., Ltd., CN=Beijing Beingfungames Technology\
+        \ Co., Ltd."
+      ValidFrom: '2023-11-08 00:00:00'
+      ValidTo: '2026-11-08 23:59:59'
+      Signature: 7f07df81bdc60e657d74ef1d5c2905ec18a1f89f3707cfcd2a2002e6bfbe2b6457361901a1e7b6469c904383bb03662ed7532f9ddeb7b9c25f073bb2545350c7b5d9bef325001cdfc4cffbd29104683e4fa47da146ea35125f6aae2d47db8264d302b7cb3a66b00623de1c5867cbefecadb058346eaa0445105fd3b86d1dbfad57e4765f696fef6cb14f02f25e40bf58063e2129bfa726e54d37adf1830b5ca9b80527a6380f2c082f5083f1041776bb15f7f1ffc4004409c3717a02678d9e857a1dd356c18ffc0d9cb715cd601c167a7b61067d5c3b5c86476de7d2093bf321ac0a8dd527edbb9f8f8d6679d3444a15cdd7b95f4164d4af3745434e7e2dc67af95633e5e3e4ebc3283f41931201656e25f994e8c196420219100ff99810ae24e9b950985f9ce2967ea3a94a5658ff5b1aec4cf2112d0bd47ffc17b8ad33bdde51fc34471e78962c72c555ed8f97cfdd7ef428ab06383465de1656ae36b5a8e9a99c19117d36fd810a3d5368a6f9113f4c61326835be9b76aee4a9bf8dbee6e42be8a107c0d556f6fbba970ddeed8028e1722420961c05c82399c6feaa7d6fcb724f65c4113ff54863280d37d97a818cdd17372b73fd0c10ebba065310a08bc19a92b014dfa3bc0638b958e719775989e8bcc5ed118d8dd475643e7e8104677d610e53737215637317e3cce19c91e87ff564df7d49f2383cc998f0667f37daf9
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 08920cd2003fabdf9465019a03326d75
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 134ee532849dc293de711ba5d01c523b
+        SHA1: 96b048fb73b83ecc85b2b1643f2cdcbb89c8f4c4
+        SHA256: 19e39745d75bcaca17f781b72b67b46feb3023dd7d43382b49c1d4d163d9546e
+        SHA384: 851f8cc12818ec95f42eed4c1e718beab81e12b4cb4e5aa16a3c07b952633bcbdfd88e70e19f940596b086949d677df9
+    Signer:
+    - SerialNumber: 08920cd2003fabdf9465019a03326d75
+      Issuer: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      Version: 1
+- Filename: KSophon_x64.sys
+  MD5: 9a1cd3071888ba68fb131f36bcc000e9
+  SHA1: debcc23345afe4ffe858749b3f7e287c00a185bc
+  SHA256: 4ea893c2da9f60590c6223b3c71b13e071d5f700cc3b93f4508b90187ef6091a
+  Imphash: 2a4da7c8a269c324f92513f358167269
+  Authentihash:
+    MD5: d39a5092bbc648aec900f0a89875983b
+    SHA1: bd5aec1c70da08f3f351bcc425eddaed06697658
+    SHA256: d579aa7b6da91da07b281f2b8be478e390ea42ccd3987d115735e8908db6a257
+  RichPEHeaderHash:
+    MD5: ''
+    SHA1: ''
+    SHA256: ''
+  Sections:
+    .text:
+      Entropy: 7.049865770163228
+      Virtual Size: '0x2d04de'
+    .rdata:
+      Entropy: 3.8571450454642204
+      Virtual Size: '0x95a00'
+    .data:
+      Entropy: 2.865848873157969
+      Virtual Size: '0x4c33ac'
+    .pdata:
+      Entropy: 7.972793371627906
+      Virtual Size: '0x64c8'
+    INIT:
+      Entropy: 0.1972748189638616
+      Virtual Size: '0x1a58'
+    .tvm00:
+      Entropy: 7.293580263595771
+      Virtual Size: '0x35e04c'
+    .gp0:
+      Entropy: 7.923621673955206
+      Virtual Size: '0x1d9e9'
+    .gp1:
+      Entropy: 6.213274604664729
+      Virtual Size: '0x415c'
+    .gp2:
+      Entropy: 7.189353580080528
+      Virtual Size: '0x155174'
+    .gp3:
+      Entropy: 6.386053249476563
+      Virtual Size: '0x9e40'
+    .rsrc:
+      Entropy: 3.4344695968019936
+      Virtual Size: '0x414'
+    .reloc:
+      Entropy: 5.414155643391903
+      Virtual Size: '0x58d4'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2022-08-10 12:06:09'
+  Description: KSophon_x64 NT Driver
+  Company: PROXIMA BETE
+  InternalName: KSophon_x64
+  OriginalFilename: KSophon_x64.sys
+  FileVersion: 0, 0, 0, 174
+  Product: KSophon_x64
+  ProductVersion: 0, 0, 0, 174
+  Copyright: Copyright (c) 2021 PROXIMA BETA. All Rights Reserved
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - hal.dll
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - MmIsAddressValid
+  - KeStallExecutionProcessor
+  - ExFreePool
+  - ExAllocatePoolWithTag
+  - ZwQuerySystemInformation
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Trusted Root
+        G4
+      ValidFrom: '2013-08-01 12:00:00'
+      ValidTo: '2038-01-15 12:00:00'
+      Signature: bb61d97da96cbe17c4911bc3a1a2008de364680f56cf77ae70f9fd9a4a99b9c9785c0c0c5fe4e61429560b36495d4463e0ad9c9618661b230d3d79e96d6bd654f8d23cc14340ae1d50f552fc903bbb9899696bc7c1a7a868a427dc9df927ae3085b9f6674d3a3e8f5939225344ebc85d03caed507a7d62210a80c87366d1a005605fe8a5b4a7afa8f76d359c7c5a8ad6a23899f3788bf44dd2200bde04ee8c9b4781720dc01432ef30592eaee071f256e46a976f92506d968d687a9ab236147a06f224b9091150d708b1b8897a8423614229e5a3cda22041d7d19c64d9ea26a18b14d74c19b25041713d3f4d7023860c4adc81d2cc3294840d0809971c4fc0ee6b207430d2e03934108521150108e85532de7149d92817504de6be4dd175acd0cafb41b843a5aad3c305444f2c369be2fae245b823536c066f67557f46b54c3f6e285a7926d2a4a86297d21ee2ed4a8bbc1bfd474a0ddf67667eb25b41d03be4f43bf40463e9efc2540051a08a2ac9ce78ccd5ea870418b3ceaf4988aff39299b6b3e6610fd28500e7501ae41b959d19a1b99cb19bb1001eefd00f4f426cc90abcee43fa3a71a5c84d26a535fd895dbc85621d32d2a02b54ed9a57c1dbfa10cf19b78b4a1b8f01b6279553e8b6896d5bbc68d423e88b51a256f9f0a680a0d61eb3bc0f0f537529aaea1377e4de8c8121ad07104711ad873d07d175bccff3667e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 059b1b579e8e2132e23907bda777755c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 41b622dd54995550fdc2f31ea12f8d9b
+        SHA1: 420704040c93dfe9d3ad01a26c07f2be1f4888c1
+        SHA256: 4816e2e9e37ba61e1def6f7a4c623e981c7af355e51349b5554a3d56c5252e24
+        SHA384: 4ea1b34b10b982a96a38915843507820ad632c6aad8343e337b34d660cd8366fa154544ae80668ae1fdf3931d57e1996
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      ValidFrom: '2021-04-29 00:00:00'
+      ValidTo: '2036-04-28 23:59:59'
+      Signature: 3a23443d8d0876ee8fbc3a99d356e0021aa5f84834f32cb6e67466f79472b100caaf6c302713129e90449f4bfd9ea37c26d537bc3a5d486d95d53f49f427bb16814550fd9cbdb685e0767e3771cb22f75aaa90cff5936ae3eb20d1d55079889a8a8ac1b6bda148187edcd8801a111918cd61998156f6c9e376e7c4e41b5f43f83e94ff76393d9ed499cf4add28eb5f26a1955848d51afed7273ffd90d17686dd1cb0605cf30da8eee089a1bd39e1384eda6ebb369dfbe521535ac3cae96af1a23edb43b833c84f38149299f5ddce546dd95d02141f40337c03e295b2c221757352cb46d8c4341ca2a54b8dcd6f76372c853f1ace26e918be9007b0437f9588208270f0cccaeffd29355c1f893855f7378a8b09a1cb0be9311aff2e195c3971e1be9ca70a06d62667b792e64e5fde7aac49cf2ea47492addb3ca49c861fe3c1561b2b23ff8fb5ea887b706be6a0bafd3a3f45a6c4e81691528b41c048844b964dab4440e38df01528ceedf11856072a2f10c40c08643c338fae288c3ccb8f880b0dbf3bf4ce1e7b8eefb5ebcbb7f07713e6e7283fac12aea52f226c41f9825c1566cc6c0ecac586c3f626330c074ba0d307026a6a4030484b34a85120bbad1b8508e2590d6dca05502bea4a1c9ea5fda0a71f0674e7f2d65290fdaf854821f9573bb49c03ed8645f4b4616ebf68e2266086eac8afa9fe941de7631b3a8656784e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 08ad40b260d29c4c9f5ecda9bd93aed9
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 5d8003a64dfa5a4d88365da1566038cb
+        SHA1: 79465b56bc7ad55a37bdf633943da8bfc84db228
+        SHA256: 84bdc82e2f2a7f7aaa782667dac556ffcb2b33240c1f9c0a00a3264526a98332
+        SHA384: 65b1d4076a89ae273f57e6eeedecb3eae129b4168f76fa7671914cdf461d542255c59d9b85b916ae0ca6fc0fcf7a8e64
+    - Subject: BUSINESS_CATEGORY=Private Organization, JURISDICTION_OF_INCORPORATION_C=SG,
+        serialNumber=201632879R, C=SG, L=Singapore, O=PROXIMA BETA PTE. LIMITED, OU=PROXIMA
+        BETA PTE. LIMITED, CN=PROXIMA BETA PTE. LIMITED
+      ValidFrom: '2022-01-04 00:00:00'
+      ValidTo: '2025-01-02 23:59:59'
+      Signature: 9335f603443aabbe7af95e7e3c70861d75afe4a34c99d37fa97462b13114a5047cf10d354ac9eb1e0a4f39726adb13e44af1eef29016f1df73005284d21982e7765da29213bd99afd302942bec553dbf06736c6f3417960e00d846f5024e6f7c43dcf7bcbb3380cab8fb2ac170fb8dd911848332266014db935624531f38681871e19503ef69c1037aa1922c67dcefe717a5e579780a02b436cac18364c576537834b7d55bf774710b68533e135abd62280a0158c34d3f41c580a7de3fcdd0f6c00ac872e17aef80dc0e85a720666cf0a5c477194ade0b61504d2e4438f113b7c46aa048f168493ad74aa66c8c28bdf397f1a50ea528dc2ad50f38bd756eb4dcd0499eecf68e319cd069328dd4066f191c51d6aa5f7b52dfb7e39b98d438150ded97d5117ee8a2fea855eee9728a3c92fe591e016e7a4592ee60d183e7473812eb2dcff0890c3c3c182c0ce5b16ffbd1d32b8f556fdd506db3ab8857dc112bea642d7f542ac96574095ff9ccf534d0776521052a9ee0c46999196dad6f6f7e45f03eb6b492cff411a14e002a5e448a10e334ed121c5c05b1bafd53b4172954d9361b3118d4e90e7e3da0e1f5804ebbab3c180ae159b6855a6a030853004dcb5ba3baf94210edef350ced81a7bae22b790ae586fac630ef29f6f042f8cbd8896e34ed34c698ee49ebcd41087603a92d48f37ba93400b9dbaa356e66e59c65fa0e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 0d601dc6f2239f4fddc08db90e9578ac
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: acc2229c44efedde09421b90254e2be1
+        SHA1: 3c9f77a7d8ea76df254fe5e7018320a35733854a
+        SHA256: cb22c3ec3764efbdbf91e75c0308fd9fcd9018373d41e9d92bd2e4ee5746cc07
+        SHA384: c958c5fd9fc4a08fb37986576c9fc66d89241edae9cb561179667c44fc365fa017bdb10b57203162f282a18973b1a4a6
+    Signer:
+    - SerialNumber: 0d601dc6f2239f4fddc08db90e9578ac
+      Issuer: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      Version: 1
+- Filename: GameDriverX64.sys
+  MD5: af036499a90e70e9ec4121ac4da9f5e2
+  SHA1: 30f08056ec1228cb78a4e1f267566919bae6b269
+  SHA256: f90cab0c3b8159162be3103fcca5bafc27fbf4ec24620900acedaf84b7c0cf30
+  Imphash: 3ce472198cabef134ebbd7e847218cf4
+  Authentihash:
+    MD5: 51aa38c14291766887183e839f03df91
+    SHA1: c61c3a8df58fb7834524c7ccf72cd18357418a4e
+    SHA256: a002fde686315a7410eaab863f51fb3fe85961e79221b0dbbb4f71d6fe68ce96
+  RichPEHeaderHash:
+    MD5: 51531fc4f099e3d0d2f4334e2bbaf6fa
+    SHA1: bce9e1939dd364371a74a7de762ccb212f8e1d4f
+    SHA256: d3d6d026af68d4386ea78afb00035b52def4a0b92066cc974162939b5d25ab56
+  Sections:
+    .text:
+      Entropy: 6.500141547165472
+      Virtual Size: '0x4bcd'
+    .rdata:
+      Entropy: 4.784674808876321
+      Virtual Size: '0xd84'
+    .data:
+      Entropy: 7.238699120320601
+      Virtual Size: '0x16ec'
+    .pdata:
+      Entropy: 7.7957145494175855
+      Virtual Size: '0x39c'
+    PAGE:
+      Entropy: 7.715112686822407
+      Virtual Size: '0x520'
+    INIT:
+      Entropy: 6.468920894577342
+      Virtual Size: '0xcfa'
+    .uo10:
+      Entropy: 5.824974378226114
+      Virtual Size: '0x1cdc'
+    .reloc:
+      Entropy: 3.2015748948312654
+      Virtual Size: '0x24'
+    .rsrc:
+      Entropy: 3.2303212256969345
+      Virtual Size: '0x2ac'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2023-11-15 03:07:55'
+  Description: GameDriverX64
+  Company: GameDriver
+  InternalName: ''
+  OriginalFilename: GameDriverX64.sys
+  FileVersion: 7.23.11.15
+  Product: GameDriverX64
+  ProductVersion: 7.23.11.15
+  Copyright: ''
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ObReferenceObjectByHandle
+  - ObfDereferenceObject
+  - ZwCreateFile
+  - ZwWriteFile
+  - ZwClose
+  - FsRtlGetFileSize
+  - ZwDeleteFile
+  - _vsnprintf
+  - IoFileObjectType
+  - MmIsAddressValid
+  - RtlImageNtHeader
+  - MmHighestUserAddress
+  - _stricmp
+  - DbgPrint
+  - IoGetCurrentProcess
+  - PsLookupProcessByProcessId
+  - IoThreadToProcess
+  - PsGetProcessImageFileName
+  - _vsnwprintf
+  - PsProcessType
+  - PsThreadType
+  - KeInitializeEvent
+  - ExAllocatePoolWithTag
+  - ExFreePoolWithTag
+  - ExAcquireFastMutex
+  - ExReleaseFastMutex
+  - _strnicmp
+  - RtlUnicodeStringToInteger
+  - RtlInitAnsiString
+  - RtlAnsiStringToUnicodeString
+  - RtlCompareUnicodeString
+  - ExSystemTimeToLocalTime
+  - RtlGetVersion
+  - KeDelayExecutionThread
+  - KeWaitForSingleObject
+  - ZwQueryInformationFile
+  - ZwReadFile
+  - ZwTerminateProcess
+  - ZwOpenProcess
+  - ExEnumHandleTable
+  - ExfUnblockPushLock
+  - PsAcquireProcessExitSynchronization
+  - PsReleaseProcessExitSynchronization
+  - PsGetProcessPeb
+  - PsGetProcessWow64Process
+  - RtlCopyUnicodeString
+  - IofCompleteRequest
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoAllocateWorkItem
+  - IoFreeWorkItem
+  - ZwUnloadDriver
+  - KdDebuggerEnabled
+  - KeBugCheckEx
+  - RtlTimeToTimeFields
+  - __C_specific_handler
+  - MmGetSystemRoutineAddress
+  - RtlFreeUnicodeString
+  - RtlInitUnicodeString
+  - WdfVersionBind
+  - WdfVersionUnbind
+  - WdfVersionUnbindClass
+  - WdfVersionBindClass
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      ValidFrom: '2021-04-29 00:00:00'
+      ValidTo: '2036-04-28 23:59:59'
+      Signature: 3a23443d8d0876ee8fbc3a99d356e0021aa5f84834f32cb6e67466f79472b100caaf6c302713129e90449f4bfd9ea37c26d537bc3a5d486d95d53f49f427bb16814550fd9cbdb685e0767e3771cb22f75aaa90cff5936ae3eb20d1d55079889a8a8ac1b6bda148187edcd8801a111918cd61998156f6c9e376e7c4e41b5f43f83e94ff76393d9ed499cf4add28eb5f26a1955848d51afed7273ffd90d17686dd1cb0605cf30da8eee089a1bd39e1384eda6ebb369dfbe521535ac3cae96af1a23edb43b833c84f38149299f5ddce546dd95d02141f40337c03e295b2c221757352cb46d8c4341ca2a54b8dcd6f76372c853f1ace26e918be9007b0437f9588208270f0cccaeffd29355c1f893855f7378a8b09a1cb0be9311aff2e195c3971e1be9ca70a06d62667b792e64e5fde7aac49cf2ea47492addb3ca49c861fe3c1561b2b23ff8fb5ea887b706be6a0bafd3a3f45a6c4e81691528b41c048844b964dab4440e38df01528ceedf11856072a2f10c40c08643c338fae288c3ccb8f880b0dbf3bf4ce1e7b8eefb5ebcbb7f07713e6e7283fac12aea52f226c41f9825c1566cc6c0ecac586c3f626330c074ba0d307026a6a4030484b34a85120bbad1b8508e2590d6dca05502bea4a1c9ea5fda0a71f0674e7f2d65290fdaf854821f9573bb49c03ed8645f4b4616ebf68e2266086eac8afa9fe941de7631b3a8656784e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 08ad40b260d29c4c9f5ecda9bd93aed9
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 5d8003a64dfa5a4d88365da1566038cb
+        SHA1: 79465b56bc7ad55a37bdf633943da8bfc84db228
+        SHA256: 84bdc82e2f2a7f7aaa782667dac556ffcb2b33240c1f9c0a00a3264526a98332
+        SHA384: 65b1d4076a89ae273f57e6eeedecb3eae129b4168f76fa7671914cdf461d542255c59d9b85b916ae0ca6fc0fcf7a8e64
+    - Subject: JURISDICTION_OF_INCORPORATION_C=HK, BUSINESS_CATEGORY=Private Organization,
+        serialNumber=2147741, C=HK, L=Kwun Tong, O=Fedeen Games Limited, CN=Fedeen
+        Games Limited
+      ValidFrom: '2022-07-21 00:00:00'
+      ValidTo: '2025-07-17 23:59:59'
+      Signature: 2e436cef00e94eb70af4b4362eb2df91a4ee941866c1fedb1d6911764b0501afa628307677cc68c6671c0601515fa158d542a961a17ff7465573f6f2946d71d8101bc9384234c83dd983d43354d4262ef68b5e03f69417afca20e36554b798fbfcadcbbe76b9789bcbd9766eb229ceca810e7468f17c1cad7c74f9f6c351d0a495c39d6308e4c34b96e418cd8b56fc1a2291c8f67cb6c8f320b263657876c401a10e1d0ac0bb203823f8d0d02d4138db236d616c102f7c43950c53ff9cfcc2a0a9594e37115ae44bd084f1ef851da1db6bb105e34023b90dd68f7eacbabf7fcf635516c2ea7a9f3f5eae6e51439f8f202c9bc16129118e7cf65c8e6d44b055cf41ed5322948a689caa506f7caf14fec8025ace35d8ebbf5f54edc9fa8aa20b9d418cf8d3ca17427f3a4b34c92a8b6e95e67c507a199fc763bd30d10ca326cec58386f06c42926c7cc2612647d0faecabce91525517c6e10085b4d1a85bb0a8dc033d1a7dd84694b15ad5c0d5a030301e237a991918ec191640eb3c3e48bca0bbec77faf235aeca08407e4f56ab45e67c26eadb7e36a57958076ba405e0407c3016c51de5ba43e5570a92788c9cc850bbf5d66d55746adb6e6c8a44cf616080b7d341abd218c25b6a530b58617c1d5e779f61e2d3a999eebc31dfdf13d6e4a81329725deddb247ad364838189229e60e6548f08a3045e30eef675486b188785dd
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 020641782828aeae70a776bee350cba2
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 053b0a8ba5681faaf22b671cbcf74b5c
+        SHA1: 025b14b061d02d8123d3a15470ed64a2054358f2
+        SHA256: 3c1f16d0ebdd0b0eb134e3acc54046e1b89098810096ca9b52c39d689d60e597
+        SHA384: 4876e1cc9c414afe90a7c75275035a2ec8f4c6fed123b51817f7946fcf128df22b189768c9af762945b60bb99a719528
+    Signer:
+    - SerialNumber: 020641782828aeae70a776bee350cba2
+      Issuer: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      Version: 1
+- Filename: GameDriverX64.sys
+  MD5: e1787057703c662e07f022f1bd67d008
+  SHA1: de6da17f92c669f1466f2a5947a054aa4c6ec04c
+  SHA256: fd08ac95226585436c03b01745c608035bfb15a3a832135589a049cb243cefd9
+  Imphash: b615e95f5fb9f4b26a7d238fcdd00e79
+  Authentihash:
+    MD5: f032db974bc4fa06e5fd4117e8e381b8
+    SHA1: ae691f567a67998e921f13d697c79f89eb6584b7
+    SHA256: 6fa8262990fbc2a1370a94c5c6e700183a5619a0d8de4b6e783215907c4b2d68
+  RichPEHeaderHash:
+    MD5: f2d76afd2f231551558bcf27fcfe5301
+    SHA1: 51ad2459282c637fb625bb08d2c767d2214fa543
+    SHA256: 7188536c55a55cfb4b1d4887584f0b5b87e1cca1cfe244bc5ec133a9dcc0c54a
+  Sections:
+    .text:
+      Entropy: 6.544231951157247
+      Virtual Size: '0x454d'
+    .rdata:
+      Entropy: 4.723942224689453
+      Virtual Size: '0xd74'
+    .data:
+      Entropy: 7.239255600120258
+      Virtual Size: '0x168c'
+    .pdata:
+      Entropy: 7.761658515597363
+      Virtual Size: '0x390'
+    PAGE:
+      Entropy: 7.676453251014581
+      Virtual Size: '0x510'
+    INIT:
+      Entropy: 6.076721294518338
+      Virtual Size: '0xd74'
+    .uo10:
+      Entropy: 5.870907820528687
+      Virtual Size: '0x1b30'
+    .reloc:
+      Entropy: 3.368241561497932
+      Virtual Size: '0x24'
+    .rsrc:
+      Entropy: 3.201288637173654
+      Virtual Size: '0x2ac'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2023-04-10 07:40:34'
+  Description: GameDriverX64
+  Company: GameDriver
+  InternalName: ''
+  OriginalFilename: GameDriverX64.sys
+  FileVersion: 7.23.04.07
+  Product: GameDriverX64
+  ProductVersion: 7.23.04.07
+  Copyright: ''
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ObReferenceObjectByHandle
+  - ObfDereferenceObject
+  - ZwCreateFile
+  - ZwWriteFile
+  - ZwClose
+  - FsRtlGetFileSize
+  - ZwDeleteFile
+  - _vsnprintf
+  - IoFileObjectType
+  - MmIsAddressValid
+  - RtlImageNtHeader
+  - __chkstk
+  - MmHighestUserAddress
+  - _stricmp
+  - DbgPrint
+  - IoGetCurrentProcess
+  - PsLookupProcessByProcessId
+  - IoThreadToProcess
+  - PsGetProcessImageFileName
+  - _vsnwprintf
+  - PsProcessType
+  - PsThreadType
+  - KeInitializeEvent
+  - ExAllocatePoolWithTag
+  - ExFreePoolWithTag
+  - ExAcquireFastMutex
+  - ExReleaseFastMutex
+  - _strnicmp
+  - RtlUnicodeStringToInteger
+  - RtlInitAnsiString
+  - RtlAnsiStringToUnicodeString
+  - RtlCompareUnicodeString
+  - RtlFreeUnicodeString
+  - RtlGetVersion
+  - KeDelayExecutionThread
+  - KeWaitForSingleObject
+  - ExSystemTimeToLocalTime
+  - ZwQueryInformationFile
+  - ZwReadFile
+  - ZwTerminateProcess
+  - ZwOpenProcess
+  - ExEnumHandleTable
+  - ExfUnblockPushLock
+  - PsAcquireProcessExitSynchronization
+  - PsReleaseProcessExitSynchronization
+  - PsGetProcessPeb
+  - PsGetProcessWow64Process
+  - RtlCopyUnicodeString
+  - KdDisableDebugger
+  - KdChangeOption
+  - PsCreateSystemThread
+  - PsTerminateSystemThread
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoAllocateWorkItem
+  - IoFreeWorkItem
+  - IoQueueWorkItem
+  - ZwUnloadDriver
+  - PsSetCreateProcessNotifyRoutine
+  - PsGetProcessDebugPort
+  - KdDebuggerEnabled
+  - KeBugCheckEx
+  - RtlTimeToTimeFields
+  - __C_specific_handler
+  - MmGetSystemRoutineAddress
+  - RtlInitUnicodeString
+  - WdfVersionBind
+  - WdfVersionUnbind
+  - WdfVersionUnbindClass
+  - WdfVersionBindClass
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      ValidFrom: '2021-04-29 00:00:00'
+      ValidTo: '2036-04-28 23:59:59'
+      Signature: 3a23443d8d0876ee8fbc3a99d356e0021aa5f84834f32cb6e67466f79472b100caaf6c302713129e90449f4bfd9ea37c26d537bc3a5d486d95d53f49f427bb16814550fd9cbdb685e0767e3771cb22f75aaa90cff5936ae3eb20d1d55079889a8a8ac1b6bda148187edcd8801a111918cd61998156f6c9e376e7c4e41b5f43f83e94ff76393d9ed499cf4add28eb5f26a1955848d51afed7273ffd90d17686dd1cb0605cf30da8eee089a1bd39e1384eda6ebb369dfbe521535ac3cae96af1a23edb43b833c84f38149299f5ddce546dd95d02141f40337c03e295b2c221757352cb46d8c4341ca2a54b8dcd6f76372c853f1ace26e918be9007b0437f9588208270f0cccaeffd29355c1f893855f7378a8b09a1cb0be9311aff2e195c3971e1be9ca70a06d62667b792e64e5fde7aac49cf2ea47492addb3ca49c861fe3c1561b2b23ff8fb5ea887b706be6a0bafd3a3f45a6c4e81691528b41c048844b964dab4440e38df01528ceedf11856072a2f10c40c08643c338fae288c3ccb8f880b0dbf3bf4ce1e7b8eefb5ebcbb7f07713e6e7283fac12aea52f226c41f9825c1566cc6c0ecac586c3f626330c074ba0d307026a6a4030484b34a85120bbad1b8508e2590d6dca05502bea4a1c9ea5fda0a71f0674e7f2d65290fdaf854821f9573bb49c03ed8645f4b4616ebf68e2266086eac8afa9fe941de7631b3a8656784e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 08ad40b260d29c4c9f5ecda9bd93aed9
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 5d8003a64dfa5a4d88365da1566038cb
+        SHA1: 79465b56bc7ad55a37bdf633943da8bfc84db228
+        SHA256: 84bdc82e2f2a7f7aaa782667dac556ffcb2b33240c1f9c0a00a3264526a98332
+        SHA384: 65b1d4076a89ae273f57e6eeedecb3eae129b4168f76fa7671914cdf461d542255c59d9b85b916ae0ca6fc0fcf7a8e64
+    - Subject: JURISDICTION_OF_INCORPORATION_C=TW, BUSINESS_CATEGORY=Private Organization,
+        serialNumber=54321633, C=TW, ST=Taipei City, L=Zhongzheng District, O=Iwplay
+        World Interactive Entertainment Technology Co,Ltd., CN=Iwplay World Interactive
+        Entertainment Technology Co,Ltd.
+      ValidFrom: '2022-07-21 00:00:00'
+      ValidTo: '2025-07-19 23:59:59'
+      Signature: 1a1b320d85dc54ec3b2d27f571aa208dba4e4267ac7d6fa7ff120679c7f074aeb4508e692232597821a3672e3421d1e62cc7f666e50acff3fac7e9fc6e42d7c0011d92ab2098a428fc5ac5080b6d8b586e350bed7089574891cba85790b4b41e6c9a6a6b769e8cc7c8701d0351046337858630bb94043b11f45c5cfac74aefcf3a9e04666e2dbe0d62939ff9a9dfff1b41d021b815522c6dbd77b8b34da2da1cb3fb3a2eda85026feadddd4907e0ea3d5860775f9a9ef7f03b32d877afb891ec2f05a8e40f434b6fb13c868e214189e56a8f565f4a73571e3fd262c01945f19f0b012acb652491f6e7b5752da8b06b9f18a4ba40f4e85567c3b97afb97da9f936ab3a19394d56a56d38368c3a5cdef026747127495a880af369e2f35d58a6047d59f52b6af3f17d85c6b6a2c46ebee4f6e1c8d31ba587cf0b072b204e4bbf8e71bb8f04a892de0f145dcc032e1e8684de43579e7d8c5f1d7982b8d9977e93615e4199837ddea7e0042b46a2b946c65fc31ab9ca20818df7134ca4b2bb5fbd1bebd4834d46a2dec6de53cbc198405c3145da212dc85857692074be20cdad6208bc3da50b93d335e1fc6fc8258185ce35907bdf968c8760dd9f14d01aa8c552efe47e5fbd3480fa22caba7108db53a0da07d70b59933c5e828282b924f7d958637ed3281a6f2dbebbb02493fac5cb7db04e289e39809246da43d6d685bff80346d
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 0a193689f65c78313696d5bc0044e495
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 37930d3ad4ff8c0e2faeba2aeeaf8544
+        SHA1: 3577adfd0eb6ca452eb044438d3c459f45dbe251
+        SHA256: befbd074b56787644f0b2d32690b3fe8e58c3480134714b2d35924eb5fffeac4
+        SHA384: bfc4bcffb786232ddcd206476b70da8ac22a7845ba4e424f2c35ee8928f53aae6ac734b505c358f0e7a946294304fb32
+    Signer:
+    - SerialNumber: 0a193689f65c78313696d5bc0044e495
+      Issuer: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      Version: 1
+- Filename: KSophon_x64.sys
+  MD5: ff3351f67270b2021937cb8a54af3d25
+  SHA1: 6bdfd00b7bdb8e24f413bd369058b49a84a98f20
+  SHA256: 2005e9afa51b7918dd1d0143d181641529c488e945fc6bfe1db48805aabdedb3
+  Imphash: 2a4da7c8a269c324f92513f358167269
+  Authentihash:
+    MD5: 506591db57a8fff3c784d847fa3c1158
+    SHA1: 8f283e17f09891e9b646cdbc96e1b9d3696a82e3
+    SHA256: 92d63f2677a536c84c032f04239baf32cde372e9717134138cab290957cf1140
+  RichPEHeaderHash:
+    MD5: ''
+    SHA1: ''
+    SHA256: ''
+  Sections:
+    .text:
+      Entropy: 7.057900125762448
+      Virtual Size: '0x2b5a7e'
+    .rdata:
+      Entropy: 4.270848586638033
+      Virtual Size: '0xa5c58'
+    .data:
+      Entropy: 2.8700320338414973
+      Virtual Size: '0x4c561c'
+    .pdata:
+      Entropy: 7.986395586934103
+      Virtual Size: '0x6888'
+    INIT:
+      Entropy: 0.1981528479710299
+      Virtual Size: '0x1a46'
+    .tvm00:
+      Entropy: 7.312194387158508
+      Virtual Size: '0x36327c'
+    .gp0:
+      Entropy: 7.919218860326175
+      Virtual Size: '0x1d9e9'
+    .gp1:
+      Entropy: 6.213461239054608
+      Virtual Size: '0x415c'
+    .gp2:
+      Entropy: 7.18938190697603
+      Virtual Size: '0x155174'
+    .gp3:
+      Entropy: 6.429351218014857
+      Virtual Size: '0xa1a0'
+    .rsrc:
+      Entropy: 3.4356221528535937
+      Virtual Size: '0x414'
+    .reloc:
+      Entropy: 5.413630036183494
+      Virtual Size: '0x5b4c'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2022-07-09 06:08:18'
+  Description: KSophon_x64 NT Driver
+  Company: PROXIMA BETE
+  InternalName: KSophon_x64
+  OriginalFilename: KSophon_x64.sys
+  FileVersion: 0, 0, 0, 168
+  Product: KSophon_x64
+  ProductVersion: 0, 0, 0, 168
+  Copyright: Copyright (c) 2021 PROXIMA BETA. All Rights Reserved
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - hal.dll
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - MmIsAddressValid
+  - KeStallExecutionProcessor
+  - ExFreePool
+  - ExAllocatePoolWithTag
+  - ZwQuerySystemInformation
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Trusted Root
+        G4
+      ValidFrom: '2013-08-01 12:00:00'
+      ValidTo: '2038-01-15 12:00:00'
+      Signature: bb61d97da96cbe17c4911bc3a1a2008de364680f56cf77ae70f9fd9a4a99b9c9785c0c0c5fe4e61429560b36495d4463e0ad9c9618661b230d3d79e96d6bd654f8d23cc14340ae1d50f552fc903bbb9899696bc7c1a7a868a427dc9df927ae3085b9f6674d3a3e8f5939225344ebc85d03caed507a7d62210a80c87366d1a005605fe8a5b4a7afa8f76d359c7c5a8ad6a23899f3788bf44dd2200bde04ee8c9b4781720dc01432ef30592eaee071f256e46a976f92506d968d687a9ab236147a06f224b9091150d708b1b8897a8423614229e5a3cda22041d7d19c64d9ea26a18b14d74c19b25041713d3f4d7023860c4adc81d2cc3294840d0809971c4fc0ee6b207430d2e03934108521150108e85532de7149d92817504de6be4dd175acd0cafb41b843a5aad3c305444f2c369be2fae245b823536c066f67557f46b54c3f6e285a7926d2a4a86297d21ee2ed4a8bbc1bfd474a0ddf67667eb25b41d03be4f43bf40463e9efc2540051a08a2ac9ce78ccd5ea870418b3ceaf4988aff39299b6b3e6610fd28500e7501ae41b959d19a1b99cb19bb1001eefd00f4f426cc90abcee43fa3a71a5c84d26a535fd895dbc85621d32d2a02b54ed9a57c1dbfa10cf19b78b4a1b8f01b6279553e8b6896d5bbc68d423e88b51a256f9f0a680a0d61eb3bc0f0f537529aaea1377e4de8c8121ad07104711ad873d07d175bccff3667e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 059b1b579e8e2132e23907bda777755c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 41b622dd54995550fdc2f31ea12f8d9b
+        SHA1: 420704040c93dfe9d3ad01a26c07f2be1f4888c1
+        SHA256: 4816e2e9e37ba61e1def6f7a4c623e981c7af355e51349b5554a3d56c5252e24
+        SHA384: 4ea1b34b10b982a96a38915843507820ad632c6aad8343e337b34d660cd8366fa154544ae80668ae1fdf3931d57e1996
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      ValidFrom: '2021-04-29 00:00:00'
+      ValidTo: '2036-04-28 23:59:59'
+      Signature: 3a23443d8d0876ee8fbc3a99d356e0021aa5f84834f32cb6e67466f79472b100caaf6c302713129e90449f4bfd9ea37c26d537bc3a5d486d95d53f49f427bb16814550fd9cbdb685e0767e3771cb22f75aaa90cff5936ae3eb20d1d55079889a8a8ac1b6bda148187edcd8801a111918cd61998156f6c9e376e7c4e41b5f43f83e94ff76393d9ed499cf4add28eb5f26a1955848d51afed7273ffd90d17686dd1cb0605cf30da8eee089a1bd39e1384eda6ebb369dfbe521535ac3cae96af1a23edb43b833c84f38149299f5ddce546dd95d02141f40337c03e295b2c221757352cb46d8c4341ca2a54b8dcd6f76372c853f1ace26e918be9007b0437f9588208270f0cccaeffd29355c1f893855f7378a8b09a1cb0be9311aff2e195c3971e1be9ca70a06d62667b792e64e5fde7aac49cf2ea47492addb3ca49c861fe3c1561b2b23ff8fb5ea887b706be6a0bafd3a3f45a6c4e81691528b41c048844b964dab4440e38df01528ceedf11856072a2f10c40c08643c338fae288c3ccb8f880b0dbf3bf4ce1e7b8eefb5ebcbb7f07713e6e7283fac12aea52f226c41f9825c1566cc6c0ecac586c3f626330c074ba0d307026a6a4030484b34a85120bbad1b8508e2590d6dca05502bea4a1c9ea5fda0a71f0674e7f2d65290fdaf854821f9573bb49c03ed8645f4b4616ebf68e2266086eac8afa9fe941de7631b3a8656784e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 08ad40b260d29c4c9f5ecda9bd93aed9
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 5d8003a64dfa5a4d88365da1566038cb
+        SHA1: 79465b56bc7ad55a37bdf633943da8bfc84db228
+        SHA256: 84bdc82e2f2a7f7aaa782667dac556ffcb2b33240c1f9c0a00a3264526a98332
+        SHA384: 65b1d4076a89ae273f57e6eeedecb3eae129b4168f76fa7671914cdf461d542255c59d9b85b916ae0ca6fc0fcf7a8e64
+    - Subject: BUSINESS_CATEGORY=Private Organization, JURISDICTION_OF_INCORPORATION_C=SG,
+        serialNumber=201632879R, C=SG, L=Singapore, O=PROXIMA BETA PTE. LIMITED, OU=PROXIMA
+        BETA PTE. LIMITED, CN=PROXIMA BETA PTE. LIMITED
+      ValidFrom: '2022-01-04 00:00:00'
+      ValidTo: '2025-01-02 23:59:59'
+      Signature: 0e3d612c9400c38de027dec45374a1c0d50a4a597cc0d00882d01a33bdcb5c5df1e8dd3b7d362e8d639c44d15edadbe0c31e5c78c28e260e5802e1714044e7a2aaae6550d55930c7eddd0bc1ef6cbcb4bb85334a449e253695dcc1a2debd92f29e3822b6e66da55c434c092ee94a7b73be9a7a94c572176cc1806b491dedeeee8ceb3f5720476b2bb00b63596339b04bba024a7d20f7ed7822b971c554e4a9447b3a14093d1cc0ad1a40c65e409ee3ce3a0837b37b7d3233e50f579d7cd8477e5c8e4f18204ad6282d16d62c4a2a8c3d725ac83cf01c645dceecf79ed5c67881be47feeb7c3d75f1119d535ab4642724a1c9377f791505d9ecaeb70d3380f8543e86215fb8d03559938d4631ba86adab4e94462be29d1325d7d99b747949b86ddd1a8a2532e010f79ad5fabac2ce4316354cb3e47fa00527f790fb449b3b662226e49e414276975925f8cd86d05530b312b8182e7ea096cdac8683030af92d832f119522a07c7e17633902ccfa199239d374b0e4007e8ed2e110342caf1d553cc80afbe636af59fb05909a9dc6ec8fb9e70b25e32d4b0d50466f98f303cf2bda5ea0d1e72eda66a2df43379d66b75d008b98930b85d907d6d3d4138ef880c87624b1163d3eba2a98c54e310ad978876b5c883a202214e6a1c6ecab09a10f8666ef7ec2ea639249efa0ddbdd0cd7ba8759c85bfd348cfcc7e42911869eb5c8b8d
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 08b400989a7b9f0d6e71be7494b332e1
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: a5f12109b2b6a157cb3b3143f21eafaa
+        SHA1: a5bc2c1e6c767d2f1ca2e6f3cdb86fc2cad95b57
+        SHA256: 0646f612cd8a3d2d0c317756ff2a4a7a149b53ec888139404e00f43a58431555
+        SHA384: 7b9ffea98d773bb0f7bd1e30b39f1d2b22f4e2433fef625620891d93ac8f4658fafd74e437d90cfaf16f2e7feea462ed
+    Signer:
+    - SerialNumber: 08b400989a7b9f0d6e71be7494b332e1
       Issuer: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
         SHA384 2021 CA1
       Version: 1


### PR DESCRIPTION
## Summary

Expands the existing Tower of Fantasy anti-cheat driver entry with eight newly tracked binaries:

- Six additional `GameDriverX64.sys` builds covering versions `7.23.04.07` and `7.23.11.15`
- Two `KSophon_x64.sys` predecessor builds, versions `0.0.0.168` and `0.0.0.174`

The existing two `GameDriverX64.sys` samples were retained and enriched, bringing the family entry to ten unique samples.

## Research

`GameDriverX64.sys` is affected by CVE-2025-61155. Public reverse engineering documents weak device and IOCTL authentication based on spoofable module/process names, PE checksums, and the hardcoded value `0xFA123456`. The exposed operations include arbitrary process termination, process protection, and removal of existing process-handle rights.

`KSophon_x64.sys` is the VMProtect-packed predecessor shipped with Tower of Fantasy. The Tower of Flaws research identifies it as the prior version of the same driver family and reports that the weak authentication and IOCTL capabilities remain present despite packing.

These are legitimate vendor-signed anti-cheat drivers, not malicious drivers. `GameDriverX64.sys` has nevertheless been observed in ransomware defense-evasion activity.

The exact SHA-256 requested in #362 (`087f002df0a02c8c74f3ba5cd99cf29fb9efff38bf57b3d808e34a5dd4200dd2`) was not recovered and is not represented as one of these samples.

## Validation

- Ran `bin/metadata-extractor.py` against all ten samples
- Confirmed each MD5/SHA-1/SHA-256 against its binary
- Confirmed all eight new binaries are staged through Git LFS
- `python3 bin/validate.py` passes
- `git diff --check` passes

Refs #362
