### PR TITLE
Add newly disclosed BYOVD drivers and in-the-wild samples

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -179,3 +179,9 @@ drivers/96a8b9db2dc9cba8cdf90c7c33fe11c4.bin filter=lfs diff=lfs merge=lfs -text
 drivers/2c10be1aea72b7bdf07c735a4ad68876.bin filter=lfs diff=lfs merge=lfs -text
 drivers/e3c123a2ee4720001ed35d45fa1e57eb.bin filter=lfs diff=lfs merge=lfs -text
 drivers/887e6502a420acb183342c60c396b0e3.bin filter=lfs diff=lfs merge=lfs -text
+drivers/01d01adc1241c8f0a4caf6764439679c.bin filter=lfs diff=lfs merge=lfs -text
+drivers/9976ae79fb3887e0243dc159b2b68a48.bin filter=lfs diff=lfs merge=lfs -text
+drivers/180d0b565d76d7e47cc3c9a2901ac2ec.bin filter=lfs diff=lfs merge=lfs -text
+drivers/1ffa4841ee616cf49b4e439fe131f001.bin filter=lfs diff=lfs merge=lfs -text
+drivers/29a53ceac3376e0928a898779adb4c5a.bin filter=lfs diff=lfs merge=lfs -text
+drivers/567f0e5ba3865b0c3af7083ca02794d9.bin filter=lfs diff=lfs merge=lfs -text

--- a/detections/yara/other/yara-rules_mal_drivers_strict.yar
+++ b/detections/yara/other/yara-rules_mal_drivers_strict.yar
@@ -1,3 +1,20 @@
+rule MAL_Driver_501E {
+	meta:
+		description = "Detects malicious driver mentioned in LOLDrivers project using VersionInfo values from the PE header - kernel_utility_driver64.sys, kernel_utility_driver32.sys. Investigate matches in context: expected filenames or standard vendor/system driver locations can be lower priority, while unexpected filenames or paths are more suspicious."
+		author = "Florian Roth"
+		reference = "https://github.com/magicsword-io/LOLDrivers"
+		hash = "501ea082774f29adc752887402af6df0edf49bf7b3816b93f6e52c06a79685bc"
+		hash = "962fb670510807fd5cab3a6e6f886aeb2b925c42054c29fa02f67011be935954"
+		date = "2026-08-28"
+		score = 85
+	strings:
+		$ = { 460069006c006500560065007200730069006f006e00[1-8]31002c0035003000320036002c0031003000300030002c00310032003700 } /* FileVersion  */
+		$ = { 500072006f006400750063007400560065007200730069006f006e00[1-8]31002c0035003000320036002c0031003000300030002c00310032003700 } /* ProductVersion  */
+		$ = { 4c006500670061006c0043006f007000790072006900670068007400[1-8]48724367406209672000280043002900200032003000310030002d003200300032003600 } /* LegalCopyright C */
+	condition:
+		uint16(0) == 0x5a4d and filesize < 100KB and all of them
+}
+
 rule MAL_Driver_773B {
 	meta:
 		description = "Detects malicious driver mentioned in LOLDrivers project using VersionInfo values from the PE header - mimidrv.sys. Investigate matches in context: expected filenames or standard vendor/system driver locations can be lower priority, while unexpected filenames or paths are more suspicious."

--- a/detections/yara/yara-rules_mal_drivers.yar
+++ b/detections/yara/yara-rules_mal_drivers.yar
@@ -1,3 +1,20 @@
+rule MAL_Driver_501E {
+	meta:
+		description = "Detects malicious driver mentioned in LOLDrivers project using VersionInfo values from the PE header - kernel_utility_driver64.sys, kernel_utility_driver32.sys. Investigate matches in context: expected filenames or standard vendor/system driver locations can be lower priority, while unexpected filenames or paths are more suspicious."
+		author = "Florian Roth"
+		reference = "https://github.com/magicsword-io/LOLDrivers"
+		hash = "501ea082774f29adc752887402af6df0edf49bf7b3816b93f6e52c06a79685bc"
+		hash = "962fb670510807fd5cab3a6e6f886aeb2b925c42054c29fa02f67011be935954"
+		date = "2026-08-28"
+		score = 70
+	strings:
+		$ = { 460069006c006500560065007200730069006f006e00[1-8]31002c0035003000320036002c0031003000300030002c00310032003700 } /* FileVersion  */
+		$ = { 500072006f006400750063007400560065007200730069006f006e00[1-8]31002c0035003000320036002c0031003000300030002c00310032003700 } /* ProductVersion  */
+		$ = { 4c006500670061006c0043006f007000790072006900670068007400[1-8]48724367406209672000280043002900200032003000310030002d003200300032003600 } /* LegalCopyright C */
+	condition:
+		all of them
+}
+
 rule MAL_Driver_773B {
 	meta:
 		description = "Detects malicious driver mentioned in LOLDrivers project using VersionInfo values from the PE header - mimidrv.sys. Investigate matches in context: expected filenames or standard vendor/system driver locations can be lower priority, while unexpected filenames or paths are more suspicious."

--- a/drivers/01d01adc1241c8f0a4caf6764439679c.bin
+++ b/drivers/01d01adc1241c8f0a4caf6764439679c.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d1fd685dc98d0c193529df3ddde7144d839f56b7b38251fd7039c33c0fcf760
+size 215864

--- a/drivers/180d0b565d76d7e47cc3c9a2901ac2ec.bin
+++ b/drivers/180d0b565d76d7e47cc3c9a2901ac2ec.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:501ea082774f29adc752887402af6df0edf49bf7b3816b93f6e52c06a79685bc
+size 48688

--- a/drivers/1ffa4841ee616cf49b4e439fe131f001.bin
+++ b/drivers/1ffa4841ee616cf49b4e439fe131f001.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:962fb670510807fd5cab3a6e6f886aeb2b925c42054c29fa02f67011be935954
+size 42032

--- a/drivers/29a53ceac3376e0928a898779adb4c5a.bin
+++ b/drivers/29a53ceac3376e0928a898779adb4c5a.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d47e7f1c87d758d9e3f17d0d53634c454ee1785478a8c7de7f3c83ecd3d3896
+size 72384

--- a/drivers/567f0e5ba3865b0c3af7083ca02794d9.bin
+++ b/drivers/567f0e5ba3865b0c3af7083ca02794d9.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7504887e1e195ad585cffa5b6a5034161a7cc49f351123d60def79302bdb8326
+size 17744

--- a/drivers/9976ae79fb3887e0243dc159b2b68a48.bin
+++ b/drivers/9976ae79fb3887e0243dc159b2b68a48.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44cefb0b3b6516e6731de09a3e2e0eb8b98b02cc3fdf7bb4b22680e93f3cde1e
+size 212664

--- a/yaml/18935808-e00c-4b75-a7fc-03e409a7570e.yaml
+++ b/yaml/18935808-e00c-4b75-a7fc-03e409a7570e.yaml
@@ -21,6 +21,7 @@ Commands:
 Resources:
 - https://github.com/KOSEC-LLC/BYOVD-Research/tree/main/EnCase
 - https://www.bleepingcomputer.com/news/security/edr-killer-tool-uses-signed-kernel-driver-from-forensic-software/
+- https://www.catonetworks.com/blog/cato-ctrl-silverfox-evolves/
 Detection: []
 Acknowledgement:
   Person: KOSEC LLC

--- a/yaml/30e8d598-2c60-49e4-953b-a6f620da1371.yaml
+++ b/yaml/30e8d598-2c60-49e4-953b-a6f620da1371.yaml
@@ -23,6 +23,7 @@ Resources:
 - https://github.com/wesmar/kvcKiller
 - https://github.com/BlackSnufkin/BYOVD/tree/main/Wsftprm-Killer
 - https://www.security.com/threat-intelligence/dragonforce-msteams-backdoor
+- https://www.catonetworks.com/blog/cato-ctrl-silverfox-evolves/
 Detection: []
 Acknowledgement:
   Person: Northwave Cyber Security

--- a/yaml/399fb787-5b06-46f0-86cb-dff7374bb015.yaml
+++ b/yaml/399fb787-5b06-46f0-86cb-dff7374bb015.yaml
@@ -26,6 +26,7 @@ Commands:
   OperatingSystem: Windows 10
 Resources:
 - https://github.com/magicsword-io/LOLDrivers/issues/308
+- https://huorong.cn/document/info/classroom/2040
 Detection: []
 Acknowledgement:
   Person: Patrick Saif

--- a/yaml/7cc0a40d-7902-4400-9fc4-0070053991cb.yaml
+++ b/yaml/7cc0a40d-7902-4400-9fc4-0070053991cb.yaml
@@ -27,6 +27,7 @@ Commands:
 Resources:
 - https://medium.com/@jehadbudagga/phantom-killer-reverse-engineering-and-weaponizing-a-lenovo-driver-to-terminate-edr-processes-9191cd06374f
 - https://github.com/redteamfortress/PhantomKiller
+- https://www.catonetworks.com/blog/cato-ctrl-silverfox-evolves/
 Detection: []
 Acknowledgement:
   Person: Jehad Abudagga

--- a/yaml/84a3007a-de5e-4622-bfc5-f05d927c3618.yaml
+++ b/yaml/84a3007a-de5e-4622-bfc5-f05d927c3618.yaml
@@ -22,6 +22,7 @@ Resources:
 - https://www.esentire.com/blog/malware-as-a-service-cocktail-errtraffic-and-cruciferra-killing-your-edr-since-2025
 - https://github.com/magicsword-io/LOLDrivers/issues/412
 - https://x.com/YungBinary/status/2092812095456936172
+- https://www.elastic.co/security-labs/threat-command/dll-search-order-hijacking-elastic-defend
 Detection:
 - type: ''
   value: ''

--- a/yaml/89643454-e38b-41cb-853d-abf649a104a5.yaml
+++ b/yaml/89643454-e38b-41cb-853d-abf649a104a5.yaml
@@ -21,6 +21,7 @@ Commands:
 Resources:
 - https://www.esentire.com/blog/malware-as-a-service-cocktail-errtraffic-and-cruciferra-killing-your-edr-since-2025
 - https://github.com/magicsword-io/LOLDrivers/issues/412
+- https://www.elastic.co/security-labs/threat-command/dll-search-order-hijacking-elastic-defend
 Detection:
 - type: ''
   value: ''

--- a/yaml/96ba5e53-6a40-4813-b6f1-ccce31a883cf.yaml
+++ b/yaml/96ba5e53-6a40-4813-b6f1-ccce31a883cf.yaml
@@ -8,12 +8,13 @@ MitreID: T1562.001
 CVE: CVE-2026-3609
 Category: vulnerable driver
 Commands:
-  Command: sc.exe create xhunter1 binPath=C:\windows\temp\xhunter1.sys type=kernel
+  Command: sc.exe create xhunter1 binPath= C:\windows\temp\xhunter1.sys type= kernel
     && sc.exe start xhunter1
-  Description: Wellbia xhunter1.sys is an XIGNCODE3 anti-cheat kernel component documented
-    by BlackSnufkin BYOVD research as CVE-2026-3609. The legacy build exposes command
-    paths that can be abused to interfere with target process handles and terminate
-    protected security processes from kernel context.
+  Description: Wellbia xhunter1.sys is an XIGNCODE3 anti-cheat kernel component affected
+    by CVE-2026-3609 through version 2023.12.7.78. Public research demonstrates that
+    its unauthenticated command channel can expose protected-process handles, read
+    cross-process memory, terminate security processes, elevate privileges, and inject
+    code from kernel context.
   Usecase: Terminate protected processes by abusing vulnerable xhunter1 kernel command
     paths.
   Privileges: kernel
@@ -21,6 +22,9 @@ Commands:
 Resources:
 - https://github.com/BlackSnufkin/BYOVD/tree/main/Xhunter1-Killer
 - https://web.archive.org/web/20180820182619/https://x86.re/blog/xigncode3-xhunter1.sys-lpe/
+- https://blacksnufkin.github.io/posts/Hunting-the-Hunter/
+- https://github.com/BlackSnufkin/AxHunter
+- https://www.cve.org/CVERecord?id=CVE-2026-3609
 Detection: []
 Acknowledgement:
   Person: BlackSnufkin
@@ -245,4 +249,221 @@ KnownVulnerableSamples:
     - SerialNumber: 1734520c9aabc257a502ec5dbf615354
       Issuer: C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec
         Class 3 SHA256 Code Signing CA
+      Version: 1
+- Filename: xhunter1.sys
+  SHA256: 0d1fd685dc98d0c193529df3ddde7144d839f56b7b38251fd7039c33c0fcf760
+  MD5: 01d01adc1241c8f0a4caf6764439679c
+  SHA1: 722a040af40397626f701b7e02ef3a6715c8259a
+  Imphash: 1b6804e310b6be3b3a4fd962cf3e7973
+  Authentihash:
+    MD5: 1234fcf09d3fd5643e17eaab620a40dc
+    SHA1: bd42b25e6cb86e49c1ae0f6c563545c53b9c1c24
+    SHA256: 12d5000637d3894acd900082f22efd5aa2133b679b1cc145444493e25297f1ee
+  RichPEHeaderHash:
+    MD5: ''
+    SHA1: ''
+    SHA256: ''
+  Sections:
+    .text:
+      Entropy: 6.986480673253291
+      Virtual Size: '0xe268'
+    .rdata:
+      Entropy: 3.900119481609735
+      Virtual Size: '0xdecc'
+    .data:
+      Entropy: 5.15563439109634
+      Virtual Size: '0x4170'
+    .pdata:
+      Entropy: 7.948146327158821
+      Virtual Size: '0xcd8'
+    INIT:
+      Entropy: 5.420108420397148
+      Virtual Size: '0xdda'
+    .~<p:
+      Entropy: 6.180707284860365
+      Virtual Size: '0x880c'
+    .reloc:
+      Entropy: 4.366048869473065
+      Virtual Size: '0x74'
+    .rsrc:
+      Entropy: 3.614249470136539
+      Virtual Size: '0x43c'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2023-12-06 22:44:37'
+  Description: Wellbia.com System Guard
+  Company: Wellbia.com Co., Ltd.
+  InternalName: xhunter1.sys
+  OriginalFilename: xhunter1.sys
+  FileVersion: 2023.12.7.78
+  Product: Wellbia.com System Guard
+  ProductVersion: 2023.12.7.78
+  Copyright: Copyright (c) 2006-2023 Wellbia.com Co., Ltd.
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - RtlInitUnicodeString
+  - MmGetSystemRoutineAddress
+  - ZwClose
+  - ObOpenObjectByPointer
+  - ZwAllocateVirtualMemory
+  - ZwFreeVirtualMemory
+  - ZwWaitForSingleObject
+  - PsGetProcessSectionBaseAddress
+  - __C_specific_handler
+  - PsProcessType
+  - wcsrchr
+  - ExAllocatePoolWithTag
+  - ExFreePoolWithTag
+  - IoGetCurrentProcess
+  - ObfDereferenceObject
+  - ZwCreateFile
+  - ZwOpenFile
+  - ZwReadFile
+  - MmSecureVirtualMemory
+  - PsGetCurrentProcessId
+  - KeStackAttachProcess
+  - KeUnstackDetachProcess
+  - ObReferenceObjectByName
+  - ZwQueryInformationProcess
+  - ObSetHandleAttributes
+  - IoDriverObjectType
+  - KeReleaseMutex
+  - KeWaitForSingleObject
+  - MmIsAddressValid
+  - ObReferenceObjectByHandle
+  - PsLookupProcessByProcessId
+  - PsLookupThreadByThreadId
+  - IoThreadToProcess
+  - PsThreadType
+  - MmProbeAndLockPages
+  - MmUnlockPages
+  - MmMapLockedPagesSpecifyCache
+  - MmUnmapLockedPages
+  - IoAllocateMdl
+  - IoFreeMdl
+  - PsSetLoadImageNotifyRoutine
+  - PsRemoveLoadImageNotifyRoutine
+  - RtlCompareUnicodeString
+  - DbgPrint
+  - ZwQueryValueKey
+  - RtlPrefixUnicodeString
+  - PsGetProcessId
+  - KeEnterGuardedRegion
+  - KeLeaveGuardedRegion
+  - _stricmp
+  - MmProtectMdlSystemAddress
+  - ZwQuerySystemInformation
+  - KeInitializeEvent
+  - ExAcquireFastMutex
+  - ExReleaseFastMutex
+  - ZwOpenSection
+  - ZwMapViewOfSection
+  - ZwUnmapViewOfSection
+  - KeSetEvent
+  - ExQueryDepthSList
+  - ExpInterlockedPopEntrySList
+  - ExpInterlockedPushEntrySList
+  - ExInitializeNPagedLookasideList
+  - ExDeleteNPagedLookasideList
+  - IoCreateNotificationEvent
+  - _wcsnicmp
+  - RtlEqualUnicodeString
+  - KeInitializeMutex
+  - PsSetCreateProcessNotifyRoutine
+  - ProbeForRead
+  - ProbeForWrite
+  - ObfReferenceObject
+  - ZwQueryInformationFile
+  - ZwQueryVirtualMemory
+  - PsLookupProcessThreadByCid
+  - MmSystemRangeStart
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - ZwUnloadDriver
+  - RtlInitAnsiString
+  - RtlAnsiStringToUnicodeString
+  - PsGetVersion
+  - RtlFreeUnicodeString
+  - KeEnterCriticalRegion
+  - KeLeaveCriticalRegion
+  - RtlImageNtHeader
+  - ExAcquireResourceExclusiveLite
+  - ExReleaseResourceLite
+  - ZwOpenProcess
+  - ZwDuplicateObject
+  - PsAcquireProcessExitSynchronization
+  - PsReleaseProcessExitSynchronization
+  - PsGetProcessImageFileName
+  - PsIsSystemProcess
+  - strcmp
+  - PsInitialSystemProcess
+  - PsSetCreateProcessNotifyRoutineEx
+  - RtlEnumerateGenericTableAvl
+  - ExAcquireSpinLockExclusive
+  - ExReleaseSpinLockExclusive
+  - KeBugCheckEx
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=KR, ST=Seoul, L=Geumcheon,gu, O=Wellbia.com Co., Ltd., CN=Wellbia.com
+        Co., Ltd.
+      ValidFrom: '2020-11-26 00:00:00'
+      ValidTo: '2024-01-25 23:59:59'
+      Signature: 29057a5fec92750f630004359b28348e9001f77f3a2e446e2dc67cdf83efa035737ace5939b0ff088d21445b884fab8808aaa044f2652f4173d28c021e8c53963cdcb6e4b20f30bd7881dc2a0cf72ab658f71c5ce1278b8a0880f4ffa8ff00cf79b0c18bd5275f8e9e50695a799078d13240c87285b92e09494c5a5bdc5208d04c9ad150f7acb3d7f878a8550abd83e17602c16e243273f0b931fe5f5768535d52f60d3781e3a76b3ac37f4a4eccd42b76e386afd0d0fc57c65ad96d8ced88f43dbd39346fad2bed430be6a135f195286c01159d4eb025d53878627c6097aa81372e1efa0ec21a0d797020fb048e50701fe40db741e84cff2234d5991000d4fc
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0c067d0f436427b359b7a6babd673873
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 49b9bd0cbef7207f21058c8b87469b17
+        SHA1: 5df3b2527bcc229063f5bdc434ae5e81f7e4e9d3
+        SHA256: e8063d72e3e59d980203cc5eb5baef3e0f11f61ad8b02130a3675b9e2f8f487e
+        SHA384: 65006234caebd0bc663cc44e765acfe2012715f3ca6bf36c5b8a8279cc2408efa1520db7601335caece2c1c6a886a290
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root
+        CA
+      ValidFrom: '2011-04-15 19:41:37'
+      ValidTo: '2021-04-15 19:51:37'
+      Signature: 5cf5b22d02ceed01b53512d813f7aa4014c7a15ca08a55ed7e55ea6ac457176fd04722423658efc5ac61c5f62c52ce6ae6c80d85dab334420ea40225182672b92a4ea57e4b16f2a0e40c449ce24d9af474f0f927a6699031c244654348c74869d0fc8409f286140ac22996857f11eb8713176ed3ec6bff1d578ab17b1ea5a07ce9a27a68e5fac6b161d67263fa379163835599f81d614f0c6fa3f7bcb1152acc8d85e31417ef7e49443fb022c0f0acbe2fdbe10c86b0f4585c5a10a94bcdf3448a4652083e0a6210e9459504b78b8d4b074f500db7bbe7fb8ca27878c6c53b7663b2cfe521845a66fce04c79834ecfa8ee700586587cc29cd73ca3ad3c7e76625c87d0ed7cd5c55b1421f4be75a275d2e9e15ad020307841624d6b5e6e1b1710244ad8588775d015d762bbfd185665842561977faad49df4f35d6da031c2e19e02ac3e90c3327ee832903416d08b14cf95accee58c54a265b8bfed186a57073ed3e79a4a2f081a041c49871a8ae61b08a365d81c31c50d9cbab368ddf45076160675fec403e7d13edfdc862e10027e661296534e7af3365879b12042d8963f35be3f8ef2999743f5e40ce13c68728c8d49d75a52b573fb7a35943a61b08482c04885c19732d39b725fa0d2348f7ef0467cf28c7294c707b0d7b5b230b81965f09c8327b0a0abd0a2727e050fb3aeddb95b9b42bcc32663456b86f11d4643edc8
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 611cb28a000000000026
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 983a0c315a50542362f2bd6a5d71c8d0
+        SHA1: 8047f476001f5cb16a661d2a3fd0c3576168f5e2
+        SHA256: 5f6a519ed2e35cd0fa1cdfc90f4387162c36287bbf9e4d6648251d99542a9e83
+        SHA384: 5f014b60511ddab3247ef0b3c03fe82c622237ba76015e2911d1adc50dc632d56ebd1ee532f3c2b6cbfe68d80a2c91dc
+    - Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Code
+        Signing CA,1
+      ValidFrom: '2011-02-11 12:00:00'
+      ValidTo: '2026-02-10 12:00:00'
+      Signature: 7b721d64ff88c83ac1b7e9e7a9c487bbdb9492d7905933fa2b87dea85b80253f138f9b831b7c43c4e68cdf393ec315ecb0da3b21257b24c1725db84791811346fa9c3f6a5138deb425cbf0abdfc528015479104624d1380f26a161904dbabd28e63ff1c4aa9bf6da35534fc9f23dd36cdc23edaaa04d6709f33a803d3cfb364c90e776a4ddf23abf56352fa24c65e8e0d4dad1c7c8916a2d234f373b199418d4d59c103cd5b11c19ff8fc86b9b9ef8ae9c999678d1cd9c51155b4226725a8d0a4a239240e886de22c2933ad49b68a6df297f06b93c0ebd9fc4869c82474271328609997209794b9d7169f541ff7f397764f1848dbe8b1eb27d68a3a590b10cff
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 0fa8490615d700a0be2176fdc5ec6dbd
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: a9a31555bbc92b6033975c5428fb3679
+        SHA1: 47f4b9898631773231b32844ec0d49990ac4eb1e
+        SHA256: c826846e4b1d73edb7561ab1b41c949354e237a91e82fe1be5b7e2e1701f52d1
+        SHA384: 86f49574f368a561914a52d7ae043ec6784ef8c718960700f834e123594605d25d39f1ad45f1eb5052c9567f3edd0e16
+    Signer:
+    - SerialNumber: 0c067d0f436427b359b7a6babd673873
+      Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Code
+        Signing CA,1
       Version: 1

--- a/yaml/9eb0156e-4c43-487f-be8c-40a7b19a4279.yaml
+++ b/yaml/9eb0156e-4c43-487f-be8c-40a7b19a4279.yaml
@@ -9,14 +9,16 @@ CVE:
 - CVE-2026-36425
 Category: vulnerable driver
 Commands:
-  Command: sc.exe create ardrv binPath=C:\windows\temp\ardrv.sys type=kernel && sc.exe
+  Command: sc.exe create ardrv binPath= C:\windows\temp\ardrv.sys type= kernel && sc.exe
     start ardrv
   Description: OPSWAT AppRemover ardrv.sys version 2017.10.02.1551 and earlier exposes
     a user-accessible \\.\ardrv device. Public research documents IOCTL 0x2420031
     reaching process-termination paths, including ZwTerminateProcess, without sufficient
     caller or target validation. This allows local users to terminate arbitrary processes,
     including security tooling, and makes the driver useful in BYOVD-style defense
-    impairment after it is loaded.
+    impairment after it is loaded. Acronis observed the tracked ardrv.sys variant
+    in an August 2026 campaign where it was used to terminate Microsoft Defender,
+    Huorong, and Tencent security processes before SparkRAT deployment.
   Usecase: Terminate arbitrary processes from kernel mode through an insufficiently
     protected IOCTL handler.
   Privileges: kernel
@@ -24,6 +26,7 @@ Commands:
 Resources:
 - https://github.com/redteamfortress/CVE-2026-36425
 - https://github.com/magicsword-io/LOLDrivers/issues/374
+- https://www.acronis.com/en/tru/posts/cambodia-focused-cluster-uses-multi-stage-infection-chain-with-localized-lures/
 Detection: []
 Acknowledgement:
   Person: Jehad Abudagga, wwwab
@@ -34,6 +37,178 @@ KnownVulnerableSamples:
   SHA1: 7340eae2ccf3d57ac3ae271c9983996d8ae7fde0
   SHA256: 07c5209bf83065fe760f4fee4ed2308b0c523671f68ca73a3854c2c8c28c0541
   LoadsDespiteHVCI: 'TRUE'
+  Imphash: 04becf2aed91570c44993f040922303d
+  Authentihash:
+    MD5: 68b2bff40bed9106fe7d684926fae2cc
+    SHA1: cf52d28e919f5034a2d206491742ab21df16e0d4
+    SHA256: c23b96fdf13b405480bbcd2e611cc67d98fd92f92cd2444da73fd8c4a4770393
+  RichPEHeaderHash:
+    MD5: 3b6934b997e6bdf8c7a22007105b190d
+    SHA1: b437f306b8f280d2bc9f878e94cd1d5ed804fdac
+    SHA256: 9e822696e56f37827e85e7bd4934cfdbba5aa80da654025b29bffaa3c028ffd0
+  Sections:
+    .text:
+      Entropy: 5.9269739323177415
+      Virtual Size: '0xeed'
+    .rdata:
+      Entropy: 4.050036833496202
+      Virtual Size: '0x224'
+    .data:
+      Entropy: 0.5159719988134768
+      Virtual Size: '0x110'
+    .pdata:
+      Entropy: 3.5459473662913776
+      Virtual Size: '0x9c'
+    INIT:
+      Entropy: 5.158608395501925
+      Virtual Size: '0x440'
+    .rsrc:
+      Entropy: 3.340466534342975
+      Virtual Size: '0x360'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2017-10-02 16:52:04'
+  Description: AppRemover Driver
+  Company: OPSWAT, Inc.
+  InternalName: ardrv.sys
+  OriginalFilename: ardrv.sys
+  FileVersion: 2017.10.02.1551
+  Product: AppRemover Driver
+  ProductVersion: 4.3.2.1
+  Copyright: " \xA9 OPSWAT, Inc.  All rights reserved."
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - IoDeleteSymbolicLink
+  - RtlInitUnicodeString
+  - IoDeleteDevice
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - IoCreateDevice
+  - DbgPrint
+  - ZwAssignProcessToJobObject
+  - PsLookupProcessByProcessId
+  - ProbeForWrite
+  - IoCreateFile
+  - ZwSetValueKey
+  - ZwSetInformationFile
+  - KeDetachProcess
+  - IoFileObjectType
+  - ZwClose
+  - ZwCreateJobObject
+  - ObReferenceObjectByHandle
+  - ZwFlushKey
+  - KeAttachProcess
+  - MmIsAddressValid
+  - ObfDereferenceObject
+  - ZwTerminateProcess
+  - ZwQueryInformationFile
+  - ObOpenObjectByPointer
+  - FsRtlReleaseFile
+  - FsRtlAcquireFileExclusive
+  - ZwTerminateJobObject
+  - ZwOpenKey
+  - KeBugCheckEx
+  - __C_specific_handler
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services CA
+        , G2
+      ValidFrom: '2012-12-21 00:00:00'
+      ValidTo: '2020-12-30 23:59:59'
+      Signature: 03099b8f79ef7f5930aaef68b5fae3091dbb4f82065d375fa6529f168dea1c9209446ef56deb587c30e8f9698d23730b126f47a9ae3911f82ab19bb01ac38eeb599600adce0c4db2d031a6085c2a7afce27a1d574ca86518e979406225966ec7c7376a8321088e41eaddd9573f1d7749872a16065ea6386a2212a35119837eb6
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 7e93ebfb7cc64e59ea4b9a77d406fc3b
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: d0785ad36e427c92b19f6826ab1e8020
+        SHA1: 365b7a9c21bd9373e49052c3e7b3e4646ddd4d43
+        SHA256: c2abb7484da91a658548de089d52436175fdb760a1387d225611dc0613a1e2ff
+        SHA384: eab4fe5ef90e0de4a6aa3a27769a5e879f588df5e4785aa4104debd1f81e19ea56d33e3a16e5facf99f68b5d8e3d287b
+    - Subject: C=US, O=Symantec Corporation, CN=Symantec Time Stamping Services Signer
+        , G4
+      ValidFrom: '2012-10-18 00:00:00'
+      ValidTo: '2020-12-29 23:59:59'
+      Signature: 783bb4912a004cf08f62303778a38427076f18b2de25dca0d49403aa864e259f9a40031cddcee379cb216806dab632b46dbff42c266333e449646d0de6c3670ef705a4356c7c8916c6e9b2dfb2e9dd20c6710fcd9574dcb65cdebd371f4378e678b5cd280420a3aaf14bc48829910e80d111fcdd5c766e4f5e0e4546416e0db0ea389ab13ada097110fc1c79b4807bac69f4fd9cb60c162bf17f5b093d9b5be216ca13816d002e380da8298f2ce1b2f45aa901af159c2c2f491bdb22bbc3fe789451c386b182885df03db451a179332b2e7bb9dc20091371eb6a195bcfe8a530572c89493fb9cf7fc9bf3e226863539abd6974acc51d3c7f92e0c3bc1cd80475
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: false
+      SerialNumber: 0ecff438c8febf356e04d86a981b1a50
+      Version: 3
+      CertificateType: Intermediate
+      IsCodeSigning: false
+      IsCA: false
+      TBS:
+        MD5: e9d38360b914c8863f6cba3ee58764d3
+        SHA1: 4cba8eae47b6bf76f20b3504b98b8f062694a89b
+        SHA256: 88901d86a4cc1f1bb193d08e1fb63d27452e63f83e228c657ab1a92e4ade3976
+        SHA384: e9f2a75334a9e336c5a4712eadee88d0374b0fdc273262f4e65c9040ad2793067cc076696db5279a478773485e285652
+    - Subject: C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec
+        Class 3 SHA256 Code Signing CA
+      ValidFrom: '2013-12-10 00:00:00'
+      ValidTo: '2023-12-09 23:59:59'
+      Signature: 13851a1e69a937f7a0bda4af7e1d6153fe9d8c5e0ca6751e781723ddfdec1a035539fb7195c7655aa78e30d2445a61db706fda2105c22e73ba49f1d193fe5dc9cd5e03e0899e3f741ed7f7388ba9d6cfbb352f3358a89256d1c84d3b82e6798416fc28b0b147f31da23eee87d9a67fa456a53fad842e29de7cbca8aaa33d0401eaba93a20e502229174c87e43a115fd6a425899b056b2fb4c9014c277b0bac190522a060153fdac9fb4d4c8ffb726777fd2794c7ba350e8849fe8dfd28af4a12bd0db39705de440c15fa362b03dcc15001f1a1115d14e5e2bd274b54be2b845e0fa6c374050aef97c38922b11f77f3bdcd43d4f14ca93fb58b84af64f2d01421
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 3d78d7f9764960b2617df4f01eca862a
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 1f056ff7d5f874984dc605402b7cb042
+        SHA1: bdb348353a2203deb4b767914fa1bd7248dd728b
+        SHA256: a08e79c386083d875014c409c13d144e0a24386132980df11ff59737c8489eb1
+        SHA384: fa2729064b49e0d77540c1ee95d5f74acaf8eaf55197851a3a40383335f8113e51190bc48b552196edf8ac5cf0c89278
+    - Subject: C=US, O=VeriSign, Inc., OU=VeriSign Trust Network, OU=(c) 2006 VeriSign,
+        Inc. , For authorized use only, CN=VeriSign Class 3 Public Primary Certification
+        Authority , G5
+      ValidFrom: '2011-02-22 19:25:17'
+      ValidTo: '2021-02-22 19:35:17'
+      Signature: 812a82168c34672be503eb347b8ca2a3508af45586f11e8c8eae7dee0319ce72951848ad6211fd20fd3f4706015ae2e06f8c152c4e3c6a506c0b36a3cf7a0d9c42bc5cf819d560e369e6e22341678c6883762b8f93a32ab57fbe59fba9c9b2268fcaa2f3821b983e919527978661ee5b5d076bcd86a8e26580a8e215e2b2be23056aba0cf347934daca48c077939c061123a050d89a3ec9f578984fbecca7c47661491d8b60f195de6b84aacbc47c8714396e63220a5dc7786fd3ce38b71db7b9b03fcb71d3264eb1652a043a3fa2ead59924e7cc7f233424838513a7c38c71b242228401e1a461f17db18f7f027356cb863d9cdb9645d2ba55eefc629b4f2c7f821cc04ba57fd01b6abc667f9e7d3997ff4f522fa72f5fdff3a1c423aa1f98018a5ee8d1cd4669e4501feaaeefffb178f30f7f1cd29c59decb5d549003d85b8cbbb933a276a49c030ae66c9f723283276f9a48356c848ce5a96aaa0cc0cc47fb48e97af6de35427c39f86c0d6e473089705dbd054625e0348c2d59f7fa7668cd09db04fd4d3985f4b7ac97fb22952d01280c70f54b61e67cdc6a06c110384d34875e72afeb03b6e0a3aa66b769905a3f177686133144706fc537f52bd92145c4a246a678caf8d90aad0f679211b93267cc3ce1ebd883892ae45c6196a4950b305f8ae59378a6a250394b1598150e8ba8380b72335f476b9671d5918ad208d94
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.5
+      IsCertificateAuthority: true
+      SerialNumber: 611993e400000000001c
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 78a717e082dcc1cda3458d917e677d14
+        SHA1: 4a872e0e51f9b304469cd1dedb496ee9b8b983a4
+        SHA256: 317fa1d234ebc49040ebc5e8746f8997471496051b185a91bdd9dfbb23fab5f8
+        SHA384: b71052da4eb9157c8c1a5d7f55df19d69b9128598b72fcca608e5b7cc7d64c43c5504b9c86355a6dc22ee40c88cc385c
+    - Subject: C=US, ST=California, L=San Francisco, O=OPSWAT, Inc., CN=OPSWAT, Inc.
+      ValidFrom: '2015-06-02 00:00:00'
+      ValidTo: '2018-08-31 23:59:59'
+      Signature: 00b224b0896ac046b130e7a9af612e0c92ce6fa6f465ae4b5dc422432d880c3ef15357c56c0db528c8ca2055263c8a3857988ce32dcc13e1578b0493d6dec39d734547eef1e37a3ac334ba5979ae0b5ab7b2c8d75323076d8cd50b68fbb8c5e47e95d359b9a4be08ba4ada34eb70f4a27ed9b4d285e285c338d19f2ef15321301b9337bfa3549e16a189aa28af9e96bff5c1b083a57e89259c9a369f72dc312db3a04334a099006c54279a7ca199b2c94a79f198def484fbf7cb8f9d8cd6df8bcf97c33c79991ed92ac2080db67741aabfa7bc41fd426fc06f2c5f0594471245777401d169c91355784699b8f1b61eb857835083c4755b8244774b231fd19610
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 1ca9cc01747a11b1eaaf103c8d9a9e6c
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 222b2be1297ccd28fe05de06d1d9254f
+        SHA1: 47a67d8afd2c756e021a6547e66e4928ba32f53a
+        SHA256: 1eb2656b465452860774b29579998a45ffe61caebf4e77dc4fbf1bbdffb41340
+        SHA384: 3cba4aa32bfb91c8eedf6933c3e6e9dcc5a11b257fe2f71f790f2cd3db65a7e6cd865ef3e1b31b82af4a328433a4a663
+    Signer:
+    - SerialNumber: 1ca9cc01747a11b1eaaf103c8d9a9e6c
+      Issuer: C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec
+        Class 3 SHA256 Code Signing CA
+      Version: 1
+- Filename: ardrv.sys
+  SHA256: 7504887e1e195ad585cffa5b6a5034161a7cc49f351123d60def79302bdb8326
+  MD5: 567f0e5ba3865b0c3af7083ca02794d9
+  SHA1: 4efb248e4330ead57850ed81f249c54af783e88b
   Imphash: 04becf2aed91570c44993f040922303d
   Authentihash:
     MD5: 68b2bff40bed9106fe7d684926fae2cc

--- a/yaml/b1f406cd-117a-45bb-97db-3f9ecb44f70d.yaml
+++ b/yaml/b1f406cd-117a-45bb-97db-3f9ecb44f70d.yaml
@@ -1,0 +1,236 @@
+Id: b1f406cd-117a-45bb-97db-3f9ecb44f70d
+Tags:
+- sxav64-v1.5.1.sys
+- sxav.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-08-28'
+MitreID: T1562.001
+CVE:
+- ''
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create Sxav binPath= C:\windows\temp\sxav64-v1.5.1.sys type= kernel
+    start= system
+  Description: The signed SXClient sxav.sys security driver processes an SXBOOTDB
+    boot configuration whose integrity is protected only by an unkeyed MD5 digest.
+    Public research demonstrates that an administrator can generate a valid configuration
+    containing arbitrary absolute paths, point the service to it, and have the kernel
+    driver delete those files during the next boot. The primitive can be abused to
+    remove security-product files that are otherwise locked while Windows is running.
+  Usecase: Delete protected antivirus or EDR files during system boot using an attacker-generated
+    boot configuration.
+  Privileges: kernel
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://github.com/wwwab123/Sxav_ZwDeleteFile_BYOVD
+Detection: []
+Acknowledgement:
+  Person: wwwab
+  Handle: '@wwwab123'
+KnownVulnerableSamples:
+- Filename: sxav64-v1.5.1.sys
+  SHA256: 4d47e7f1c87d758d9e3f17d0d53634c454ee1785478a8c7de7f3c83ecd3d3896
+  MD5: 29a53ceac3376e0928a898779adb4c5a
+  SHA1: 77488e805d266aa1968842b4698565bb4fd8c36c
+  Imphash: 044f125cfa7e2697826082f8d5501ccf
+  Authentihash:
+    MD5: 82a5166a8b7710ea462b6b6b686ec5d6
+    SHA1: 6f5b769888b5989990478d34d16b120adf50e27c
+    SHA256: 9c246d9c611383dc1b32fda185322629aedc8527bd831ebfe41f5f92b1332070
+  RichPEHeaderHash:
+    MD5: 7d12388578802e8f1f5eb4af8c23f5d0
+    SHA1: ef8f667e744c231ffcd0efaa9d024451357e13ba
+    SHA256: 36cd35cb00b81a2ebd9cb7d5d84c5dc0e06a30c0f0662d990fb3fb442ed95117
+  Sections:
+    .text:
+      Entropy: 6.404075280062686
+      Virtual Size: '0xafad'
+    .rdata:
+      Entropy: 4.7686252088929235
+      Virtual Size: '0x1a90'
+    .data:
+      Entropy: 2.5508895067895754
+      Virtual Size: '0xe40'
+    .pdata:
+      Entropy: 4.472811878008731
+      Virtual Size: '0x570'
+    INIT:
+      Entropy: 5.227893705577557
+      Virtual Size: '0xe5a'
+    .rsrc:
+      Entropy: 3.631466010424983
+      Virtual Size: '0x340'
+    .reloc:
+      Entropy: 4.837029625833363
+      Virtual Size: '0x118'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2026-06-30 02:45:56'
+  Description: "\u77AC\u7280\u5B89\u5168\u9632\u75C5\u6BD2\u8F6F\u4EF6"
+  Company: "\u6CB3\u5357\u5BD2\u9732\u7535\u5B50\u79D1\u6280\u6709\u9650\u516C\u53F8"
+  InternalName: sxav.sys
+  OriginalFilename: sxav.sys
+  FileVersion: 3.0.0.2
+  Product: "\u77AC\u7280\u5B89\u5168"
+  ProductVersion: 3.0.0.2
+  Copyright: "Copyright (C) \u6CB3\u5357\u5BD2\u9732\u7535\u5B50\u79D1\u6280\u6709\
+    \u9650\u516C\u53F8. All rights reserved."
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  - FLTMGR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ZwFlushBuffersFile
+  - ExAcquireFastMutex
+  - ExReleaseFastMutex
+  - MmUnlockPages
+  - IofCompleteRequest
+  - IoFreeMdl
+  - ProbeForRead
+  - __C_specific_handler
+  - ZwSetInformationFile
+  - RtlWriteRegistryValue
+  - RtlCreateRegistryKey
+  - ExGetPreviousMode
+  - MmAllocateContiguousMemory
+  - MmFreeContiguousMemory
+  - IoBuildDeviceIoControlRequest
+  - IofCallDriver
+  - IoGetTopLevelIrp
+  - IoAllocateWorkItem
+  - IoFreeWorkItem
+  - IoQueueWorkItem
+  - ObfDereferenceObject
+  - PsGetCurrentProcessId
+  - IoVolumeDeviceToDosName
+  - _vsnwprintf
+  - MmMapLockedPagesSpecifyCache
+  - IoCsqInsertIrp
+  - IoCsqRemoveNextIrp
+  - KeAreApcsDisabled
+  - ZwDeleteFile
+  - MmProbeAndLockPages
+  - IoAllocateMdl
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoGetCurrentProcess
+  - IoRegisterShutdownNotification
+  - IoUnregisterShutdownNotification
+  - IoCsqInitialize
+  - ZwOpenFile
+  - PsSetCreateProcessNotifyRoutineEx
+  - KeStackAttachProcess
+  - KeUnstackDetachProcess
+  - PsLookupProcessByProcessId
+  - IoQueryFileDosDeviceName
+  - PsReferenceProcessFilePointer
+  - InitSafeBootMode
+  - RtlFreeUnicodeString
+  - RtlStringFromGUID
+  - ExUuidCreate
+  - ZwDeviceIoControlFile
+  - RtlInitializeGenericTable
+  - RtlInsertElementGenericTable
+  - RtlDeleteElementGenericTable
+  - RtlLookupElementGenericTable
+  - RtlEnumerateGenericTable
+  - KeBugCheckEx
+  - ZwReadFile
+  - ZwWriteFile
+  - ZwClose
+  - ZwQueryInformationFile
+  - ZwCreateFile
+  - IoGetBootDiskInformation
+  - RtlQueryRegistryValues
+  - RtlInitUnicodeString
+  - _wcsnicmp
+  - _wcsicmp
+  - ZwWaitForSingleObject
+  - PsTerminateSystemThread
+  - PsCreateSystemThread
+  - ExDeleteResourceLite
+  - ExReleaseResourceLite
+  - ExAcquireResourceExclusiveLite
+  - ExInitializeResourceLite
+  - ExFreePoolWithTag
+  - ExAllocatePoolWithTag
+  - KeWaitForSingleObject
+  - KeLeaveCriticalRegion
+  - KeEnterCriticalRegion
+  - KeDelayExecutionThread
+  - KeSetEvent
+  - KeInitializeEvent
+  - ProbeForWrite
+  - DbgPrintEx
+  - KeQueryPerformanceCounter
+  - FltFreeSecurityDescriptor
+  - FltBuildDefaultSecurityDescriptor
+  - FltSendMessage
+  - FltCloseCommunicationPort
+  - FltCreateCommunicationPort
+  - FltGetDiskDeviceObject
+  - FltReleaseContext
+  - FltGetStreamContext
+  - FltGetVolumeContext
+  - FltDeleteStreamContext
+  - FltSetStreamContext
+  - FltSetVolumeContext
+  - FltAllocateContext
+  - FltReadFile
+  - FltIsDirectory
+  - FltGetDestinationFileNameInformation
+  - FltParseFileNameInformation
+  - FltReleaseFileNameInformation
+  - FltGetFileNameInformation
+  - FltStartFiltering
+  - FltUnregisterFilter
+  - FltRegisterFilter
+  - FltSetCallbackDataDirty
+  - FltGetRequestorProcessId
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2026-05-13 18:17:34'
+      ValidTo: '2027-05-11 18:17:34'
+      Signature: 93cc2199d0389421a76807d521fdadd3ebc78db57beeabbfe80fef4ceca91861d30b11e74b6cc50b2d3082224b1c0d03c25153db795b52597215c29e7a85d8642fd16b1271d0c6766643583909ca9d6bc0f65ab21a3f82eb72a9f21ed72d229d960aa4b9995784837073fe28463c4d7ed553734eea8664c79f76d81dd2777d747d172182f62260b778ec9b0efacfbff430be868acff311f1f0700d547a3ccc37ecce1776332c3b679ac4c2e4ec2183144084886165856aff226ba6bff25b31757362be5a8687435c4c70e61d3fd33551a2315197238d76174943e4c2bfe2ac9198ee8116072aeb79a2f90f463d5e35f367c41604a2984d8e9da549c6f472be1aac6659574afa3cc12a5d4768faf08a945952b9b23dcff0e8d131c07366d18a95b04b12f454fb2dbea85f616e050e487c909a4d1cda95172dcc304306b699768375d0f3e1caf5f03db1975f6b7aa6e77588176027fb2d0b9b56b93249d19cca92528a4eedd85054f2b6f4f266f7b81b50510f4b58c3b2e733cb6999567fdf6b8c41e7667c899b4098b3b9cb18dde8e0a4a0a41aa83c27ca107f4440c6650ce21ea4ced7d43c72ab560240a0d0a2c68a24194c847eeaeb4c9b49bd5a69510b24c95c369604b0a3e241ef95389066b6cf139340d91b46b798615eb051d1adad8f9a2cad2cab64db5b9177ecc9aa0737c87f20084bd38e626195c13005cb185fb357
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 33000000849686aedfb4b66376000000000084
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 9fe699b3ab2f27e4f2aa6fcaca729d23
+        SHA1: be806effbdd84c713d2286ad1d79e5601c0a9b07
+        SHA256: 04894d613d22d6af2d76b7f319073c187bee05eee27fd167a050076fb2009d45
+        SHA384: fa1eb815b52f12434ab15fef34ae98bf077130fb31f022b93f999863606c7d1acc77ee05b6df2e7808487562bccbae8b
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      ValidFrom: '2014-10-15 20:31:27'
+      ValidTo: '2029-10-15 20:41:27'
+      Signature: 96b5c33b31f27b6ba11f59dd742c3764b1bca093f9f33347e9f95df21d89f4579ee33f10a3595018053b142941b6a70e5b81a2ccbd8442c1c4bed184c2c4bd0c8c47bcbd8886fb5a0896ae2c2fdfbf9366a32b20ca848a6945273f732332936a23e9fffdd918edceffbd6b41738d579cf8b46d499805e6a335a9f07e6e86c06ba8086725afc0998cdba7064d4093188ba959e69914b912178144ac57c3ae8eae947bcb3b8edd7ab4715bba2bc3c7d085234b371277a54a2f7f1ab763b94459ed9230cce47c099212111f52f51e0291a4d7d7e58f8047ff189b7fd19c0671dcf376197790d52a0fbc6c12c4c50c2066f50e2f5093d8cafb7fe556ed09d8a753b1c72a6978dcf05fe74b20b6af63b5e1b15c804e9c7aa91d4df72846782106954d32dd6042e4b61ac4f24636de357302c1b5e55fb92b59457a9243d7c4e963dd368f76c728caa8441be8321a66cde5485c4a0a602b469206609698dcd933d721777f886dac4772daa2466eab64682bd24e98fb35cc7fec3f136d11e5db77edc1c37e1f6a4a14f8b4a721c671866770cdd819a35d1fa09b9a7cc55d4d728e74077fa74d00fcdd682412772a557527cda92c1d8e7c19ee692c9f7425338208db38cc7cc74f6c3a6bc237117872fe55596460333e2edfc42de72cd7fb0a82256fb8d70c84a5e1c4746e2a95329ea0fecdb4188fd33bad32b2b19ab86d0543fbff0d0f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 330000000d690d5d7893d076df00000000000d
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 83f69422963f11c3c340b81712eef319
+        SHA1: 0c5e5f24590b53bc291e28583acb78e5adc95601
+        SHA256: d8be9e4d9074088ef818bc6f6fb64955e90378b2754155126feebbbd969cf0ae
+        SHA384: 260ad59ba706420f68ba212931153bd89f760c464b21be55fba9d014fff322407859d4ebfb78ea9a3330f60dc9821a63
+    Signer:
+    - SerialNumber: 33000000849686aedfb4b66376000000000084
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      Version: 1

--- a/yaml/c7f94129-f95f-4848-b1ab-68aae24275e7.yaml
+++ b/yaml/c7f94129-f95f-4848-b1ab-68aae24275e7.yaml
@@ -1,0 +1,333 @@
+Id: c7f94129-f95f-4848-b1ab-68aae24275e7
+Tags:
+- kernel_utility_driver64.sys
+- kernel_utility_driver32.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-08-28'
+MitreID: T1562.001
+CVE:
+- ''
+Category: malicious
+Commands:
+  Command: sc.exe create kernel_utility_driver binPath= C:\windows\temp\kernel_utility_driver64.sys
+    type= kernel && sc.exe start kernel_utility_driver
+  Description: Huorong Security identified these WHCP-signed kernel drivers in Vaultify
+    rogueware. After a challenge-response exchange, the driver accepts a target driver
+    name and removes process-creation callbacks registered by that driver. This strips
+    callback-based antivirus and EDR visibility from kernel context. Public analysis
+    reproduced the behavior in both the 32-bit and 64-bit builds.
+  Usecase: Remove process-creation callbacks registered by antivirus and EDR drivers.
+  Privileges: kernel
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/398
+- https://bbs.huorong.cn/thread-163244-1-1.html
+- https://github.com/wwwab123/Tjbxld_Drv_CreateProcessCallbacksKiller_BYOVD
+Detection: []
+Acknowledgement:
+  Person: wwwab
+  Handle: '@wwwab123'
+KnownVulnerableSamples:
+- Filename: kernel_utility_driver64.sys
+  SHA256: 501ea082774f29adc752887402af6df0edf49bf7b3816b93f6e52c06a79685bc
+  MD5: 180d0b565d76d7e47cc3c9a2901ac2ec
+  SHA1: e11e7ee8824e45c25ab638fec6d6e7d4ab89cffa
+  Imphash: df691992834a38d3116d3b2a5bd39e29
+  Authentihash:
+    MD5: 1aec6940e814dadb6b348bd31ef12e2e
+    SHA1: b88989e61d2de030376b546c400ac6f57a6ada66
+    SHA256: 52b2a30279b3849123e5eb42ab883372aa807c67b7ffb7f221e6e052ad29e8dc
+  RichPEHeaderHash:
+    MD5: ca8ee7be3d7c20b569d8e9447e6a1f1d
+    SHA1: 310acb44aad2c5ccf4ea62e003d5a8f56b76031d
+    SHA256: 599d4960a09a811950b974a93f4958564382b9a9fde0d9b37dd4eea2315d47f9
+  Sections:
+    .text:
+      Entropy: 6.3019026296233625
+      Virtual Size: '0x2ed6'
+    .rdata:
+      Entropy: 4.32488505979853
+      Virtual Size: '0x21d4'
+    .data:
+      Entropy: 7.31606413508129
+      Virtual Size: '0x2798'
+    .pdata:
+      Entropy: 4.278046747819361
+      Virtual Size: '0x378'
+    PAGE:
+      Entropy: 6.224765622209708
+      Virtual Size: '0x1bab'
+    INIT:
+      Entropy: 5.16198034059504
+      Virtual Size: '0x700'
+    .rsrc:
+      Entropy: 3.3095266931685723
+      Virtual Size: '0x2f0'
+    .reloc:
+      Entropy: 3.5248991724076317
+      Virtual Size: '0x40'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2026-02-25 02:41:12'
+  Description: ''
+  Company: ''
+  InternalName: ''
+  OriginalFilename: ''
+  FileVersion: 1,5026,1000,127
+  Product: ''
+  ProductVersion: 1,5026,1000,127
+  Copyright: "\u7248\u6743\u6240\u6709 (C) 2010-2026"
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - RtlRandomEx
+  - RtlInitUnicodeString
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - _vsnwprintf
+  - IofCompleteRequest
+  - MmGetSystemRoutineAddress
+  - MmIsAddressValid
+  - KeAcquireSpinLockRaiseToDpc
+  - KeReleaseSpinLock
+  - strstr
+  - ExReleaseFastMutex
+  - ZwClose
+  - ZwSetSecurityObject
+  - IoDeviceObjectType
+  - IoCreateDevice
+  - ObOpenObjectByPointer
+  - RtlGetDaclSecurityDescriptor
+  - ExAcquireFastMutex
+  - RtlGetOwnerSecurityDescriptor
+  - RtlGetSaclSecurityDescriptor
+  - SeCaptureSecurityDescriptor
+  - _snwprintf
+  - RtlLengthSecurityDescriptor
+  - SeExports
+  - RtlCreateSecurityDescriptor
+  - _wcsnicmp
+  - wcschr
+  - RtlAbsoluteToSelfRelativeSD
+  - RtlAddAccessAllowedAce
+  - RtlLengthSid
+  - IoIsWdmVersionAvailable
+  - RtlSetDaclSecurityDescriptor
+  - ZwOpenKey
+  - ZwSetValueKey
+  - ZwQueryValueKey
+  - ZwCreateKey
+  - RtlFreeUnicodeString
+  - KeBugCheckEx
+  - KeInitializeEvent
+  - RtlCompareMemory
+  - RtlCopyUnicodeString
+  - RtlIsNtDdiVersionAvailable
+  - ExFreePoolWithTag
+  - RtlGetGroupSecurityDescriptor
+  - ExAllocatePoolWithTag
+  - KeQueryPerformanceCounter
+  - WdfVersionUnbind
+  - WdfVersionBind
+  - WdfVersionUnbindClass
+  - WdfVersionBindClass
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2025-11-13 19:59:40'
+      ValidTo: '2026-11-10 19:59:40'
+      Signature: 7027f4dae4e1916c6c1497dc353dcefdef09044faf0b41df8e9cbf316e9efe85e7d6e013218e8a26fcc429326b9ba45d793be971f810a2d94ac47082bb5746f6791d6852fd1a86680337b65509dfe78631e8f603aef366e2f07716d0c65ed188ca0c748c44979be74293858208351ceb59cae059dc2acaa6050db2822f86570b750dcd892f5972680f4a46d1152c2f7e345bcf3a2dd14cc5aea9099e00d3b8be5b07949ccb72d8b7484b24764e7c29704b1001a7b837daa21c76d690e1cfa99ff7324d2f11fe30cf83b79eaac30a776e64c20831fcc1256199ac86d2cb0e8e39f85a1330f8fbfe4fad14d98323ef9d9f3a452badb2e17326e920d235541e7a1f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 330000013d8f4dd77862f0ad2000000000013d
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: d98977d115c14597f0bbce9e377d9d36
+        SHA1: 3c5bed71f114313ca3ffbe905002568e47a13138
+        SHA256: 642865a6fb047124c66954823d2726901f6288c2a3a1c9062faad0bdb24f738c
+        SHA384: 65b73fb035c9d2c72325c92641b097a7cf3c34bbdf43137d18a136988635b7c391e46a68bdae71cbfa0688abb80cd0be
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      ValidFrom: '2012-04-18 23:48:38'
+      ValidTo: '2027-04-18 23:58:38'
+      Signature: 5a8a67daccd5fd0d264177bf0a4678b4b3de12692b7723c2652f015fd203f461ba509d2e8c3972f36c3e6ab11e766decb7f382dcccbbc56970287366173f54ebee011648c446d91b80ae813a8d0f796d68b09eea2d3f39d3ca387ebd5e7c086e19dcc6c2f438336861e2524783e1000156d2bacb878205310a418b4ee77f5f5fed5fd3392d45eba213bffd1ec298417161165fc80a70257c59693124e471e70abb0417f79f721ec9d2bb1abe3d02fe090cb243b4591a99539396215fe0d6b72601429536ac27fdbef48577683d18bdf4be98882211865216f345ec0397107087a37043713cdbc98603170cf5735bc67de15c64edd7c548d7ed32e2d1aad3cfa7f6574e61f977eb67f288b3de00da038fd08a34373e1dd862b8d2b1f3e12f8b723b81967c6ffcec667672601b24f2a0896d5b6d002eef28dd868705c2b4b9e5be64c22af24a155c98e2c42785ff52e3627e0fb2020bd766c70ab2d33d200414503259830a7d9bed5a38120152ba2f5e20728e4af1fde771028c3be107bec973f4dd47d8b4efb4a4b330b9893e76cab90098567eabea8ab8a5d038ab6977130b142fe9aa411ff7babd3a2b348aee0aab63e663f788248e200d2b3b9de3c24952ac9f1f0e393b5dd46e506ae67d523aaa7c3315290d265e0158a74ea93d7a846f743f609fe4324f3600af6d71d33ea646655f8174f1fec171da4ca0415a82ddf11f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 610baac1000000000009
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: a569061297e8e824767dbc3184a69bea
+        SHA1: adbb26a587a8f44b4fccaecb306f980d1c55a150
+        SHA256: cec1afd0e310c55c1dcc601ab8e172917706aa32fb5eaf826813547fdf02dd46
+        SHA384: e947cac936803f5683196e4ff1b259096073395d0b908522ddce90d57597c9f7b57f7ddcdbe021ba863d843c340da8ba
+    Signer:
+    - SerialNumber: 330000013d8f4dd77862f0ad2000000000013d
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      Version: 1
+- Filename: kernel_utility_driver32.sys
+  SHA256: 962fb670510807fd5cab3a6e6f886aeb2b925c42054c29fa02f67011be935954
+  MD5: 1ffa4841ee616cf49b4e439fe131f001
+  SHA1: 71ab9bd0a43754b1a87cd05a1188cbf27b95b96f
+  Imphash: 3df5f109bc00887b8230282740059e26
+  Authentihash:
+    MD5: 7641ea013e9045027e6e4d3fd5c091b0
+    SHA1: 915d533a8ecb1c13fef384dc63845f874084758c
+    SHA256: 8a9a9e4276f947cfd188fd28daa35bdfae62a2620e90fdd2311096ee1a905fee
+  RichPEHeaderHash:
+    MD5: 8af90fc9a2d06bffa76a5ab9460ec831
+    SHA1: b33208c53868c1cc16c24723546540f54d21cc1b
+    SHA256: 9c8933d97d2d66d9ce0569aa3003b187a6abce354693d23b904567aed38d68bb
+  Sections:
+    .text:
+      Entropy: 6.396745468719643
+      Virtual Size: '0x2300'
+    .rdata:
+      Entropy: 3.8701154079634548
+      Virtual Size: '0x1854'
+    .data:
+      Entropy: 7.295825029973247
+      Virtual Size: '0x1fb0'
+    PAGE:
+      Entropy: 6.232442074018103
+      Virtual Size: '0x16fe'
+    INIT:
+      Entropy: 5.450281175804367
+      Virtual Size: '0x656'
+    .rsrc:
+      Entropy: 3.3068671187004877
+      Virtual Size: '0x2f0'
+    .reloc:
+      Entropy: 6.300907797067297
+      Virtual Size: '0x2f0'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2026-02-25 02:41:18'
+  Description: ''
+  Company: ''
+  InternalName: ''
+  OriginalFilename: ''
+  FileVersion: 1,5026,1000,127
+  Product: ''
+  ProductVersion: 1,5026,1000,127
+  Copyright: "\u7248\u6743\u6240\u6709 (C) 2010-2026"
+  MachineType: I386
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - _vsnwprintf
+  - IofCompleteRequest
+  - MmGetSystemRoutineAddress
+  - MmIsAddressValid
+  - strstr
+  - IoCreateSymbolicLink
+  - ZwClose
+  - ZwSetSecurityObject
+  - IoDeviceObjectType
+  - IoCreateDevice
+  - ObOpenObjectByPointer
+  - RtlGetDaclSecurityDescriptor
+  - RtlGetGroupSecurityDescriptor
+  - RtlGetOwnerSecurityDescriptor
+  - RtlGetSaclSecurityDescriptor
+  - RtlInitUnicodeString
+  - _snwprintf
+  - RtlLengthSecurityDescriptor
+  - SeExports
+  - RtlCreateSecurityDescriptor
+  - _wcsnicmp
+  - wcschr
+  - RtlAbsoluteToSelfRelativeSD
+  - RtlAddAccessAllowedAce
+  - RtlLengthSid
+  - IoIsWdmVersionAvailable
+  - RtlSetDaclSecurityDescriptor
+  - ZwOpenKey
+  - ZwSetValueKey
+  - ZwQueryValueKey
+  - ZwCreateKey
+  - RtlFreeUnicodeString
+  - KeBugCheckEx
+  - RtlRandomEx
+  - KeQuerySystemTime
+  - KeQueryInterruptTime
+  - KeInitializeEvent
+  - RtlCompareMemory
+  - RtlIsNtDdiVersionAvailable
+  - memset
+  - RtlCopyUnicodeString
+  - memcpy
+  - ExFreePoolWithTag
+  - SeCaptureSecurityDescriptor
+  - ExAllocatePoolWithTag
+  - KeGetCurrentIrql
+  - ExReleaseFastMutex
+  - KeQueryPerformanceCounter
+  - KfAcquireSpinLock
+  - KfReleaseSpinLock
+  - ExAcquireFastMutex
+  - WdfVersionBind
+  - WdfVersionUnbind
+  - WdfVersionBindClass
+  - WdfVersionUnbindClass
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2025-11-13 19:59:40'
+      ValidTo: '2026-11-10 19:59:40'
+      Signature: 7027f4dae4e1916c6c1497dc353dcefdef09044faf0b41df8e9cbf316e9efe85e7d6e013218e8a26fcc429326b9ba45d793be971f810a2d94ac47082bb5746f6791d6852fd1a86680337b65509dfe78631e8f603aef366e2f07716d0c65ed188ca0c748c44979be74293858208351ceb59cae059dc2acaa6050db2822f86570b750dcd892f5972680f4a46d1152c2f7e345bcf3a2dd14cc5aea9099e00d3b8be5b07949ccb72d8b7484b24764e7c29704b1001a7b837daa21c76d690e1cfa99ff7324d2f11fe30cf83b79eaac30a776e64c20831fcc1256199ac86d2cb0e8e39f85a1330f8fbfe4fad14d98323ef9d9f3a452badb2e17326e920d235541e7a1f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 330000013d8f4dd77862f0ad2000000000013d
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: d98977d115c14597f0bbce9e377d9d36
+        SHA1: 3c5bed71f114313ca3ffbe905002568e47a13138
+        SHA256: 642865a6fb047124c66954823d2726901f6288c2a3a1c9062faad0bdb24f738c
+        SHA384: 65b73fb035c9d2c72325c92641b097a7cf3c34bbdf43137d18a136988635b7c391e46a68bdae71cbfa0688abb80cd0be
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      ValidFrom: '2012-04-18 23:48:38'
+      ValidTo: '2027-04-18 23:58:38'
+      Signature: 5a8a67daccd5fd0d264177bf0a4678b4b3de12692b7723c2652f015fd203f461ba509d2e8c3972f36c3e6ab11e766decb7f382dcccbbc56970287366173f54ebee011648c446d91b80ae813a8d0f796d68b09eea2d3f39d3ca387ebd5e7c086e19dcc6c2f438336861e2524783e1000156d2bacb878205310a418b4ee77f5f5fed5fd3392d45eba213bffd1ec298417161165fc80a70257c59693124e471e70abb0417f79f721ec9d2bb1abe3d02fe090cb243b4591a99539396215fe0d6b72601429536ac27fdbef48577683d18bdf4be98882211865216f345ec0397107087a37043713cdbc98603170cf5735bc67de15c64edd7c548d7ed32e2d1aad3cfa7f6574e61f977eb67f288b3de00da038fd08a34373e1dd862b8d2b1f3e12f8b723b81967c6ffcec667672601b24f2a0896d5b6d002eef28dd868705c2b4b9e5be64c22af24a155c98e2c42785ff52e3627e0fb2020bd766c70ab2d33d200414503259830a7d9bed5a38120152ba2f5e20728e4af1fde771028c3be107bec973f4dd47d8b4efb4a4b330b9893e76cab90098567eabea8ab8a5d038ab6977130b142fe9aa411ff7babd3a2b348aee0aab63e663f788248e200d2b3b9de3c24952ac9f1f0e393b5dd46e506ae67d523aaa7c3315290d265e0158a74ea93d7a846f743f609fe4324f3600af6d71d33ea646655f8174f1fec171da4ca0415a82ddf11f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 610baac1000000000009
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: a569061297e8e824767dbc3184a69bea
+        SHA1: adbb26a587a8f44b4fccaecb306f980d1c55a150
+        SHA256: cec1afd0e310c55c1dcc601ab8e172917706aa32fb5eaf826813547fdf02dd46
+        SHA384: e947cac936803f5683196e4ff1b259096073395d0b908522ddce90d57597c9f7b57f7ddcdbe021ba863d843c340da8ba
+    Signer:
+    - SerialNumber: 330000013d8f4dd77862f0ad2000000000013d
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      Version: 1

--- a/yaml/ed3abb66-c577-44b8-89fa-80d300c82373.yaml
+++ b/yaml/ed3abb66-c577-44b8-89fa-80d300c82373.yaml
@@ -1,0 +1,247 @@
+Id: ed3abb66-c577-44b8-89fa-80d300c82373
+Tags:
+- xhunter2.sys
+Verified: 'TRUE'
+Author: Michael Haag
+Created: '2026-08-28'
+MitreID: T1562.001
+CVE:
+- CVE-2026-15430
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create xhunter2 binPath= C:\windows\temp\xhunter2.sys type= kernel
+    && sc.exe start xhunter2
+  Description: Wellbia xhunter2.sys version 2026.6.1.192 is an XIGNCODE3 anti-cheat
+    kernel component affected by CVE-2026-15430. Public research demonstrates bypasses
+    for its module, caller, and request authentication layers, exposing privileged
+    command paths for cross-process memory access, protected-process handle creation,
+    process termination, local privilege escalation, and kernel-assisted code injection.
+  Usecase: Impair security processes and access protected process memory through privileged
+    kernel command paths.
+  Privileges: kernel
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://blacksnufkin.github.io/posts/Hunting-the-Hunter-II/
+- https://github.com/BlackSnufkin/AxHunter
+- https://www.cve.org/CVERecord?id=CVE-2026-15430
+Detection: []
+Acknowledgement:
+  Person: BlackSnufkin
+  Handle: '@BlackSnufkin42'
+KnownVulnerableSamples:
+- Filename: xhunter2.sys
+  SHA256: 44cefb0b3b6516e6731de09a3e2e0eb8b98b02cc3fdf7bb4b22680e93f3cde1e
+  MD5: 9976ae79fb3887e0243dc159b2b68a48
+  SHA1: fb2dc9c59b8dfcf040b42f7d5eb41eb7b12852fb
+  Imphash: adbf77a9144f66e2953ee1e6ed60c41c
+  Authentihash:
+    MD5: 2e89c3f2aed10a71f7d1dcf16c711fe0
+    SHA1: 943f317e5ef8fcff293e959ec1a57d1a66dfe3e4
+    SHA256: 3c92a1df7bb856afaef29216533b1d407408bfc4c6236961eb2b769c205f936f
+  RichPEHeaderHash:
+    MD5: ''
+    SHA1: ''
+    SHA256: ''
+  Sections:
+    .text:
+      Entropy: 6.912644724668445
+      Virtual Size: '0x125e8'
+    .rdata:
+      Entropy: 4.055747129084019
+      Virtual Size: '0xd124'
+    .data:
+      Entropy: 5.156849789135883
+      Virtual Size: '0x44f8'
+    .pdata:
+      Entropy: 7.956115984894373
+      Virtual Size: '0xf18'
+    INIT:
+      Entropy: 5.464664983880308
+      Virtual Size: '0xfa0'
+    .E!z:
+      Entropy: 6.149100035654993
+      Virtual Size: '0x8efc'
+    .reloc:
+      Entropy: 4.479838194504187
+      Virtual Size: '0x74'
+    .rsrc:
+      Entropy: 3.61577537982695
+      Virtual Size: '0x43c'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2026-06-01 01:35:20'
+  Description: Wellbia.com System Guard
+  Company: Wellbia.com Co., Ltd.
+  InternalName: xhunter1.sys
+  OriginalFilename: xhunter1.sys
+  FileVersion: 2026.6.1.192
+  Product: Wellbia.com System Guard
+  ProductVersion: 2026.6.1.192
+  Copyright: Copyright (c) 2006-2023 Wellbia.com Co., Ltd.
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - ZwClose
+  - ObOpenObjectByPointer
+  - ZwAllocateVirtualMemory
+  - ZwFreeVirtualMemory
+  - ZwWaitForSingleObject
+  - PsGetProcessSectionBaseAddress
+  - __C_specific_handler
+  - PsProcessType
+  - RtlCompareMemory
+  - ExFreePoolWithTag
+  - ProbeForRead
+  - IoGetCurrentProcess
+  - ObfReferenceObject
+  - ObfDereferenceObject
+  - ZwCreateFile
+  - ZwReadFile
+  - PsGetCurrentProcessId
+  - KeStackAttachProcess
+  - KeUnstackDetachProcess
+  - ZwQueryVirtualMemory
+  - _vsnprintf
+  - MmHighestUserAddress
+  - wcsrchr
+  - ExAllocatePoolWithTag
+  - ObReferenceObjectByHandle
+  - ZwOpenFile
+  - MmSecureVirtualMemory
+  - ObReferenceObjectByName
+  - ZwQueryInformationProcess
+  - ObSetHandleAttributes
+  - IoFileObjectType
+  - IoDriverObjectType
+  - KeReleaseMutex
+  - KeWaitForSingleObject
+  - MmIsAddressValid
+  - PsLookupProcessByProcessId
+  - PsLookupThreadByThreadId
+  - IoThreadToProcess
+  - PsThreadType
+  - MmProbeAndLockPages
+  - MmUnlockPages
+  - MmMapLockedPagesSpecifyCache
+  - MmUnmapLockedPages
+  - IoAllocateMdl
+  - IoFreeMdl
+  - PsSetLoadImageNotifyRoutine
+  - PsRemoveLoadImageNotifyRoutine
+  - RtlCompareUnicodeString
+  - DbgPrint
+  - ZwQueryValueKey
+  - RtlPrefixUnicodeString
+  - PsGetProcessId
+  - KeEnterGuardedRegion
+  - KeLeaveGuardedRegion
+  - _stricmp
+  - MmProtectMdlSystemAddress
+  - ZwQuerySystemInformation
+  - KeInitializeEvent
+  - ExAcquireFastMutex
+  - ExReleaseFastMutex
+  - ZwOpenSection
+  - ZwMapViewOfSection
+  - ZwUnmapViewOfSection
+  - KeSetEvent
+  - ExQueryDepthSList
+  - ExpInterlockedPopEntrySList
+  - ExpInterlockedPushEntrySList
+  - RtlInitUnicodeString
+  - ExDeleteNPagedLookasideList
+  - IoCreateNotificationEvent
+  - _wcsnicmp
+  - RtlEqualUnicodeString
+  - KeInitializeMutex
+  - PsSetCreateProcessNotifyRoutine
+  - RtlCopyUnicodeString
+  - KeAreAllApcsDisabled
+  - ProbeForWrite
+  - IoGetTopLevelIrp
+  - ZwQueryInformationFile
+  - ObQueryNameString
+  - PsLookupProcessThreadByCid
+  - PsGetProcessInheritedFromUniqueProcessId
+  - ZwQueryInformationThread
+  - MmSystemRangeStart
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - ZwUnloadDriver
+  - RtlInitAnsiString
+  - RtlAnsiStringToUnicodeString
+  - PsGetVersion
+  - RtlFreeUnicodeString
+  - KeEnterCriticalRegion
+  - KeLeaveCriticalRegion
+  - RtlImageNtHeader
+  - ExAcquireResourceSharedLite
+  - ExAcquireResourceExclusiveLite
+  - ExReleaseResourceLite
+  - ZwOpenProcess
+  - ZwDuplicateObject
+  - PsAcquireProcessExitSynchronization
+  - PsReleaseProcessExitSynchronization
+  - PsGetProcessImageFileName
+  - PsIsSystemProcess
+  - strcmp
+  - PsInitialSystemProcess
+  - PsLoadedModuleList
+  - PsSetCreateProcessNotifyRoutineEx
+  - RtlEnumerateGenericTableAvl
+  - ExAcquireSpinLockExclusive
+  - ExReleaseSpinLockExclusive
+  - KeBugCheckEx
+  - MmGetSystemRoutineAddress
+  - ExInitializeNPagedLookasideList
+  - KeQueryPerformanceCounter
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      ValidFrom: '2021-04-29 00:00:00'
+      ValidTo: '2036-04-28 23:59:59'
+      Signature: 3a23443d8d0876ee8fbc3a99d356e0021aa5f84834f32cb6e67466f79472b100caaf6c302713129e90449f4bfd9ea37c26d537bc3a5d486d95d53f49f427bb16814550fd9cbdb685e0767e3771cb22f75aaa90cff5936ae3eb20d1d55079889a8a8ac1b6bda148187edcd8801a111918cd61998156f6c9e376e7c4e41b5f43f83e94ff76393d9ed499cf4add28eb5f26a1955848d51afed7273ffd90d17686dd1cb0605cf30da8eee089a1bd39e1384eda6ebb369dfbe521535ac3cae96af1a23edb43b833c84f38149299f5ddce546dd95d02141f40337c03e295b2c221757352cb46d8c4341ca2a54b8dcd6f76372c853f1ace26e918be9007b0437f9588208270f0cccaeffd29355c1f893855f7378a8b09a1cb0be9311aff2e195c3971e1be9ca70a06d62667b792e64e5fde7aac49cf2ea47492addb3ca49c861fe3c1561b2b23ff8fb5ea887b706be6a0bafd3a3f45a6c4e81691528b41c048844b964dab4440e38df01528ceedf11856072a2f10c40c08643c338fae288c3ccb8f880b0dbf3bf4ce1e7b8eefb5ebcbb7f07713e6e7283fac12aea52f226c41f9825c1566cc6c0ecac586c3f626330c074ba0d307026a6a4030484b34a85120bbad1b8508e2590d6dca05502bea4a1c9ea5fda0a71f0674e7f2d65290fdaf854821f9573bb49c03ed8645f4b4616ebf68e2266086eac8afa9fe941de7631b3a8656784e
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 08ad40b260d29c4c9f5ecda9bd93aed9
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 5d8003a64dfa5a4d88365da1566038cb
+        SHA1: 79465b56bc7ad55a37bdf633943da8bfc84db228
+        SHA256: 84bdc82e2f2a7f7aaa782667dac556ffcb2b33240c1f9c0a00a3264526a98332
+        SHA384: 65b1d4076a89ae273f57e6eeedecb3eae129b4168f76fa7671914cdf461d542255c59d9b85b916ae0ca6fc0fcf7a8e64
+    - Subject: JURISDICTION_OF_INCORPORATION_C=KR, JURISDICTION_OF_INCORPORATION_SP=Seoul,
+        BUSINESS_CATEGORY=Private Organization, serialNumber=110111,3525536, C=KR,
+        ST=Seoul, L=Geumcheon District, O=Wellbia.com Co., Ltd., CN=Wellbia.com Co.,
+        Ltd.
+      ValidFrom: '2026-04-29 00:00:00'
+      ValidTo: '2027-04-28 23:59:59'
+      Signature: 8171796de4d7f5a8227e192b7eeb7cc68ae96d4566d199e29879598d9f45afe264e6bf47b15727d46fea0eb4725cd9dbb8664236609283ef1bf3a9d161afba599cc1120d80e8512eee3d37e1fef715b967b4260c9cff2ea8073eaae0dbed1492c13bf506dc8c8c798cf1e0d66e5a34ff3a0cea94cff78b72b2909add08171304d0d7797b624759869c2186e6aa265ccbdfb02e002697c9ba50d28adc1a84d0df00f94b4424aa6d8f5ab657ce0a18d61d0f4b969f8fab103ad3e3c176db00dc6ddde9542f0b91a0118825605faa881b64813329a81400258e35dacaf3cab5c2e21c21085886aa06d9fedbbba05b5aaf99001abca272ffb80caf3f9fc5cfd7a90d3e32cabdd0483a3ad0e934b5ba26cebe5f0f277234f7e0cb586cfcd031397b59fc0b48a11bb43af9dbc935f48468d8483f9bcddb86c371a40217ad01cea59202b6e96f6782efb3bb58b00c1e3912609387bf533d238ccf36f991d9a0ed6d23b8d24c2b151b71dea2da7e4a802bd018be43f981e3b89053b2d7962fa09d4f728fa5999c775c6237d1dca69a2c79da987df05e8c0917ee83f373ce828f1d93ef14d2db8a39749c0f44f90b4ba392852257a1540109d01a9e1a2ad1ad1502e92afcaffe87a4d60efaf86ae307e52b73d1a406591a609bbe7f821a3476932eb62579089fdb83543046dbe91dd8f6a0c9f0bbe6a97dcc9fda4c544c69ea4c36c7b2d8
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 05d5c8c98ae5547b352ea1861bc7a61f
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 6a52a903261459fbd47e0591ab8572e0
+        SHA1: 31ff51a1fddc77381767e844743d17288377d27e
+        SHA256: dada17fc5f5f4835fbb3bdefc41a706baf10de685aa6e6492388f58605e7fc5d
+        SHA384: cff132037cc82be91998d5dc0a0cd2cd314b0bc4f00f0fac0f9fb11f499440abe486226d2c254b4dd3e59f5fc6669e5b
+    Signer:
+    - SerialNumber: 05d5c8c98ae5547b352ea1861bc7a61f
+      Issuer: C=US, O=DigiCert, Inc., CN=DigiCert Trusted G4 Code Signing RSA4096
+        SHA384 2021 CA1
+      Version: 1


### PR DESCRIPTION
## Summary

- add Wellbia `xhunter2.sys` (CVE-2026-15430) and the current affected `xhunter1.sys` build (CVE-2026-3609)
- add the signed Tjbxld `kernel_utility_driver` pair documented removing antivirus and EDR process-creation callbacks
- add the signed Sxav boot-time arbitrary file-deletion driver
- add the `ardrv.sys` variant observed in the August 2026 Cambodia-focused campaign
- enrich existing BootRepair, EnPortv, wsftprm, Alinubx, DCRCVDrv, and DsArk records with recent in-the-wild reporting
- add normal and strict YARA coverage for the malicious Tjbxld samples
- store all six new driver samples through Git LFS with complete extracted PE and signer metadata

Closes #398

## Validation

- `poetry run python bin/validate.py`
- `poetry run python bin/site.py -v`
- `poetry run python bin/gen-files.py`
- `poetry run python bin/yara-generator/validate-malicious-rules.py --skip-generate --json-output`
- `git lfs fsck`
- exact MD5, SHA-1, SHA-256, YAML, and indexed LFS pointer cross-checks for all six samples
- independent read-only diff review
