### PR TITLE
Add BYOVD entries: Alinubx.sys and DCRCVDrv.sys (Cruciferra MaaS)

### DIFF
--- a/drivers/10b3049f4a954665512eca5d24728c89.bin
+++ b/drivers/10b3049f4a954665512eca5d24728c89.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:611b3ba687b7f46319a19609605ddfe5225e6d85277d8e923eea3fdb6f7b5b61
+size 538664

--- a/drivers/567c158ee0858f8e941d4ab7a6c18dbc.bin
+++ b/drivers/567c158ee0858f8e941d4ab7a6c18dbc.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87e8d39db624f37d3e77aedf487a2dfd197f71a4730ea74f4e7a4341deaec2ff
+size 141240

--- a/yaml/84a3007a-de5e-4622-bfc5-f05d927c3618.yaml
+++ b/yaml/84a3007a-de5e-4622-bfc5-f05d927c3618.yaml
@@ -1,0 +1,85 @@
+Id: 84a3007a-de5e-4622-bfc5-f05d927c3618
+Tags:
+- Alinubx.sys
+- nvfsflt64.sys
+Verified: 'TRUE'
+Author: Jose Hernandez
+Created: '2026-08-27'
+MitreID: T1068
+CVE:
+- ''
+Category: vulnerable driver
+Commands:
+  Command: ''
+  Description: Alinubx.sys exposes IOCTL 0x222024 which allows user-mode applications
+    to terminate arbitrary processes from the kernel via ZwTerminateProcess. The IOCTL
+    input buffer expects a structure containing the PID (DWORD) and an exit status
+    code (DWORD). Abused by the Cruciferra MaaS loader to kill AV/EDR processes.
+  OperatingSystem: Windows
+  Privileges: kernel
+  Usecase: Terminate AV/EDR processes from kernel mode (BYOVD)
+Resources:
+- https://www.esentire.com/blog/malware-as-a-service-cocktail-errtraffic-and-cruciferra-killing-your-edr-since-2025
+- https://www.virustotal.com/gui/file/611b3ba687b7f46319a19609605ddfe5225e6d85277d8e923eea3fdb6f7b5b61/details
+- https://github.com/magicsword-io/LOLDrivers/issues/412
+- https://x.com/YungBinary/status/2092812095456936172
+Detection:
+- type: ''
+  value: ''
+Acknowledgement:
+  Handle: '@eSentire_TRU'
+  Person: eSentire Threat Response Unit (TRU)
+KnownVulnerableSamples:
+- Filename: Alinubx.sys
+  MD5: 10b3049f4a954665512eca5d24728c89
+  SHA1: 172c5ce3afab6d63fe12a7e036f20271b9d09c13
+  SHA256: 611b3ba687b7f46319a19609605ddfe5225e6d85277d8e923eea3fdb6f7b5b61
+  Authentihash:
+    SHA256: c202e7bb00135434321dad49f6c746b1ea071f6e7400a598438868f660f0e887
+  Imphash: 57a2f40fccb4fb28f3e0fc12f06cf4b2
+  RichPEHeaderHash:
+    MD5: 65e11ac7adedb54f4ce7a324f7ae2a5b
+  CreationTimestamp: '2023-03-24 11:08:33'
+  Date: '12:18 PM 03/24/2023'
+  MachineType: AMD64
+  MagicHeader: 50 45 0 0
+  Company: 河南大风软件有限公司
+  Copyright: ''
+  Description: Alinubx Driver
+  Product: CnCrypt
+  FileVersion: '1.32'
+  OriginalFilename: Alinubx.sys
+  Imports:
+  - ntoskrnl.exe
+  - FLTMGR.SYS
+  - ksecdd.sys
+  - NDIS.SYS
+  - fwpkclnt.sys
+  Signature:
+  - Microsoft Windows Hardware Compatibility Publisher
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: CN=Microsoft Windows Hardware Compatibility Publisher
+      ValidFrom: ''
+      ValidTo: ''
+      IsCodeSigning: true
+    Signer:
+    - Issuer: CN=Microsoft Windows Third Party Component CA 2014
+  Sections:
+    .text:
+      Entropy: 6.42
+      Virtual Size: '0x3837d'
+    .rdata:
+      Entropy: 5.14
+      Virtual Size: '0x30d0'
+    .data:
+      Entropy: 1.89
+      Virtual Size: '0xb4f0'
+    .pdata:
+      Entropy: 5.41
+      Virtual Size: '0x20e8'
+    PAGE:
+      Entropy: 6.32
+      Virtual Size: '0x23e8'

--- a/yaml/84a3007a-de5e-4622-bfc5-f05d927c3618.yaml
+++ b/yaml/84a3007a-de5e-4622-bfc5-f05d927c3618.yaml
@@ -20,7 +20,6 @@ Commands:
   Usecase: Terminate AV/EDR processes from kernel mode (BYOVD)
 Resources:
 - https://www.esentire.com/blog/malware-as-a-service-cocktail-errtraffic-and-cruciferra-killing-your-edr-since-2025
-- https://www.virustotal.com/gui/file/611b3ba687b7f46319a19609605ddfe5225e6d85277d8e923eea3fdb6f7b5b61/details
 - https://github.com/magicsword-io/LOLDrivers/issues/412
 - https://x.com/YungBinary/status/2092812095456936172
 Detection:
@@ -35,15 +34,19 @@ KnownVulnerableSamples:
   SHA1: 172c5ce3afab6d63fe12a7e036f20271b9d09c13
   SHA256: 611b3ba687b7f46319a19609605ddfe5225e6d85277d8e923eea3fdb6f7b5b61
   Authentihash:
+    MD5: 207e7aaa3c30c8dffeb20fd8f3b72852
+    SHA1: 1cbb8931e81f662af15b71db621d78d7988fe704
     SHA256: c202e7bb00135434321dad49f6c746b1ea071f6e7400a598438868f660f0e887
   Imphash: 57a2f40fccb4fb28f3e0fc12f06cf4b2
   RichPEHeaderHash:
     MD5: 65e11ac7adedb54f4ce7a324f7ae2a5b
-  CreationTimestamp: '2023-03-24 11:08:33'
-  Date: '12:18 PM 03/24/2023'
+    SHA1: e608e549ca9c3fc44c31dcd38561b0b035eb7b75
+    SHA256: ed10715fb9768cbe7f171a8d633022bd64d380f746ceaead60a263c5ed5ba8f7
+  CreationTimestamp: '2023-03-24 05:08:33'
+  Date: 12:18 PM 03/24/2023
   MachineType: AMD64
   MagicHeader: 50 45 0 0
-  Company: 河南大风软件有限公司
+  Company: CnCrypt Foundation
   Copyright: ''
   Description: Alinubx Driver
   Product: CnCrypt
@@ -61,25 +64,314 @@ KnownVulnerableSamples:
   - CertificatesInfo: ''
     SignerInfo: ''
     Certificates:
-    - Subject: CN=Microsoft Windows Hardware Compatibility Publisher
-      ValidFrom: ''
-      ValidTo: ''
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2022-06-07 18:08:05'
+      ValidTo: '2023-06-01 18:08:05'
+      Signature: 0915e1bc394d6afd2453e27c2cb0907bb3a569ca2f39bc8e430a355013bd29a2aa0f8d724499e05b94f919195e917a198a754a790c8f4f49ebeea699d62e4b97b18055d6872b13e5c3866e8617fafb65a59cf0c463f75b45f870595677ecdda4ae3562b0f4a30d09626cef7f4e20e77385bd4e4db94fc77088d698236e92e1440cef351a1f3bff256df13c1a14b5c6787dad23e1e28d4148b69b3a92fe692bed7db3feb760db45fe1700983b834ab7805ba6105fdf94d5e0833679fae2fc051d745c6fab49c8aa9044d92da8c26fe7c87a9268bd1211117298b391752c08f98ffaa3731bbca891a83a0bdb9d94546d1bab380ade386213b3833327f48b9ff29971732bfe5810b51569da90676b459f8f6341ef9ff11f96f44f58181ef7ffe3ff19ba7874ad2e8c4faa9f8d1c5cd698bbdab1658f5f234f64a0063ecaa346f16e58690dea8c52e02733560027155457863b38775e24f30176cadd0d2738b4d90f2e4f688e25bc908a5fb1057be8372e58dc7c018b4663588fb1ab36855c09e54924951cff3b29810339efca415995a577e7db9d8b43c79b0bcb888b3647c7b28b9599bf0cbc7683e0e68c610d0071e79a3f1b4160dcfcb3002478ccc6bbf0c6dd27893169825f7b50356e01ea77aeae1b534d8c8801eda6bc60682a7b3a78b8b74eddb75044a789e7c4fd8f27ac8050196a7b1de4b5ac2e2b268c568534f75ca9
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 330000005635887ede1882ef76000000000056
+      Version: 3
+      CertificateType: Leaf (Code Signing)
       IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: b2247e5539fb97f429f20b17b38c4bcb
+        SHA1: a3b745afc365e9ddf6abdb2f52f76f1714c0461c
+        SHA256: e0c84b42e07e8f56ed8dcd2103e98cd43816cf2e05a27b8ff09fdccccfbcffaa
+        SHA384: 70e84fe31ec8f61d70755ec61ba53db7741610d7348247c97796147dcaa77a55bc3887cedf16eb0a2f32867670d007c1
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      ValidFrom: '2014-10-15 20:31:27'
+      ValidTo: '2029-10-15 20:41:27'
+      Signature: 96b5c33b31f27b6ba11f59dd742c3764b1bca093f9f33347e9f95df21d89f4579ee33f10a3595018053b142941b6a70e5b81a2ccbd8442c1c4bed184c2c4bd0c8c47bcbd8886fb5a0896ae2c2fdfbf9366a32b20ca848a6945273f732332936a23e9fffdd918edceffbd6b41738d579cf8b46d499805e6a335a9f07e6e86c06ba8086725afc0998cdba7064d4093188ba959e69914b912178144ac57c3ae8eae947bcb3b8edd7ab4715bba2bc3c7d085234b371277a54a2f7f1ab763b94459ed9230cce47c099212111f52f51e0291a4d7d7e58f8047ff189b7fd19c0671dcf376197790d52a0fbc6c12c4c50c2066f50e2f5093d8cafb7fe556ed09d8a753b1c72a6978dcf05fe74b20b6af63b5e1b15c804e9c7aa91d4df72846782106954d32dd6042e4b61ac4f24636de357302c1b5e55fb92b59457a9243d7c4e963dd368f76c728caa8441be8321a66cde5485c4a0a602b469206609698dcd933d721777f886dac4772daa2466eab64682bd24e98fb35cc7fec3f136d11e5db77edc1c37e1f6a4a14f8b4a721c671866770cdd819a35d1fa09b9a7cc55d4d728e74077fa74d00fcdd682412772a557527cda92c1d8e7c19ee692c9f7425338208db38cc7cc74f6c3a6bc237117872fe55596460333e2edfc42de72cd7fb0a82256fb8d70c84a5e1c4746e2a95329ea0fecdb4188fd33bad32b2b19ab86d0543fbff0d0f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 330000000d690d5d7893d076df00000000000d
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 83f69422963f11c3c340b81712eef319
+        SHA1: 0c5e5f24590b53bc291e28583acb78e5adc95601
+        SHA256: d8be9e4d9074088ef818bc6f6fb64955e90378b2754155126feebbbd969cf0ae
+        SHA384: 260ad59ba706420f68ba212931153bd89f760c464b21be55fba9d014fff322407859d4ebfb78ea9a3330f60dc9821a63
     Signer:
-    - Issuer: CN=Microsoft Windows Third Party Component CA 2014
+    - SerialNumber: 330000005635887ede1882ef76000000000056
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      Version: 1
   Sections:
     .text:
-      Entropy: 6.42
+      Entropy: 6.425748426163659
       Virtual Size: '0x3837d'
     .rdata:
-      Entropy: 5.14
+      Entropy: 5.225851534532288
       Virtual Size: '0x30d0'
     .data:
-      Entropy: 1.89
+      Entropy: 1.889525297232436
       Virtual Size: '0xb4f0'
     .pdata:
-      Entropy: 5.41
+      Entropy: 5.529801228792628
       Virtual Size: '0x20e8'
     PAGE:
-      Entropy: 6.32
+      Entropy: 6.32945823837949
       Virtual Size: '0x23e8'
+    INIT:
+      Entropy: 5.9160723075063
+      Virtual Size: '0x28ac'
+    .rsrc:
+      Entropy: 3.1585031139600117
+      Virtual Size: '0x2d0'
+    .reloc:
+      Entropy: 1.8525569859993862
+      Virtual Size: '0x426'
+  InternalName: ''
+  ProductVersion: '1.32'
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - RtlAppendUnicodeToString
+  - _wcsicmp
+  - ZwQuerySystemInformation
+  - ZwQueryInformationProcess
+  - PsGetCurrentProcessId
+  - ZwTerminateProcess
+  - ObOpenObjectByPointer
+  - PsGetCurrentProcessWow64Process
+  - PsWrapApcWow64Thread
+  - KeInitializeApc
+  - KeInsertQueueApc
+  - PsGetThreadTeb
+  - ZwWaitForSingleObject
+  - IoGetCurrentProcess
+  - ZwFreeVirtualMemory
+  - PsIsThreadTerminating
+  - PsGetCurrentThreadId
+  - KeTestAlertThread
+  - ZwQueryInformationThread
+  - PsLookupThreadByThreadId
+  - PsGetProcessWow64Process
+  - ZwAllocateVirtualMemory
+  - RtlAppendUnicodeStringToString
+  - RtlImageNtHeader
+  - isspace
+  - tolower
+  - isdigit
+  - RtlCopyUnicodeString
+  - ZwQueryValueKey
+  - ZwOpenKey
+  - ExAllocatePool
+  - isprint
+  - MmUnmapLockedPages
+  - MmProtectMdlSystemAddress
+  - _strlwr
+  - MmGetSystemRoutineAddress
+  - RtlPrefixUnicodeString
+  - ZwDeleteFile
+  - ZwWriteFile
+  - _snwprintf
+  - swprintf
+  - wcsstr
+  - ZwEnumerateValueKey
+  - IoGetDeviceProperty
+  - ZwEnumerateKey
+  - ZwQueryKey
+  - IoFileObjectType
+  - RtlQueryRegistryValues
+  - KeStackAttachProcess
+  - RtlWriteRegistryValue
+  - RtlUnicodeStringToInteger
+  - RtlCreateRegistryKey
+  - PsProcessType
+  - PsThreadType
+  - ZwCreateKey
+  - ZwDeleteValueKey
+  - ZwSetValueKey
+  - wcsncat
+  - ObQueryNameString
+  - ZwDeleteKey
+  - IoCreateFile
+  - ExInterlockedInsertHeadList
+  - memchr
+  - RtlGetVersion
+  - KeSetTimerEx
+  - KeQueryTimeIncrement
+  - KeInitializeTimerEx
+  - IoAcquireRemoveLockEx
+  - IoDeleteSymbolicLink
+  - IoRegisterShutdownNotification
+  - IoDeleteDevice
+  - IoReleaseRemoveLockEx
+  - IofCompleteRequest
+  - IoReleaseRemoveLockAndWaitEx
+  - IoCreateSymbolicLink
+  - IoInitializeRemoveLockEx
+  - IoCreateDevice
+  - ExAllocatePoolWithQuotaTag
+  - IoCreateNotificationEvent
+  - KdDebuggerEnabled
+  - KdDisableDebugger
+  - RtlRandomEx
+  - IoGetDeviceObjectPointer
+  - ExGetPreviousMode
+  - RtlIntegerToUnicodeString
+  - DbgPrintEx
+  - wcschr
+  - ZwQuerySymbolicLinkObject
+  - ZwOpenSymbolicLinkObject
+  - IoGetDeviceAttachmentBaseRef
+  - ExInitializeNPagedLookasideList
+  - ExDeleteNPagedLookasideList
+  - KeBugCheckEx
+  - PsGetProcessId
+  - PsInitialSystemProcess
+  - KeDelayExecutionThread
+  - KeUnstackDetachProcess
+  - LsaFreeReturnBuffer
+  - PsReferencePrimaryToken
+  - PsLookupProcessByProcessId
+  - PsGetProcessPeb
+  - ExQueueWorkItem
+  - ZwQueryInformationFile
+  - ZwReadFile
+  - MmIsAddressValid
+  - PsSetLoadImageNotifyRoutine
+  - ObfReferenceObject
+  - NtBuildNumber
+  - MmUnlockPages
+  - KeReleaseMutex
+  - KeInitializeMutex
+  - KeResetEvent
+  - IoReuseIrp
+  - RtlFreeUnicodeString
+  - RtlAnsiStringToUnicodeString
+  - strncpy
+  - strncmp
+  - RtlFreeAnsiString
+  - RtlUnicodeStringToAnsiString
+  - atoi
+  - RtlInitAnsiString
+  - strchr
+  - strstr
+  - ExDeleteLookasideListEx
+  - SeQueryAuthenticationIdToken
+  - ExInitializeLookasideListEx
+  - ExInterlockedRemoveHeadList
+  - ExQueryDepthSList
+  - ExInterlockedInsertTailList
+  - ExpInterlockedPopEntrySList
+  - ExpInterlockedPushEntrySList
+  - wcsncpy
+  - sprintf
+  - KeAcquireSpinLockRaiseToDpc
+  - KeReleaseSpinLock
+  - _stricmp
+  - _snprintf
+  - _strnicmp
+  - MmMapLockedPagesSpecifyCache
+  - MmBuildMdlForNonPagedPool
+  - PsTerminateSystemThread
+  - KeClearEvent
+  - ObfDereferenceObject
+  - PsCreateSystemThread
+  - KeAcquireInStackQueuedSpinLock
+  - KeReleaseInStackQueuedSpinLock
+  - IofCallDriver
+  - IoAllocateMdl
+  - IoAllocateIrp
+  - MmProbeAndLockPages
+  - IoFreeIrp
+  - KeWaitForSingleObject
+  - ObReferenceObjectByHandle
+  - ZwClose
+  - ZwCreateFile
+  - IoFreeMdl
+  - KeInitializeEvent
+  - KeSetEvent
+  - IoBuildDeviceIoControlRequest
+  - strrchr
+  - PsGetVersion
+  - RtlTimeToTimeFields
+  - _vsnwprintf
+  - ExSystemTimeToLocalTime
+  - RtlInitUnicodeString
+  - _wcsnicmp
+  - ExFreePoolWithTag
+  - IoGetTransactionParameterBlock
+  - ExAllocatePoolWithTag
+  - __C_specific_handler
+  - RtlRaiseException
+  - FltFreeCallbackData
+  - FltSetCallbackDataDirty
+  - FltCreateFile
+  - FltClose
+  - FltPerformSynchronousIo
+  - FltAllocateCallbackData
+  - FltCheckAndGrowNameControl
+  - FltGetFileNameInformationUnsafe
+  - FltGetDiskDeviceObject
+  - FltReleaseContext
+  - FltCreateFileEx2
+  - FltAllocateContext
+  - FltGetFileNameInformation
+  - FltUnregisterFilter
+  - FltGetRoutineAddress
+  - FltGetVolumeName
+  - FltRegisterFilter
+  - FltReleaseFileNameInformation
+  - FltStartFiltering
+  - FltSetVolumeContext
+  - FltGetStreamHandleContext
+  - FltGetVolumeContext
+  - FltSetStreamHandleContext
+  - FltLockUserBuffer
+  - FltGetDestinationFileNameInformation
+  - FltDoCompletionProcessingWhenSafe
+  - FltParseFileNameInformation
+  - FltReadFile
+  - FltCreateFileEx
+  - FltQueryInformationFile
+  - GetSecurityUserInfo
+  - NdisFreeNetBufferListPool
+  - NdisGetDataBuffer
+  - NdisRetreatNetBufferDataStart
+  - NdisAdvanceNetBufferDataStart
+  - NdisAllocateGenericObject
+  - NdisFreeNetBufferPool
+  - NdisAllocateNetBufferPool
+  - NdisAllocateNetBufferListPool
+  - NdisFreeGenericObject
+  - FwpmFreeMemory0
+  - FwpmEngineClose0
+  - FwpmTransactionBegin0
+  - FwpsCalloutRegister1
+  - FwpmFilterAdd0
+  - FwpmEngineOpen0
+  - FwpmTransactionAbort0
+  - FwpmCalloutGetByKey0
+  - FwpmCalloutAdd0
+  - FwpmTransactionCommit0
+  - FwpsInjectionHandleCreate0
+  - FwpsInjectionHandleDestroy0
+  - FwpmSubLayerAdd0
+  - FwpsCalloutUnregisterById0
+  - FwpsReleaseClassifyHandle0
+  - FwpsAcquireClassifyHandle0
+  - FwpsAllocateCloneNetBufferList0
+  - FwpsInjectNetworkSendAsync0
+  - FwpsQueryPacketInjectionState0
+  - FwpsFreeCloneNetBufferList0
+  - FwpsInjectNetworkReceiveAsync0
+  - FwpsApplyModifiedLayerData0
+  - FwpsAcquireWritableLayerDataPointer0
+  - FwpsFreeNetBufferList0
+  - FwpsAllocateNetBufferAndNetBufferList0
+  - FwpsReferenceNetBufferList0
+  - FwpsDereferenceNetBufferList0
+  - FwpmSubLayerDeleteByKey0
+  - FwpsFlowRemoveContext0
+  - FwpsFlowAssociateContext0
+  - FwpsStreamInjectAsync0
+  - FwpsCopyStreamDataToBuffer0

--- a/yaml/89643454-e38b-41cb-853d-abf649a104a5.yaml
+++ b/yaml/89643454-e38b-41cb-853d-abf649a104a5.yaml
@@ -1,0 +1,36 @@
+Id: 89643454-e38b-41cb-853d-abf649a104a5
+Tags:
+- DCRCVDrv.sys
+Verified: 'TRUE'
+Author: Jose Hernandez
+Created: '2026-08-27'
+MitreID: T1068
+CVE:
+- ''
+Category: vulnerable driver
+Commands:
+  Command: ''
+  Description: DCRCVDrv.sys exposes IOCTL 0x2205C0 which allows user-mode applications
+    to terminate arbitrary processes from the kernel via ZwTerminateProcess. The IOCTL
+    input buffer contains the PID to terminate. Abused by the Cruciferra MaaS loader,
+    which writes the driver to C:\Windows\Temp\DCRCVDrv.sys, creates a service for it,
+    and opens a handle via the symbolic link \\.\DCRCVDRV_U to kill AV/EDR processes.
+  OperatingSystem: Windows
+  Privileges: kernel
+  Usecase: Terminate AV/EDR processes from kernel mode (BYOVD)
+Resources:
+- https://www.esentire.com/blog/malware-as-a-service-cocktail-errtraffic-and-cruciferra-killing-your-edr-since-2025
+- https://github.com/magicsword-io/LOLDrivers/issues/412
+Detection:
+- type: ''
+  value: ''
+Acknowledgement:
+  Handle: '@eSentire_TRU'
+  Person: eSentire Threat Response Unit (TRU)
+KnownVulnerableSamples:
+- Filename: DCRCVDrv.sys
+  MD5: 567c158ee0858f8e941d4ab7a6c18dbc
+  SHA1: 47d922b0fd5d704025d14ef98ded46e74830a423
+  SHA256: 87e8d39db624f37d3e77aedf487a2dfd197f71a4730ea74f4e7a4341deaec2ff
+  Signature:
+  - MocoMsys

--- a/yaml/89643454-e38b-41cb-853d-abf649a104a5.yaml
+++ b/yaml/89643454-e38b-41cb-853d-abf649a104a5.yaml
@@ -13,8 +13,8 @@ Commands:
   Description: DCRCVDrv.sys exposes IOCTL 0x2205C0 which allows user-mode applications
     to terminate arbitrary processes from the kernel via ZwTerminateProcess. The IOCTL
     input buffer contains the PID to terminate. Abused by the Cruciferra MaaS loader,
-    which writes the driver to C:\Windows\Temp\DCRCVDrv.sys, creates a service for it,
-    and opens a handle via the symbolic link \\.\DCRCVDRV_U to kill AV/EDR processes.
+    which writes the driver to C:\Windows\Temp\DCRCVDrv.sys, creates a service for
+    it, and opens a handle via the symbolic link \\.\DCRCVDRV_U to kill AV/EDR processes.
   OperatingSystem: Windows
   Privileges: kernel
   Usecase: Terminate AV/EDR processes from kernel mode (BYOVD)
@@ -34,3 +34,188 @@ KnownVulnerableSamples:
   SHA256: 87e8d39db624f37d3e77aedf487a2dfd197f71a4730ea74f4e7a4341deaec2ff
   Signature:
   - MocoMsys
+  Imphash: 3be3ab07a4108143e8c2d10beeaa1788
+  Authentihash:
+    MD5: d6f560a8e5f5476a632e83814ded5a7f
+    SHA1: 5b129c6f9669f1b33a42b9c0d5c970d5b4925bf6
+    SHA256: 2a7ed8d0be70e0667aa14e161ae1dc6b7daaeb1438b534d73b1093c0b44d78a2
+  RichPEHeaderHash:
+    MD5: bc65325e8b3839fa906e179124755b07
+    SHA1: ed0e7b8ec6ed7bb3b100a17a9b4cad6ed59a7de0
+    SHA256: e159e3a544aad40e47177ad1944598d8b621ab9333b226f59dfe1736bf3ea0c1
+  Sections:
+    .text:
+      Entropy: 6.382556518950604
+      Virtual Size: '0x1c6a7'
+    .rdata:
+      Entropy: 5.015492178765635
+      Virtual Size: '0x11a4'
+    .data:
+      Entropy: 0.5578716016060967
+      Virtual Size: '0x8220'
+    .pdata:
+      Entropy: 5.072837753781875
+      Virtual Size: '0xe1c'
+    INIT:
+      Entropy: 5.278748055168351
+      Virtual Size: '0xb86'
+    .rsrc:
+      Entropy: 3.295461349688772
+      Virtual Size: '0x360'
+    .reloc:
+      Entropy: 1.2248474438670764
+      Virtual Size: '0x84'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2022-12-15 20:19:37'
+  Description: DCRCV_U Driver (for SCM)
+  Company: MOCOMSYS & DCRC
+  InternalName: DCRCVDrv.sys
+  OriginalFilename: DCRCVDrv.sys
+  FileVersion: 1, 0, 0, 0
+  Product: DCRCV_U
+  ProductVersion: 1, 0, 0, 0
+  Copyright: Copyright (C) MOCOMSYS & DCRC
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - TDI.SYS
+  - FLTMGR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - PsLookupProcessByProcessId
+  - ZwQuerySymbolicLinkObject
+  - IoGetRelatedDeviceObject
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - ExpInterlockedPushEntrySList
+  - MmGetSystemRoutineAddress
+  - ExpInterlockedPopEntrySList
+  - ZwOpenSymbolicLinkObject
+  - IoAllocateErrorLogEntry
+  - ObQueryNameString
+  - strncpy
+  - IoFileObjectType
+  - ZwCreateFile
+  - wcsrchr
+  - IoGetCurrentProcess
+  - ExEventObjectType
+  - ZwClose
+  - ExQueryDepthSList
+  - ObReferenceObjectByHandle
+  - IoAttachDeviceToDeviceStack
+  - PsGetVersion
+  - ZwOpenProcess
+  - ObfReferenceObject
+  - ObfDereferenceObject
+  - IoCreateDevice
+  - ZwTerminateProcess
+  - ObOpenObjectByPointer
+  - DbgPrint
+  - ExDeleteNPagedLookasideList
+  - IoUnregisterFsRegistrationChange
+  - IoRegisterFsRegistrationChange
+  - IoDeleteSymbolicLink
+  - IoIs32bitProcess
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - _wcsicmp
+  - PsSetLoadImageNotifyRoutine
+  - _wcsnicmp
+  - KeSetEvent
+  - PsSetCreateThreadNotifyRoutine
+  - ExInitializeNPagedLookasideList
+  - PsSetCreateProcessNotifyRoutine
+  - KeAcquireSpinLockRaiseToDpc
+  - PsGetCurrentProcessId
+  - ExReleaseFastMutex
+  - ExAcquireFastMutex
+  - KeInitializeEvent
+  - KeWaitForSingleObject
+  - ZwFsControlFile
+  - wcsncpy
+  - ZwSetInformationFile
+  - wcsstr
+  - ZwQueryDirectoryFile
+  - ZwOpenFile
+  - ZwQueryInformationFile
+  - ZwReadFile
+  - ZwQuerySecurityObject
+  - ZwWriteFile
+  - ZwCreateKey
+  - ZwSetValueKey
+  - ZwDeleteKey
+  - ZwEnumerateKey
+  - ZwOpenKey
+  - IoDetachDevice
+  - ZwQueryValueKey
+  - PoStartNextPowerIrp
+  - PoCallDriver
+  - RtlCompareMemory
+  - IofCallDriver
+  - MmBuildMdlForNonPagedPool
+  - IoFreeMdl
+  - IoFreeIrp
+  - IoAttachDevice
+  - IoAllocateIrp
+  - IoAllocateMdl
+  - ZwEnumerateValueKey
+  - ExGetPreviousMode
+  - PsProcessType
+  - KeBugCheckEx
+  - IoWriteErrorLogEntry
+  - ExFreePoolWithTag
+  - ExAllocatePoolWithTag
+  - _strnicmp
+  - _stricmp
+  - KeReleaseSpinLock
+  - ZwOpenEvent
+  - RtlAnsiCharToUnicodeChar
+  - __C_specific_handler
+  - TdiMapUserRequest
+  - FltSetCallbackDataDirty
+  - FltStartFiltering
+  - FltRegisterFilter
+  - FltGetVolumeName
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2022-03-10 19:58:05'
+      ValidTo: '2023-03-08 19:58:05'
+      Signature: 61b21fe5891421228f4bf81ef5a09005d450860e55d2013253f0c9240631c08e1643156b71e60bf9c78b9b116227cece4cf769c69e06b306614cecfb421e11b46f3074bff1e8a57925aa145c7b18b812899908db232437f0f44d4861544a96ee3e40b02935659e281c2ffc5cb04e92eb6db56bd35a919227430ee72019c2d2f0deb3f8d0b66b213367d42311bbd559b20ece3a2f8966c6b76ebfc8452fb4ab79d5c4734cb35d639838a73d65626d0a9bb512eeba084ece0f8deb229cfb98d43bcdec5575792f7af71698c4618db5b2723d39ffee829b00a96b14f74edd560449b040a7611f7e1b16d9d3763501bec9c483a73e63f191d26b2902d879c0612040
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 33000000dc341a520fbbcf3d8c0000000000dc
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: a3320406647f4541c4f8e731342ced04
+        SHA1: 73f33ada4ceacbc289cffac339cdb36a01773a23
+        SHA256: 4e21391a41bf00d507b1ec6ea2a71fe57c28b022ec0c504b19f9e608c6b2acb5
+        SHA384: e7f40fafff666298c5154ba64cdd1060454547233fb1d8a7982d4927d46e6e4038a40e581f33963401d6553f3ab97499
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      ValidFrom: '2012-04-18 23:48:38'
+      ValidTo: '2027-04-18 23:58:38'
+      Signature: 5a8a67daccd5fd0d264177bf0a4678b4b3de12692b7723c2652f015fd203f461ba509d2e8c3972f36c3e6ab11e766decb7f382dcccbbc56970287366173f54ebee011648c446d91b80ae813a8d0f796d68b09eea2d3f39d3ca387ebd5e7c086e19dcc6c2f438336861e2524783e1000156d2bacb878205310a418b4ee77f5f5fed5fd3392d45eba213bffd1ec298417161165fc80a70257c59693124e471e70abb0417f79f721ec9d2bb1abe3d02fe090cb243b4591a99539396215fe0d6b72601429536ac27fdbef48577683d18bdf4be98882211865216f345ec0397107087a37043713cdbc98603170cf5735bc67de15c64edd7c548d7ed32e2d1aad3cfa7f6574e61f977eb67f288b3de00da038fd08a34373e1dd862b8d2b1f3e12f8b723b81967c6ffcec667672601b24f2a0896d5b6d002eef28dd868705c2b4b9e5be64c22af24a155c98e2c42785ff52e3627e0fb2020bd766c70ab2d33d200414503259830a7d9bed5a38120152ba2f5e20728e4af1fde771028c3be107bec973f4dd47d8b4efb4a4b330b9893e76cab90098567eabea8ab8a5d038ab6977130b142fe9aa411ff7babd3a2b348aee0aab63e663f788248e200d2b3b9de3c24952ac9f1f0e393b5dd46e506ae67d523aaa7c3315290d265e0158a74ea93d7a846f743f609fe4324f3600af6d71d33ea646655f8174f1fec171da4ca0415a82ddf11f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 610baac1000000000009
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: a569061297e8e824767dbc3184a69bea
+        SHA1: adbb26a587a8f44b4fccaecb306f980d1c55a150
+        SHA256: cec1afd0e310c55c1dcc601ab8e172917706aa32fb5eaf826813547fdf02dd46
+        SHA384: e947cac936803f5683196e4ff1b259096073395d0b908522ddce90d57597c9f7b57f7ddcdbe021ba863d843c340da8ba
+    Signer:
+    - SerialNumber: 33000000dc341a520fbbcf3d8c0000000000dc
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      Version: 1


### PR DESCRIPTION
## Summary

Adds two new vulnerable driver entries abused as BYOVD process killers by the **Cruciferra** MaaS loader, as reported by eSentire TRU. Neither hash previously existed in LOLDrivers or the Microsoft vulnerable driver blocklist.

### 1. Alinubx.sys (`84a3007a-de5e-4622-bfc5-f05d927c3618`)

- SHA256: `611b3ba687b7f46319a19609605ddfe5225e6d85277d8e923eea3fdb6f7b5b61`
- CnCrypt "Alinubx Driver," Microsoft WHCP attestation-signed
- IOCTL `0x222024` permits arbitrary process termination through `ZwTerminateProcess`; the input contains a PID and exit status
- Also observed as `nvfsflt64.sys`
- Binary included through Git LFS and enriched with repository-generated PE, Authenticode, certificate, import, section, and hash metadata
- Closes #412

### 2. DCRCVDrv.sys (`89643454-e38b-41cb-853d-abf649a104a5`)

- SHA256: `87e8d39db624f37d3e77aedf487a2dfd197f71a4730ea74f4e7a4341deaec2ff`
- Signed by South Korean IT company MocoMsys
- IOCTL `0x2205C0` permits process termination through `ZwTerminateProcess`; the input contains the target PID
- Dropped to `C:\Windows\Temp\DCRCVDrv.sys` and accessed through `\\.\DCRCVDRV_U`
- Binary included through Git LFS and enriched with repository-generated PE, Authenticode, certificate, import, section, and hash metadata

## References

- https://www.esentire.com/blog/malware-as-a-service-cocktail-errtraffic-and-cruciferra-killing-your-edr-since-2025
- https://github.com/magicsword-io/LOLDrivers/issues/412