### PR TITLE
Add KKYUM.sys

### DIFF
--- a/drivers/8516410b49bb79c08c19a37c516dad72.bin
+++ b/drivers/8516410b49bb79c08c19a37c516dad72.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72bd55f4459c992b9caa1a33cb6862f1f3085ca35839c58dee8b75db22ca605f
+size 26768

--- a/yaml/459c39a0-d6bd-4d3e-91ae-a701bb0b3198.yaml
+++ b/yaml/459c39a0-d6bd-4d3e-91ae-a701bb0b3198.yaml
@@ -1,0 +1,156 @@
+Id: 459c39a0-d6bd-4d3e-91ae-a701bb0b3198
+Tags:
+- KKYUM.sys
+Author: Element2023H
+Created: '2026-08-12'
+MitreID: T1068
+Category: vulnerable driver
+Verified: 'TRUE'
+Commands:
+  Command: sc.exe create KKYUM binPath=C:\windows\temp\KKYUM.sys type=kernel && sc.exe
+    start KKYUM
+  Description: The driver creates a device object named "\\.\KKYUM" without strict access controls, allowing low-privileged users to interact with it.
+      It exposes unauthenticated IOCTL control codes "0x22265C" (Read) and "0x222658" (Write) that encapsulate the MmCopyVirtualMemory kernel API.
+      The handler accepts a target Process ID (PID) and a structured array of source/destination virtual addresses directly from user space without checking execution privileges,
+      enabling local attackers to perform unauthorized arbitrary process memory reads and writes against any active process.
+  Usecase: Read and write the virtual memory space of arbitrary processes from kernel mode,
+      allowing attackers to dump sensitive credentials (e.g., from lsass.exe) or elevate privileges.
+  Privileges: kernel
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://github.com/The-Sword-of-Constantine/UsingBYOVD
+KnownVulnerableSamples:
+- Filename: KKYUM.sys
+  MD5: 8516410b49bb79c08c19a37c516dad72
+  SHA1: 4d0708b4a6adee830c30b72add84172fb62fd049
+  SHA256: 72bd55f4459c992b9caa1a33cb6862f1f3085ca35839c58dee8b75db22ca605f
+  Signature:
+  - Microsoft Windows Hardware Compatibility Publisher
+  CreationTimestamp: '2025-11-04 18:10:23'
+  Company: ''
+  Description: ''
+  Product: ''
+  ProductVersion: ''
+  FileVersion: ''
+  MachineType: AMD64
+  Authentihash:
+    MD5: d4adce0a36ed4692f11bab7f7ac56b3d
+    SHA1: a3398305ceb9e9ce3baf6f7a6690c6c5b38dfc8c
+    SHA256: eed8f67bfdcc3c30362ab35f7f9cf9f21a47065ea03cffcab27ca9d6317a3016
+  Imports:
+  - ntoskrnl.exe
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ExFreePoolWithTag
+  - MmMapLockedPagesSpecifyCache
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoGetCurrentProcess
+  - IoSetDeviceInterfaceState
+  - ObfDereferenceObject
+  - KeStackAttachProcess
+  - KeUnstackDetachProcess
+  - ExAllocatePoolWithTag
+  - PsGetProcessWow64Process
+  - PsGetProcessPeb
+  - ZwQuerySystemInformation
+  - RtlFindExportedRoutineByName
+  - MmCopyVirtualMemory
+  - __C_specific_handler
+  - ExAllocatePool
+  - MmIsAddressValid
+  - ObReferenceObjectByName
+  - IoDriverObjectType
+  - KeFlushIoBuffers
+  - RtlCopyUnicodeString
+  - DbgPrintEx
+  - RtlEqualUnicodeString
+  - RtlCompareUnicodeString
+  - RtlInitUnicodeString
+  - PsLookupProcessByProcessId
+  - _stricmp
+  - WdfVersionUnbind
+  - WdfLdrQueryInterface
+  - WdfVersionBind
+  - WdfVersionUnbindClass
+  - WdfVersionBindClass
+  PDBPath: E:\Windows\Desktop\Dev\Driver\IOBase\kmum\x64\Release\ioctl-km.pdb
+  Imphash: 1f0b3ed19bdad1a668d8bdf3ebeccbab
+  RichPEHeaderHash:
+    MD5: d7c72fb473f2f3a00d6ab12710c17bc0
+    SHA1: cc0ec256ab44c712dcb03fdaadd62ac76aac8d6a
+    SHA256: e33aaa5b471c9f7d3ed8149b6200a81aa0bee39eb0e06011116b7c973a619354
+  Sections:
+    .text:
+      Entropy: 6.302621954167963
+      Virtual Size: '0x25e0'
+    .rdata:
+      Entropy: 4.723512821429953
+      Virtual Size: '0xb80'
+    .data:
+      Entropy: 0.8176822242264905
+      Virtual Size: '0x4e0'
+    .pdata:
+      Entropy: 4.032308121808265
+      Virtual Size: '0x1f8'
+    INIT:
+      Entropy: 4.928877881264077
+      Virtual Size: '0x4f4'
+    .reloc:
+      Entropy: 3.573079645651109
+      Virtual Size: '0x38'
+  MagicHeader: 50 45 0 0
+  InternalName: ''
+  OriginalFilename: ''
+  Copyright: ''
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2025-02-20 20:08:08'
+      ValidTo: '2026-02-18 20:08:08'
+      Signature: 3a915ff496468e86d34a86bc4951e3d12d88d33fdd9826b98e674328eb433cad2113c9b57ceef54448eff7b018068dd2dcdab1daadf0536e5840a50e8adfd9da55a6094444c2b2222c402518668f8b610fde25de085d0097ff8e1548d3f15214de67bc40ec593546a1d2996ac74a9667ad8a05872c13ea1f68febffa660d691ff628a2240586db6fb6e26c5df277774231f7cb85e07d2c9918693e23e31b55b10dcb8fc7a1c588aa9089a96f4cd119fa76a370a9abcf4d43a2ceefb1c8adfbd13c76ccecc99c11f6bb8a56f4ea2bf19a6183feb46852de6b673c9bdaf830ffa07ac365efaf5184e21e5c3f32b308342fd07f2e3e2eccc753057aa3688984a183
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 3300000124e76f6ca813a27c35000000000124
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: cfe40b64f31750e7a57db8c4ad451bff
+        SHA1: 4031068d5106d7b364c9b99daf963a00fce3c1fb
+        SHA256: 11dfc1860474603fc5821f01931eb0e945a652e9e5d48b5042472941109b1932
+        SHA384: fafef1d7376886b2895becf586b67dbb317d6ad4398625b0eed2725280d6b29ea072dc4ec32fbc5e041996f8708351f9
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      ValidFrom: '2012-04-18 23:48:38'
+      ValidTo: '2027-04-18 23:58:38'
+      Signature: 5a8a67daccd5fd0d264177bf0a4678b4b3de12692b7723c2652f015fd203f461ba509d2e8c3972f36c3e6ab11e766decb7f382dcccbbc56970287366173f54ebee011648c446d91b80ae813a8d0f796d68b09eea2d3f39d3ca387ebd5e7c086e19dcc6c2f438336861e2524783e1000156d2bacb878205310a418b4ee77f5f5fed5fd3392d45eba213bffd1ec298417161165fc80a70257c59693124e471e70abb0417f79f721ec9d2bb1abe3d02fe090cb243b4591a99539396215fe0d6b72601429536ac27fdbef48577683d18bdf4be98882211865216f345ec0397107087a37043713cdbc98603170cf5735bc67de15c64edd7c548d7ed32e2d1aad3cfa7f6574e61f977eb67f288b3de00da038fd08a34373e1dd862b8d2b1f3e12f8b723b81967c6ffcec667672601b24f2a0896d5b6d002eef28dd868705c2b4b9e5be64c22af24a155c98e2c42785ff52e3627e0fb2020bd766c70ab2d33d200414503259830a7d9bed5a38120152ba2f5e20728e4af1fde771028c3be107bec973f4dd47d8b4efb4a4b330b9893e76cab90098567eabea8ab8a5d038ab6977130b142fe9aa411ff7babd3a2b348aee0aab63e663f788248e200d2b3b9de3c24952ac9f1f0e393b5dd46e506ae67d523aaa7c3315290d265e0158a74ea93d7a846f743f609fe4324f3600af6d71d33ea646655f8174f1fec171da4ca0415a82ddf11f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 610baac1000000000009
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: a569061297e8e824767dbc3184a69bea
+        SHA1: adbb26a587a8f44b4fccaecb306f980d1c55a150
+        SHA256: cec1afd0e310c55c1dcc601ab8e172917706aa32fb5eaf826813547fdf02dd46
+        SHA384: e947cac936803f5683196e4ff1b259096073395d0b908522ddce90d57597c9f7b57f7ddcdbe021ba863d843c340da8ba
+    Signer:
+    - SerialNumber: 3300000124e76f6ca813a27c35000000000124
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      Version: 1
+Detection: []
+Acknowledgement:
+  Person: ''
+  Handle: Element2023H


### PR DESCRIPTION
The driver creates a device object named "\\.\KKYUM" without strict access controls, allowing low-privileged users to interact with it.
It exposes unauthenticated IOCTL control codes "0x22265C" (Read) and "0x222658" (Write) that encapsulate the MmCopyVirtualMemory kernel API.
The handler accepts a target Process ID (PID) and a structured array of source/destination virtual addresses directly from user space without checking execution privileges, enabling local attackers to perform unauthorized arbitrary process memory reads and writes against any active process.

<details>
<summary><b>View Decompiled IOCTL Handler (IDA Pro Screenshot)</b></summary>


<img width="1260" height="753" alt="image" src="https://github.com/user-attachments/assets/da18908c-0b1d-4ead-82c0-2355ac153ac1" />
<img width="1404" height="795" alt="image" src="https://github.com/user-attachments/assets/85cd4821-7f86-409c-9709-e6ad64441fa5" />
