### PR TITLE
add shdrv_x64.sys

### DIFF
--- a/drivers/4521531a5003be1897a7964481cace4a.bin
+++ b/drivers/4521531a5003be1897a7964481cace4a.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3b99f727e59aab08862a161df7e3d7790842a76c42184fb4ba267db14eae4fa
+size 41648

--- a/yaml/855bbfa2-9b25-4673-a25d-c6b39d35f833.yaml
+++ b/yaml/855bbfa2-9b25-4673-a25d-c6b39d35f833.yaml
@@ -1,0 +1,191 @@
+Id: 855bbfa2-9b25-4673-a25d-c6b39d35f833
+Tags:
+- shdrv_x64.sys
+Author: Element2023H
+Created: '2026-07-12'
+MitreID: T1068
+Category: vulnerable driver
+Verified: 'TRUE'
+Commands:
+  Command: sc.exe create shdrv binPath=C:\windows\temp\shdrv_x64.sys type=kernel &&
+    sc.exe start shdrv
+  Description: The driver creates a device object at \\.\shdrv with no DACL restrictions,
+    so any local user can open a handle. The IRP_MJ_DEVICE_CONTROL dispatcher accepts
+    IOCTL 0x22E018u  chains ZwOpenProcess -> ZwTerminateProcess against the supplied
+    PID, with no caller validation. Because the kernel-mode caller bypasses user-mode
+    access checks, the primitive can terminate any process on the system including
+    PPL-protected AV/EDR processes.
+  Usecase: Terminate arbitrary processes from kernel mode, including protected security
+    processes, through an unauthenticated IOCTL handler.
+  Privileges: kernel
+  OperatingSystem: Windows 10, Windows 11
+Resources: -https://github.com/The-Sword-of-Constantine/UsingBYOVD
+KnownVulnerableSamples:
+- Filename: shdrv_x64.sys
+  MD5: 4521531a5003be1897a7964481cace4a
+  SHA1: a5da59ea783055f1c2ae19116b4254ac12da72f4
+  SHA256: e3b99f727e59aab08862a161df7e3d7790842a76c42184fb4ba267db14eae4fa
+  Signature:
+  - Microsoft Windows Hardware Compatibility Publisher
+  CreationTimestamp: '2024-11-18 15:17:30'
+  Company: ''
+  Description: ''
+  Product: ''
+  ProductVersion: ''
+  FileVersion: ''
+  MachineType: AMD64
+  Authentihash:
+    MD5: af4903c2ebd1cc770b41977bbe31a5ba
+    SHA1: 35e6a5c9f38837c6c0792a020cab3b50b276bbc2
+    SHA256: 4d524d302632b6581f952efd49faa4b711a15484a50c00b1085ab6affd3ca174
+  Imports:
+  - ntoskrnl.exe
+  - ksecdd.sys
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ZwClose
+  - ObReferenceObjectByHandle
+  - KeWaitForSingleObject
+  - ObfDereferenceObject
+  - ZwWriteFile
+  - DbgPrint
+  - InitializeSListHead
+  - ExpInterlockedPushEntrySList
+  - KeInitializeDpc
+  - KeReleaseSpinLock
+  - ExpInterlockedPopEntrySList
+  - ZwWaitForSingleObject
+  - KeFlushQueuedDpcs
+  - PsCreateSystemThread
+  - ExSystemTimeToLocalTime
+  - _vsnprintf
+  - KeInsertQueueDpc
+  - RtlTimeToTimeFields
+  - PsThreadType
+  - PsGetCurrentThreadId
+  - KeAcquireSpinLockRaiseToDpc
+  - PsProcessType
+  - PsLookupProcessByProcessId
+  - _wcsnicmp
+  - PsGetProcessInheritedFromUniqueProcessId
+  - ZwOpenProcess
+  - ZwQueryInformationProcess
+  - RtlCopyUnicodeString
+  - MmIsAddressValid
+  - ZwTerminateProcess
+  - ObOpenObjectByPointer
+  - PsGetProcessId
+  - RtlAppendUnicodeToString
+  - ZwQuerySymbolicLinkObject
+  - ZwOpenSymbolicLinkObject
+  - KeDelayExecutionThread
+  - ZwQuerySystemInformation
+  - _stricmp
+  - KeClearEvent
+  - IoDeleteSymbolicLink
+  - KeResetEvent
+  - IoCreateNotificationEvent
+  - KeSetPriorityThread
+  - IoDeleteDevice
+  - KeSetTimerEx
+  - PsTerminateSystemThread
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - PsGetCurrentProcessId
+  - IoCreateDevice
+  - KeInitializeTimerEx
+  - KeCancelTimer
+  - ExAllocatePool
+  - ZwCreateFile
+  - KeInitializeEvent
+  - KeSetEvent
+  - RtlInitUnicodeString
+  - ExFreePoolWithTag
+  - ExAllocatePoolWithTag
+  - __C_specific_handler
+  - BCryptDestroyKey
+  - BCryptImportKeyPair
+  - BCryptCloseAlgorithmProvider
+  - BCryptCreateHash
+  - BCryptFinishHash
+  - BCryptHashData
+  - BCryptDestroyHash
+  - BCryptOpenAlgorithmProvider
+  - BCryptVerifySignature
+  - BCryptGetProperty
+  PDBPath: D:\slave\workspace\rentdrv-64\bin\pdb\rentdrv_x64.pdb
+  Imphash: 7c5d39c5ab50d813d0d66ec221d23837
+  RichPEHeaderHash:
+    MD5: 7e413274770bd37a9c5d9301794d3d72
+    SHA1: 88446ea7687e733fea0f9c8c614da1b8d7b75d81
+    SHA256: 592ec7096680f386830cbcb11737c007da35c9352de2c6989018aa0752b677b2
+  Sections:
+    .text:
+      Entropy: 6.298261906827406
+      Virtual Size: '0x4b1a'
+    .rdata:
+      Entropy: 5.034353134868883
+      Virtual Size: '0x1414'
+    .data:
+      Entropy: 1.5058910068814653
+      Virtual Size: '0x20e8'
+    .pdata:
+      Entropy: 4.329123657993235
+      Virtual Size: '0x4b0'
+    INIT:
+      Entropy: 4.952036251169612
+      Virtual Size: '0x89a'
+    .reloc:
+      Entropy: 1.584962500721156
+      Virtual Size: '0xc'
+  MagicHeader: 50 45 0 0
+  InternalName: ''
+  OriginalFilename: ''
+  Copyright: ''
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2024-10-10 19:04:53'
+      ValidTo: '2025-10-08 19:04:53'
+      Signature: 3870e583035a72db64856d80e17833cd3badd24f19abf9a3d7c7485743dd875f69102820df4992d74f8fba0529be4e16f4234910064a3a1863299a29b82d3fac869915a368ec0e5d0127282221bce84db444d2e9974dc2761a2080a7bc7508d7064f32b2d97b0263d0d937527a8af95f18bcb54ec21a453ba35e55869791416a2a8813fcf95e889e65158dbb5b4cba653c989179947d286051ef6b0d56f41da479db08c6b93c44fa5c8399e126594cc53dfa756180607a1dd29559061d828b0ce2c5a462245ed0995a196ad96223b6eb1a787b4d10b5a7d4e3a130750103bc9c713fc8f32015273bb238b15aae25e4765d7ab81c5d3df82ef6a7d3c2e7a61dab024ff02df6876a86ec7198aa6e28c8e69a015129a717b1036113911f0aeefa8d05081974d026196f24bc1e4ef942599fafbd1b2c316bda73237f1822296888df2344c92b08c363976beb7020242b3069e6691f19e715e1d1a19ddc03235263c9bb7b8390145af57603105ced358f394547e3be96718835917234eb7fd7134d9fb605656717ed6b15f0583068c84c6c01abf31cc1df1fe7c4d2935590e6017cf8cc5635e1cd7054240fd0059f168e90ec1a49f24e0f050034d99e4aa6599a64d280d00ea8af57d3125caddb342a0b2c160a2f95d97e6045e69dc1c1b3fa56dfd40380ce60536a59750edf0069dc7c27f8ccc8f073b46d169b8fed1fd40ac6f00c
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 330000006e1229856f0ade6cfc00000000006e
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 3066a9830894e57ce6e47f7a6b58b84f
+        SHA1: ce441ecd2f11e400515a85d5a592da38f950f3dc
+        SHA256: 3e30a731a3b620db0971ecd743ecd312bcdf14c82b9bdc9918102bacbf70520d
+        SHA384: 68c6537d64e3a4f02a2c1d04257c13ab1def23c9c54bafc434176be50a411a75c118c9f8edc81f97b8a1db2dc1d009e3
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      ValidFrom: '2014-10-15 20:31:27'
+      ValidTo: '2029-10-15 20:41:27'
+      Signature: 96b5c33b31f27b6ba11f59dd742c3764b1bca093f9f33347e9f95df21d89f4579ee33f10a3595018053b142941b6a70e5b81a2ccbd8442c1c4bed184c2c4bd0c8c47bcbd8886fb5a0896ae2c2fdfbf9366a32b20ca848a6945273f732332936a23e9fffdd918edceffbd6b41738d579cf8b46d499805e6a335a9f07e6e86c06ba8086725afc0998cdba7064d4093188ba959e69914b912178144ac57c3ae8eae947bcb3b8edd7ab4715bba2bc3c7d085234b371277a54a2f7f1ab763b94459ed9230cce47c099212111f52f51e0291a4d7d7e58f8047ff189b7fd19c0671dcf376197790d52a0fbc6c12c4c50c2066f50e2f5093d8cafb7fe556ed09d8a753b1c72a6978dcf05fe74b20b6af63b5e1b15c804e9c7aa91d4df72846782106954d32dd6042e4b61ac4f24636de357302c1b5e55fb92b59457a9243d7c4e963dd368f76c728caa8441be8321a66cde5485c4a0a602b469206609698dcd933d721777f886dac4772daa2466eab64682bd24e98fb35cc7fec3f136d11e5db77edc1c37e1f6a4a14f8b4a721c671866770cdd819a35d1fa09b9a7cc55d4d728e74077fa74d00fcdd682412772a557527cda92c1d8e7c19ee692c9f7425338208db38cc7cc74f6c3a6bc237117872fe55596460333e2edfc42de72cd7fb0a82256fb8d70c84a5e1c4746e2a95329ea0fecdb4188fd33bad32b2b19ab86d0543fbff0d0f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 330000000d690d5d7893d076df00000000000d
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 83f69422963f11c3c340b81712eef319
+        SHA1: 0c5e5f24590b53bc291e28583acb78e5adc95601
+        SHA256: d8be9e4d9074088ef818bc6f6fb64955e90378b2754155126feebbbd969cf0ae
+        SHA384: 260ad59ba706420f68ba212931153bd89f760c464b21be55fba9d014fff322407859d4ebfb78ea9a3330f60dc9821a63
+    Signer:
+    - SerialNumber: 330000006e1229856f0ade6cfc00000000006e
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      Version: 1
+Detection: []
+Acknowledgement:
+  Person: ''
+  Handle: Element2023H

--- a/yaml/855bbfa2-9b25-4673-a25d-c6b39d35f833.yaml
+++ b/yaml/855bbfa2-9b25-4673-a25d-c6b39d35f833.yaml
@@ -19,7 +19,8 @@ Commands:
     processes, through an unauthenticated IOCTL handler.
   Privileges: kernel
   OperatingSystem: Windows 10, Windows 11
-Resources: -https://github.com/The-Sword-of-Constantine/UsingBYOVD
+Resources: 
+- https://github.com/The-Sword-of-Constantine/UsingBYOVD
 KnownVulnerableSamples:
 - Filename: shdrv_x64.sys
   MD5: 4521531a5003be1897a7964481cace4a


### PR DESCRIPTION
This PR adds a newly identified vulnerable driver sample (`shdrv_x64.sys`) along with its enriched metadata YAML file.

* **Driver Name**: shdrv_x64.sys
* **Vulnerability Context**: The driver creates a device object at `\\.\shdrv` with no DACL restrictions, allowing any local user to open a handle. The `IRP_MJ_DEVICE_CONTROL` dispatcher accepts IOCTL `0x22E018`, chaining `ZwOpenProcess` into `ZwTerminateProcess` against the supplied PID without caller validation, enabling arbitrary process termination (BYOVD).