### PR TITLE
Add OPSWAT and WinRing0 vulnerable driver samples

### DIFF
--- a/yaml/5329911b-bd24-4206-94b2-f844b4c7a708.yml
+++ b/yaml/5329911b-bd24-4206-94b2-f844b4c7a708.yml
@@ -1,0 +1,52 @@
+Id: 5329911b-bd24-4206-94b2-f844b4c7a708
+Tags:
+    - WinRing0.sys
+    - WinRing0x64.sys
+    - OpenHardwareMonitorLib.sys
+    - TrafficMonitor.sys
+    - ZenStates-Core.sys
+    - WR64.sys
+    - WinRing0x64_Fan.sys
+Author: Jose Manuel Martinez
+Created: '2026-07-18'
+MitreID: T1068
+CVE:
+    - CVE-2020-14979
+Category: vulnerable driver
+Verified: 'TRUE'
+Commands:
+    Command: 'sc.exe create WinRing0 binPath=C:\Windows\Temp\WinRing0.sys type=kernel && sc.exe start WinRing0'
+    Description: 'Create and start the vulnerable WinRing0 kernel driver'
+    Usecase: 'Load a vulnerable kernel driver that exposes arbitrary physical memory read and write capabilities'
+    Privileges: Administrator
+    OperatingSystem: Windows
+Resources:
+    - 'https://nvd.nist.gov/vuln/detail/CVE-2020-14979'
+    - 'https://posts.specterops.io/cve-2020-14979-local-privilege-escalation-in-evga-precisionx1-cf63c6b95896'
+    - 'https://www.evga.com/precisionx1/'
+Acknowledgement:
+    Person: 'SpecterOps'
+    Handle: '@SpecterOps'
+KnownVulnerableSamples:
+-   Filename: WinRing0.sys
+    MD5: 0c0195c48b6b8582fa6f6373032118da
+    SHA1: d25340ae8e92a6d29f599fef426a2bc1b5217299
+    SHA256: 11bd2c9f9e2397c9a16e0990e4ed2cf0679498fe0fd418a3dfdac60b5c160ee5
+    Signature:
+        - 'Noriyuki MIYAZAKI'
+    Date: '2008-07-26 13:29:37 UTC'
+    Publisher: OpenLibSys.org
+    Company: OpenLibSys.org
+    Description: WinRing0
+    Product: WinRing0
+    ProductVersion: 1.2.0.5
+    FileVersion: 1.2.0.5
+    MachineType: AMD64
+    OriginalFilename: WinRing0.sys
+    Authentihash:
+        SHA256: 1b845e5e43ce9e9b645ac198549e81f45c08197aad69708d96cdb9a719eb0e29
+    InternalName: WinRing0.sys
+    Copyright: 'Copyright (C) 2007-2008 OpenLibSys.org. All rights reserved.'
+    Imports:
+        - ntoskrnl.exe
+        - HAL.dll

--- a/yaml/CVE-2026-36425_OPSWAT.yml
+++ b/yaml/CVE-2026-36425_OPSWAT.yml
@@ -1,0 +1,69 @@
+Id: c8f0b25b-1b61-4700-b491-5d26bcfba1d3
+Tags:
+    - ardrv_1.sys
+    - ardrv_2.sys
+    - ardrv_3.sys
+    - ardrv_4.sys
+    - ardrv_5.sys
+    - ardrv_6.sys
+    - ardrv_7.sys
+    - ardrv_8.sys
+    - ardrv_9.sys
+    - ardrv_10.sys
+    - ardrv_11.sys
+    - ardrv_12.sys
+    - ardrv_13.sys
+    - ardrv_14.sys
+    - ardrv_15.sys
+    - ardrv_16.sys
+Author: Jose Manuel Martinez
+Created: '2026-07-18'
+MitreID: T1068
+CVE:
+    - CVE-2026-36425
+Category: vulnerable driver
+Verified: 'TRUE'
+Commands:
+    Command: 'sc.exe create ardrv binPath=C:\Windows\Temp\ardrv_1.sys type=kernel && sc.exe start ardrv'
+    Description: 'Create and start an affected OPSWAT kernel driver'
+    Usecase: 'Load a vulnerable kernel driver'
+    Privileges: Administrator
+    OperatingSystem: Windows
+Resources:
+    - 'https://github.com/redteamfortress/CVE-2026-36425'
+Acknowledgement:
+    Person: 'RedTeamFortress'
+    Handle: '@redteamfortress'
+KnownVulnerableSamples:
+-   Filename: ardrv_1.sys
+    SHA256: 0B4C5A2D24810748DE8CE6FB3D6A3E8ACD0305272D6425FA054632410D23EC80
+-   Filename: ardrv_2.sys
+    SHA256: 1C5129B4D63F2D5252B5B02A0A7D655DAC3B6EAC23DD4ED92B4DD55F243387FF
+-   Filename: ardrv_3.sys
+    SHA256: 4D07B6423F4D5D80D2DAEC8FAED7ECC40855339BEE95C26289179C1FD083078E
+-   Filename: ardrv_4.sys
+    SHA256: 6B208CE68BA3F6C788BD89BA677EBF1C2407A55F9F43A42EA7207635634BAF66
+-   Filename: ardrv_5.sys
+    SHA256: 07C5209BF83065FE760F4FEE4ED2308B0C523671F68CA73A3854C2C8C28C0541
+-   Filename: ardrv_6.sys
+    SHA256: 7B3F8FA5844D829142002D47C2DF8573C7D67DEFE4171414C6A015A38AFE55F5
+-   Filename: ardrv_7.sys
+    SHA256: 9F326EDE322930A7D5E149FA8720802B0623C1972DC54E41A2A73608FB6810DD
+-   Filename: ardrv_8.sys
+    SHA256: 34AD901B4FEA05DA301EBB619FA48CFAC058720E41DB71B3FCA1C47763BAE066
+-   Filename: ardrv_9.sys
+    SHA256: 4574CF50DBE2FBCE849881E8875297753CE2E240C312E01B3B461D80DF063BBE
+-   Filename: ardrv_10.sys
+    SHA256: 75454A8583EA2A5B6C7711E9BF32C61B8A7E902F5C429FCBE36673CCC076E910
+-   Filename: ardrv_11.sys
+    SHA256: 551254A5E59DF92E6049867162633E3E476CDF5999D05C3E23A57C98BE03F475
+-   Filename: ardrv_12.sys
+    SHA256: 7504887E1E195AD585CFFA5B6A5034161A7CC49F351123D60DEF79302BDB8326
+-   Filename: ardrv_13.sys
+    SHA256: 33233988D8C735FDF1162E043ED1E6FFF62E7D6102C5BD300561D71FD32526F3
+-   Filename: ardrv_14.sys
+    SHA256: 59080957DE2519F5013BE8CCF0B9012DC97AD692E69578CB3F60148C528BDBB1
+-   Filename: ardrv_15.sys
+    SHA256: D82108E6578F4866D7114D6847282C04F0B146809BC66DED3300FE993B42D20F
+-   Filename: ardrv_16.sys
+    SHA256: E3CB9F52A4FDE53FC886DC35D41BB36E8B993C74826389D22440B92D94480A6D


### PR DESCRIPTION
## Summary

This pull request adds vulnerable driver samples associated with:

- OPSWAT drivers affected by CVE-2026-36425
- WinRing0 affected by CVE-2020-14979

## Changes

- Added 16 OPSWAT driver SHA-256 hashes.
- Added the WinRing0 sample and available file metadata.
- Included public vulnerability references.
- Used the repository YAML template and UUIDv4 filenames.

## References

- CVE-2026-36425 research:
  https://github.com/redteamfortress/CVE-2026-36425

- CVE-2020-14979:
  https://nvd.nist.gov/vuln/detail/CVE-2020-14979