### PR TITLE
Add CVE-2026-68820 to Afd.sys

### DIFF
--- a/yaml/394f49b2-2d78-4d0d-b374-1399695455f3.yaml
+++ b/yaml/394f49b2-2d78-4d0d-b374-1399695455f3.yaml
@@ -7,6 +7,7 @@ Created: '2024-08-21'
 MitreID: T1068
 CVE:
 - CVE-2023-21768
+- CVE-2026-68820
 Category: vulnerable driver
 Commands:
   Command: sc.exe create Afd.sys binPath=C:\windows\temp\Afd.sys type=kernel && sc.exe
@@ -19,6 +20,7 @@ Commands:
 Resources:
 - https://securityintelligence.com/x-force/patch-tuesday-exploit-wednesday-pwning-windows-ancillary-function-driver-winsock/
 - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-21768
+- https://research.checkpoint.com/2026/shattering-the-dream-when-a-job-offer-becomes-a-zero-day-attack/
 Detection: []
 Acknowledgement:
   Person: ''


### PR DESCRIPTION
Adds CVE-2026-68820 to the existing Afd.sys entry.

Check Point Research disclosed that Lazarus/FudModule exploited a previously unknown race condition/use-after-free vulnerability in Afd.sys during Operation Dream Job.

This PR:
- Adds CVE-2026-68820 to the existing Afd.sys CVE list
- Adds the Check Point Research report as a reference

No new vulnerable sample/hash is included since the research does not provide a specific Afd.sys hash associated with CVE-2026-68820.