### PR TITLE
Add verified drivers from open issue reports

### DIFF
--- a/drivers/741daa162541343e15f0448487ca52c5.bin
+++ b/drivers/741daa162541343e15f0448487ca52c5.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34cdbf48f5a51ca9553c14f007aaa1b67c24e1334d8cb29e80f07c80c5dc07e7
+size 466336

--- a/drivers/77ebf3e9386daa51551af429052d88d0.bin
+++ b/drivers/77ebf3e9386daa51551af429052d88d0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94c3294bb9e14b07448734ae65b37801d3ff15bec987d182a929a017fef7b276
+size 5248

--- a/drivers/8e82dfac112073fce1697dbca586b5b9.bin
+++ b/drivers/8e82dfac112073fce1697dbca586b5b9.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00833dd6f61e768ec3cfdf2bdc5ef074df07f2df8921558e4c5e5a32e97b4080
+size 20104

--- a/drivers/c3c0be3d23dac6698ba12cea5d7b2dd8.bin
+++ b/drivers/c3c0be3d23dac6698ba12cea5d7b2dd8.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf07c46effde8b6b0fd3c9586a5a9636800fb37418c1e8e606c67cb613cbf832
+size 19128

--- a/yaml/19f13965-7078-4c19-a2e3-71ab8b77a9b7.yaml
+++ b/yaml/19f13965-7078-4c19-a2e3-71ab8b77a9b7.yaml
@@ -1,0 +1,149 @@
+Id: 19f13965-7078-4c19-a2e3-71ab8b77a9b7
+Tags:
+- HP_SWTOOLS_DRIVER.sys
+- HP_WKS_SWTOOLS_DRIVER.sys
+Verified: 'TRUE'
+Author: Faxs
+Created: '2026-08-29'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create HP_SWTOOLS_DRIVER binPath= C:\windows\temp\HP_SWTOOLS_DRIVER.sys
+    type= kernel && sc.exe start HP_SWTOOLS_DRIVER
+  Description: HP_SWTOOLS_DRIVER exposes privileged CPU and memory operations through
+    the \\.\HP_WKS_SWTOOLS_DRIVER device. Static analysis confirms IOCTLs for MSR
+    read and write, performance-counter access, physical/MMIO mapping and read/write,
+    PCI configuration access, port I/O, and a CPU-halt path. A standard user can reach
+    the device after an administrator installs the driver.
+  Usecase: Read or modify privileged CPU state and physical memory from user mode.
+  Privileges: Administrator required to install; device access is available to standard
+    users after installation
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://github.com/10fax01/HP_SWTOOLS_DRIVER
+- https://github.com/magicsword-io/LOLDrivers/issues/401
+Detection: []
+Acknowledgement:
+  Person: Faxs
+  Handle: '@10fax01'
+KnownVulnerableSamples:
+- Filename: HP_SWTOOLS_DRIVER.sys
+  MD5: c3c0be3d23dac6698ba12cea5d7b2dd8
+  SHA1: 528c24f0b3424598843937c10f97ee37dbb07109
+  SHA256: bf07c46effde8b6b0fd3c9586a5a9636800fb37418c1e8e606c67cb613cbf832
+  Imphash: 367517ad3d7699009eb23e8b62c3d5d5
+  Authentihash:
+    MD5: 2bfeb9e03baf8869598f2eb8753af710
+    SHA1: eaa3f5e371f710b9823e297eafcbd95ee6254433
+    SHA256: 6c9cf15e82c22d909eb2b17c4f7bc88ca246cf8b66f720d0094c8066c3fc39b9
+  RichPEHeaderHash:
+    MD5: c069e84cce8b3fcfe1e93a6a873691cf
+    SHA1: 2aab938ef009e453a309ac69e4988bb243fdd512
+    SHA256: e15a5dac595b91a0ad5f25b604f50039685355555e8575c79475b6f136d71a2e
+  Sections:
+    .text:
+      Entropy: 6.01462749215711
+      Virtual Size: '0x8c7'
+    .rdata:
+      Entropy: 3.6615045590906803
+      Virtual Size: '0x38c'
+    .data:
+      Entropy: 0.6185079451479871
+      Virtual Size: '0xf28'
+    .pdata:
+      Entropy: 3.6130044696076036
+      Virtual Size: '0x108'
+    PAGE:
+      Entropy: 5.843604006949804
+      Virtual Size: '0x324'
+    INIT:
+      Entropy: 5.240246815679745
+      Virtual Size: '0x4c4'
+    .rsrc:
+      Entropy: 3.2370732702339713
+      Virtual Size: '0x360'
+    .reloc:
+      Entropy: 2.3910353655857572
+      Virtual Size: '0x20'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2019-01-11 12:52:32'
+  Description: HP SW TOOLS DRIVER
+  Company: HP Inc.
+  InternalName: HP SW TOOLS DRIVER
+  OriginalFilename: HP SW TOOLS DRIVER
+  FileVersion: 1.5.0.0
+  Product: HP SW TOOLS DRIVER
+  ProductVersion: 1.5.0.0
+  Copyright: Copyright (C) 2018 HP Inc.
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  - WDFLDR.SYS
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoAllocateMdl
+  - IoFreeMdl
+  - __C_specific_handler
+  - MmUnmapIoSpace
+  - MmMapIoSpace
+  - MmUnmapLockedPages
+  - RtlCopyUnicodeString
+  - MmMapLockedPagesSpecifyCache
+  - MmBuildMdlForNonPagedPool
+  - RtlInitUnicodeString
+  - IoDeleteSymbolicLink
+  - memcpy_s
+  - HalGetBusDataByOffset
+  - HalSetBusDataByOffset
+  - WdfVersionUnbind
+  - WdfVersionBind
+  - WdfVersionBindClass
+  - WdfVersionUnbindClass
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2018-09-06 21:30:32'
+      ValidTo: '2019-09-06 21:30:32'
+      Signature: a5a2a99a97df110e18898e98fd07aaa52616e13f9c681d0f99cbafcb2914dd7a56a8324ab1fa926b26b9c5c87fd653c193cac3773f7750425d2090034461012f476d77005a079f2883e4cfa8b1dbab735f086c9692b3f6f53efb5db881bd94cdbda4c4c9597026a8fbf1eed41bf628879156fcacae96e751d4fe117f0f6dc985ef3bd72a7bd299bd507633600c9df2f92306fe4833a8d784019dbe8baaaa06fddae1d5066677c9bcce6506e6ebe455cc9f46b1e6e9d77f2a82159b2aac861eeb400de3dcef2bdfa85e0dc51628945f14b3f44340ba9f2a3af7ef1bf24f372b3a0d0fef4baafb86cf3ba43f29030b891d4b46b4ccb29b00506dc0ee0e44959f8369fc9e0fd4bc5fa12159a4cd6db8f9af57353c132654278784509635cf5e020c43757525a4d3dcbbd532986b46b2efaa2b6b3a00aa8d44cd0546efddb6ab2e30ccf75aba4bc8d9249262e408516b89cdd58c55b9af18baeb0201f7732724b4d3ca0c74ebc4afa19bb5583f948e9619232ece825e09465fdab93f6fe6ed0590d08435879ac1ba3cf41a8c4a8f5fea6a50e84a21a5ca38414e85de3867f4bce967cb45b62335b7416a0fdc08c1e3c049e85ef944f438e5f1296a659ff8e01a170001751f92b395bd7c9b4f33106a708a005c16c2b5439bac392253e1bcfbcb545d5f6243466205655a2e496098b9045d605b632b8f98d29f51e27e62fe63a4e8f2
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 33000000253a2738690a3451c1000000000025
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 60cb2d8488f8724a67bf3254e6a57ff1
+        SHA1: 37aef77a1afaa33ac5787fc43a2c1e2509a19eb1
+        SHA256: 495a6ff7ace92f915eb1753c4c0b32612056e6d320bb17ff90346db3aa357432
+        SHA384: 2a90dcf67abc92f070775de78ecf066e7730ea57b4c4d6c64cfdd66c3eb0f639ac188b24571a9f600ef017737a71decf
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      ValidFrom: '2014-10-15 20:31:27'
+      ValidTo: '2029-10-15 20:41:27'
+      Signature: 96b5c33b31f27b6ba11f59dd742c3764b1bca093f9f33347e9f95df21d89f4579ee33f10a3595018053b142941b6a70e5b81a2ccbd8442c1c4bed184c2c4bd0c8c47bcbd8886fb5a0896ae2c2fdfbf9366a32b20ca848a6945273f732332936a23e9fffdd918edceffbd6b41738d579cf8b46d499805e6a335a9f07e6e86c06ba8086725afc0998cdba7064d4093188ba959e69914b912178144ac57c3ae8eae947bcb3b8edd7ab4715bba2bc3c7d085234b371277a54a2f7f1ab763b94459ed9230cce47c099212111f52f51e0291a4d7d7e58f8047ff189b7fd19c0671dcf376197790d52a0fbc6c12c4c50c2066f50e2f5093d8cafb7fe556ed09d8a753b1c72a6978dcf05fe74b20b6af63b5e1b15c804e9c7aa91d4df72846782106954d32dd6042e4b61ac4f24636de357302c1b5e55fb92b59457a9243d7c4e963dd368f76c728caa8441be8321a66cde5485c4a0a602b469206609698dcd933d721777f886dac4772daa2466eab64682bd24e98fb35cc7fec3f136d11e5db77edc1c37e1f6a4a14f8b4a721c671866770cdd819a35d1fa09b9a7cc55d4d728e74077fa74d00fcdd682412772a557527cda92c1d8e7c19ee692c9f7425338208db38cc7cc74f6c3a6bc237117872fe55596460333e2edfc42de72cd7fb0a82256fb8d70c84a5e1c4746e2a95329ea0fecdb4188fd33bad32b2b19ab86d0543fbff0d0f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 330000000d690d5d7893d076df00000000000d
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: 83f69422963f11c3c340b81712eef319
+        SHA1: 0c5e5f24590b53bc291e28583acb78e5adc95601
+        SHA256: d8be9e4d9074088ef818bc6f6fb64955e90378b2754155126feebbbd969cf0ae
+        SHA384: 260ad59ba706420f68ba212931153bd89f760c464b21be55fba9d014fff322407859d4ebfb78ea9a3330f60dc9821a63
+    Signer:
+    - SerialNumber: 33000000253a2738690a3451c1000000000025
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2014
+      Version: 1

--- a/yaml/24fb7bab-b8c3-46ea-a370-c84d2f0ff614.yaml
+++ b/yaml/24fb7bab-b8c3-46ea-a370-c84d2f0ff614.yaml
@@ -15,6 +15,9 @@ Commands:
   Usecase: Elevate privileges
 Resources:
 - https://github.com/namazso/physmem_drivers
+- https://github.com/Haider303/trinity-2.0-lpe
+- https://medium.com/@haider303mustafa/teaccess-sys-adv64drv-sys-phymem-sys-kaslr-bypass-to-system-token-theft-69441310b7f4
+- https://github.com/magicsword-io/LOLDrivers/issues/395
 Detection:
 - type: BlockRule
   value: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules

--- a/yaml/3207f14b-a66c-4d5e-a5d5-2467ffd58265.yaml
+++ b/yaml/3207f14b-a66c-4d5e-a5d5-2467ffd58265.yaml
@@ -1,0 +1,137 @@
+Id: 3207f14b-a66c-4d5e-a5d5-2467ffd58265
+Tags:
+- d39DuiY9sxtDSiu4LSvS.sys
+- wifis.sys
+Verified: 'TRUE'
+Author: wwwab
+Created: '2026-08-29'
+MitreID: T1547.006
+Category: malicious
+Commands:
+  Command: sc.exe create wifis binPath= C:\windows\temp\d39DuiY9sxtDSiu4LSvS.sys type=
+    kernel && sc.exe start wifis
+  Description: This purpose-built kernel loader creates the \\.\wifis device and accepts
+    encrypted PE images through IOCTL 0x222000. Its worker thread decrypts input with
+    an RC4-like routine using the embedded key dsmjklsafbv, manually maps the supplied
+    PE image, resolves imports and relocations, and transfers execution to the unsigned
+    payload in kernel memory.
+  Usecase: Reflectively load and execute an unsigned kernel payload after the loader
+    is installed.
+  Privileges: Administrator
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/400
+Detection: []
+Acknowledgement:
+  Person: wwwab
+  Handle: '@wwwab123'
+KnownVulnerableSamples:
+- Filename: d39DuiY9sxtDSiu4LSvS.sys
+  MD5: 8e82dfac112073fce1697dbca586b5b9
+  SHA1: 5fdc38f30fefcdad652a761927fa5d4fa9ff1122
+  SHA256: 00833dd6f61e768ec3cfdf2bdc5ef074df07f2df8921558e4c5e5a32e97b4080
+  Imphash: 5445ae5cd933e77e5ece380db932320e
+  Authentihash:
+    MD5: 8e692d8ebcedf22274fe23c053c642d3
+    SHA1: 98af0d0f259c2d35dedc2f87aded8ba3e6b66a7a
+    SHA256: 9360e91c4183f3215254698bf804ed242957451f06a31b0a2b1c8a7f05035f80
+  RichPEHeaderHash:
+    MD5: 1fd5836e392383ade7b29361a8698502
+    SHA1: cbee2da2b5e56e35277319f55d812269728e0b9e
+    SHA256: 25aa3b0bcbb905632a8e526e07735e7ca0360aa027e0c37bea8bb3934b12f8f5
+  Sections:
+    .text:
+      Entropy: 6.352496592156005
+      Virtual Size: '0x10e8'
+    .rdata:
+      Entropy: 5.002501678389281
+      Virtual Size: '0x614'
+    .data:
+      Entropy: 3.1174924611847556
+      Virtual Size: '0x18'
+    .pdata:
+      Entropy: 3.6415360036048567
+      Virtual Size: '0xd8'
+    INIT:
+      Entropy: 5.252843306478683
+      Virtual Size: '0x2fe'
+    .reloc:
+      Entropy: 2.6464393446710157
+      Virtual Size: '0x14'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2025-11-10 03:26:04'
+  Description: ''
+  Company: ''
+  InternalName: ''
+  OriginalFilename: ''
+  FileVersion: ''
+  Product: ''
+  ProductVersion: ''
+  Copyright: ''
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - RtlInitUnicodeString
+  - DbgPrintEx
+  - ExAllocatePool
+  - ExFreePoolWithTag
+  - PsCreateSystemThread
+  - PsTerminateSystemThread
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - KeStackAttachProcess
+  - KeUnstackDetachProcess
+  - ZwWaitForSingleObject
+  - PsInitialSystemProcess
+  - strstr
+  - _strupr
+  - MmGetSystemRoutineAddress
+  - ZwQuerySystemInformation
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Hardware Compatibility Publisher
+      ValidFrom: '2025-02-20 20:08:08'
+      ValidTo: '2026-02-18 20:08:08'
+      Signature: 3a915ff496468e86d34a86bc4951e3d12d88d33fdd9826b98e674328eb433cad2113c9b57ceef54448eff7b018068dd2dcdab1daadf0536e5840a50e8adfd9da55a6094444c2b2222c402518668f8b610fde25de085d0097ff8e1548d3f15214de67bc40ec593546a1d2996ac74a9667ad8a05872c13ea1f68febffa660d691ff628a2240586db6fb6e26c5df277774231f7cb85e07d2c9918693e23e31b55b10dcb8fc7a1c588aa9089a96f4cd119fa76a370a9abcf4d43a2ceefb1c8adfbd13c76ccecc99c11f6bb8a56f4ea2bf19a6183feb46852de6b673c9bdaf830ffa07ac365efaf5184e21e5c3f32b308342fd07f2e3e2eccc753057aa3688984a183
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 3300000124e76f6ca813a27c35000000000124
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: cfe40b64f31750e7a57db8c4ad451bff
+        SHA1: 4031068d5106d7b364c9b99daf963a00fce3c1fb
+        SHA256: 11dfc1860474603fc5821f01931eb0e945a652e9e5d48b5042472941109b1932
+        SHA384: fafef1d7376886b2895becf586b67dbb317d6ad4398625b0eed2725280d6b29ea072dc4ec32fbc5e041996f8708351f9
+    - Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      ValidFrom: '2012-04-18 23:48:38'
+      ValidTo: '2027-04-18 23:58:38'
+      Signature: 5a8a67daccd5fd0d264177bf0a4678b4b3de12692b7723c2652f015fd203f461ba509d2e8c3972f36c3e6ab11e766decb7f382dcccbbc56970287366173f54ebee011648c446d91b80ae813a8d0f796d68b09eea2d3f39d3ca387ebd5e7c086e19dcc6c2f438336861e2524783e1000156d2bacb878205310a418b4ee77f5f5fed5fd3392d45eba213bffd1ec298417161165fc80a70257c59693124e471e70abb0417f79f721ec9d2bb1abe3d02fe090cb243b4591a99539396215fe0d6b72601429536ac27fdbef48577683d18bdf4be98882211865216f345ec0397107087a37043713cdbc98603170cf5735bc67de15c64edd7c548d7ed32e2d1aad3cfa7f6574e61f977eb67f288b3de00da038fd08a34373e1dd862b8d2b1f3e12f8b723b81967c6ffcec667672601b24f2a0896d5b6d002eef28dd868705c2b4b9e5be64c22af24a155c98e2c42785ff52e3627e0fb2020bd766c70ab2d33d200414503259830a7d9bed5a38120152ba2f5e20728e4af1fde771028c3be107bec973f4dd47d8b4efb4a4b330b9893e76cab90098567eabea8ab8a5d038ab6977130b142fe9aa411ff7babd3a2b348aee0aab63e663f788248e200d2b3b9de3c24952ac9f1f0e393b5dd46e506ae67d523aaa7c3315290d265e0158a74ea93d7a846f743f609fe4324f3600af6d71d33ea646655f8174f1fec171da4ca0415a82ddf11f
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: true
+      SerialNumber: 610baac1000000000009
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: false
+      IsCA: true
+      TBS:
+        MD5: a569061297e8e824767dbc3184a69bea
+        SHA1: adbb26a587a8f44b4fccaecb306f980d1c55a150
+        SHA256: cec1afd0e310c55c1dcc601ab8e172917706aa32fb5eaf826813547fdf02dd46
+        SHA384: e947cac936803f5683196e4ff1b259096073395d0b908522ddce90d57597c9f7b57f7ddcdbe021ba863d843c340da8ba
+    Signer:
+    - SerialNumber: 3300000124e76f6ca813a27c35000000000124
+      Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft
+        Windows Third Party Component CA 2012
+      Version: 1

--- a/yaml/408964b3-1799-425b-92bf-465c72a272d1.yaml
+++ b/yaml/408964b3-1799-425b-92bf-465c72a272d1.yaml
@@ -20,6 +20,9 @@ Commands:
 Resources:
 - https://github.com/magicsword-io/LOLDrivers/issues/316
 - https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+- https://github.com/Haider303/trinity-2.0-lpe
+- https://medium.com/@haider303mustafa/teaccess-sys-adv64drv-sys-phymem-sys-kaslr-bypass-to-system-token-theft-69441310b7f4
+- https://github.com/magicsword-io/LOLDrivers/issues/395
 Detection: []
 Acknowledgement:
   Person: ''

--- a/yaml/4c9a91ff-9284-49a7-899d-dfe85a112465.yaml
+++ b/yaml/4c9a91ff-9284-49a7-899d-dfe85a112465.yaml
@@ -5,26 +5,29 @@ Tags:
 Verified: 'TRUE'
 Author: Michael Haag
 Created: '2026-06-16'
-MitreID: T1562.001
+MitreID: T1068
 Category: vulnerable driver
 Commands:
-  Command: sc.exe create RootLaser binPath=C:\windows\temp\RootLaser.sys type=kernel
+  Command: sc.exe create RootLaser binPath= C:\windows\temp\RootLaser.sys type= kernel
     && sc.exe start RootLaser
-  Description: Adlice RootLaser.sys version 3.4.1 is a signed kernel driver assessed
-    in public KOSEC BYOVD research. The driver retains a process-termination IOCTL
-    reachable from administrator context and additional kernel read/information-leak
-    attack surface, even though newer access-control and PPL checks mitigate some
-    earlier TrueSight abuse paths.
-  Usecase: Terminate non-protected processes from kernel mode and expose kernel read/information
-    leak primitives.
-  Privileges: kernel
+  Description: Adlice RootLaser.sys version 3.4.1 is a signed kernel driver with
+    administrator-reachable kernel read and write primitives through IOCTLs 0x22E050
+    and 0x22E014. Public proof-of-concept code combines these primitives with build-specific
+    kernel offsets to replace a process token and elevate an administrator to SYSTEM.
+    The exploit requires offsets that match the target Windows build.
+  Usecase: Read and write kernel memory to replace a process token or terminate non-protected
+    processes.
+  Privileges: Administrator
   OperatingSystem: Windows 10, Windows 11
 Resources:
 - https://github.com/KOSEC-LLC/BYOVD-Research/tree/main/Adlice
+- https://github.com/AmeerTheInteger/Windows-kernel-LPE-RootLaser.sys
+- https://github.com/magicsword-io/LOLDrivers/issues/410
+- https://github.com/magicsword-io/LOLDrivers/issues/411
 Detection: []
 Acknowledgement:
-  Person: KOSEC LLC
-  Handle: ''
+  Person: KOSEC LLC, megab0t
+  Handle: '@AmeerTheInteger'
 KnownVulnerableSamples:
 - Filename: RootLaser.sys
   SHA256: 85b69f4e518c66b8ba7154ecb1ac1e8791dfe2fdf1e20b7c3a707f59639ac10d

--- a/yaml/50bbae3f-f6d8-4881-8fd7-a70002d52841.yaml
+++ b/yaml/50bbae3f-f6d8-4881-8fd7-a70002d52841.yaml
@@ -1,0 +1,84 @@
+Id: 50bbae3f-f6d8-4881-8fd7-a70002d52841
+Tags:
+- giveio.sys
+Verified: 'TRUE'
+Author: impudent
+Created: '2026-08-29'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create giveio binPath= C:\windows\temp\giveio.sys type= kernel &&
+    sc.exe start giveio
+  Description: The 32-bit giveio driver bundled with SpeedFan creates the \\.\giveio
+    device and handles IRP_MJ_CREATE by applying a zeroed 8 KiB I/O permission map
+    to the opening process through Ke386IoSetAccessProcess and Ke386SetIoAccessMap.
+    This grants unrestricted direct access to all x86 I/O ports without validating
+    the caller.
+  Usecase: Grant a user-mode process unrestricted access to hardware I/O ports.
+  Privileges: Administrator required to install; opening the device grants port access
+    without an additional caller check
+  OperatingSystem: 32-bit Windows NT, Windows 2000, Windows XP
+Resources:
+- https://github.com/magicsword-io/LOLDrivers/issues/407
+- https://www.almico.com/speedfan.php
+Detection: []
+Acknowledgement:
+  Person: impudent
+  Handle: '@dsavxc'
+KnownVulnerableSamples:
+- Filename: giveio.sys
+  MD5: 77ebf3e9386daa51551af429052d88d0
+  SHA1: bd4f3e24f531e974fbaac43381120b42e804fbaf
+  SHA256: 94c3294bb9e14b07448734ae65b37801d3ff15bec987d182a929a017fef7b276
+  Imphash: b5986408bbf7e1b5028742a5d8adac66
+  Authentihash:
+    MD5: 196f8a68da8632173d1243354d124484
+    SHA1: bdd62bb96cda70580b9a0abec86432fb1cdf7f60
+    SHA256: daf4d9df4b1e64ca7c800500a7f290b9af5fdc5c63c5afadb7d6630480688ddc
+  RichPEHeaderHash:
+    MD5: ''
+    SHA1: ''
+    SHA256: ''
+  Sections:
+    .text:
+      Entropy: 5.451405826272336
+      Virtual Size: '0x168'
+    .rdata:
+      Entropy: 2.073478759373367
+      Virtual Size: '0x54'
+    .data:
+      Entropy: 2.3039580038764
+      Virtual Size: '0x4a'
+    .idata:
+      Entropy: 4.5908291157247785
+      Virtual Size: '0x192'
+    .reloc:
+      Entropy: 3.327969535943128
+      Virtual Size: '0x48'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '1996-04-03 19:33:25'
+  Description: ''
+  Company: ''
+  InternalName: ''
+  OriginalFilename: ''
+  FileVersion: ''
+  Product: ''
+  ProductVersion: ''
+  Copyright: ''
+  MachineType: I386
+  Imports:
+  - ntoskrnl.exe
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - IoGetCurrentProcess
+  - IoDeleteSymbolicLink
+  - RtlInitUnicodeString
+  - MmFreeNonCachedMemory
+  - Ke386SetIoAccessMap
+  - Ke386IoSetAccessProcess
+  - IoDeleteDevice
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - IoCreateDevice
+  - MmAllocateNonCachedMemory
+  Signatures: {}

--- a/yaml/619953be-2115-4da2-bb59-603fcf93a3d2.yaml
+++ b/yaml/619953be-2115-4da2-bb59-603fcf93a3d2.yaml
@@ -17,6 +17,9 @@ Commands:
 Resources:
 - https://github.com/magicsword-io/LOLDrivers/issues/325
 - https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+- https://github.com/Haider303/trinity-lpe
+- https://medium.com/@haider303mustafa/fastdump-sys-citmdrv-sys-567f57e9cd20
+- https://github.com/magicsword-io/LOLDrivers/issues/394
 Detection: []
 Acknowledgement:
   Person: ''

--- a/yaml/7789e9ca-8508-486b-9d77-7497c5c61474.yaml
+++ b/yaml/7789e9ca-8508-486b-9d77-7497c5c61474.yaml
@@ -1,0 +1,262 @@
+Id: 7789e9ca-8508-486b-9d77-7497c5c61474
+Tags:
+- PSKD64.SYS
+Verified: 'TRUE'
+Author: Venexy
+Created: '2026-08-29'
+MitreID: T1068
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create PSKD64 binPath= C:\windows\temp\PSKD64.SYS type= kernel &&
+    sc.exe start PSKD64
+  Description: APSoft PCIScope's PSKD64 driver exposes memory-access operations through
+    \\.\PSKD64. IOCTL 0x220044 dispatches sub-operations 0x701E and 0x701F for caller-selected
+    virtual or physical memory reads and writes without constraining the target address.
+    Public testing demonstrates arbitrary kernel read/write on Windows 11, including
+    process protection removal and security-process termination.
+  Usecase: Read or write arbitrary kernel memory to disable security controls or elevate
+    privileges.
+  Privileges: Administrator
+  OperatingSystem: Windows 10, Windows 11
+Resources:
+- https://www.tssc.de/site/products/tools/pciscope
+- https://www.tssc.de/site/download/prods/pciscope.exe
+- https://github.com/magicsword-io/LOLDrivers/issues/408
+Detection: []
+Acknowledgement:
+  Person: Venexy, Dark Monkey
+  Handle: '@M4xSec, @v8k6b2jjps-prog'
+KnownVulnerableSamples:
+- Filename: PSKD64.SYS
+  MD5: 741daa162541343e15f0448487ca52c5
+  SHA1: 9bd89c27aa2b230feea1171798bfc0e24652444a
+  SHA256: 34cdbf48f5a51ca9553c14f007aaa1b67c24e1334d8cb29e80f07c80c5dc07e7
+  Imphash: cec72858409b9ae0decb0b0cd9111791
+  Authentihash:
+    MD5: 2eb18722d74040a5f2713f958b1fc2b1
+    SHA1: 5f0369a2f3f9ffc931ef1a982e5685a8ade50add
+    SHA256: d53d5e1311f42580e5cbc675f6435753dd5869418ff47451a0b372f841662534
+  RichPEHeaderHash:
+    MD5: 8ae9f4d712397e916ae0c458857cec66
+    SHA1: a181cf1e611219c7cd1fda172f8ab4431c26657b
+    SHA256: 78241920372366f18eb945a9b022d046b0dcd29f91a9ebfb12f41f6749ee845b
+  Sections:
+    .text:
+      Entropy: 6.253019517999342
+      Virtual Size: '0x3db35'
+    DebugDat:
+      Entropy: 5.1421711325738
+      Virtual Size: '0x70'
+    .rdata:
+      Entropy: 4.890149006770144
+      Virtual Size: '0x67ac'
+    .data:
+      Entropy: 3.502049332136162
+      Virtual Size: '0xf9e8'
+    .pdata:
+      Entropy: 5.480100463541544
+      Virtual Size: '0x36c0'
+    DebugCod:
+      Entropy: 4.447928859423906
+      Virtual Size: '0x11400'
+    PAGE:
+      Entropy: 5.981720914796221
+      Virtual Size: '0x4eb'
+    .edata:
+      Entropy: 4.107634193044584
+      Virtual Size: '0x4e'
+    INIT:
+      Entropy: 6.163420182524112
+      Virtual Size: '0x16d2'
+    INITDATA:
+      Entropy: -0.0
+      Virtual Size: '0x8'
+    .rsrc:
+      Entropy: 4.373360839613024
+      Virtual Size: '0x718'
+    .reloc:
+      Entropy: 4.735408620756494
+      Virtual Size: '0x2af0'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2026-03-08 09:06:34'
+  Description: PCI Diagnostic Driver
+  Company: APSoft
+  InternalName: PSKD64.SYS
+  OriginalFilename: PSKD64.SYS
+  FileVersion: 4.00.032
+  Product: PCIScope
+  ProductVersion: 4.00.032
+  Copyright: "Copyright \xA9 APSoft, 2000 - 2026.\nAll rights reserved.\nDisassembly\
+    \ or decompilation prohibited."
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions:
+  - _except_handler3
+  ImportedFunctions:
+  - MmProbeAndLockPages
+  - MmUnlockPages
+  - IoAllocateMdl
+  - sprintf
+  - ExFreePoolWithTag
+  - ExQueryPoolBlockSize
+  - ObfDereferenceObject
+  - strchr
+  - strstr
+  - strncpy
+  - IoDeleteDevice
+  - IoCreateDevice
+  - MmIsAddressValid
+  - KeReleaseSpinLock
+  - KeAcquireSpinLockRaiseToDpc
+  - RtlInitUnicodeString
+  - ZwQuerySystemInformation
+  - ExAllocatePool
+  - _strnicmp
+  - IoGetDeviceObjectPointer
+  - _stricmp
+  - KeRemoveQueueDpc
+  - ZwClose
+  - KeReadStateTimer
+  - KeCancelTimer
+  - ExAllocatePoolWithTag
+  - ExSystemTimeToLocalTime
+  - RtlTimeToTimeFields
+  - KeNumberProcessors
+  - KeReleaseSpinLockFromDpcLevel
+  - KeAcquireSpinLockAtDpcLevel
+  - RtlQueryRegistryValues
+  - RtlFreeUnicodeString
+  - KeBugCheckEx
+  - IoFreeMdl
+  - KeDelayExecutionThread
+  - KeQueryTimeIncrement
+  - MmGetSystemRoutineAddress
+  - PsGetVersion
+  - ZwOpenKey
+  - ExAcquireResourceExclusiveLite
+  - IoCreateNotificationEvent
+  - KeLeaveCriticalRegion
+  - ZwOpenDirectoryObject
+  - KeEnterCriticalRegion
+  - ZwCreateFile
+  - ExReleaseResourceLite
+  - ObReferenceObjectByHandle
+  - RtlCompareUnicodeString
+  - RtlUpcaseUnicodeChar
+  - PsCreateSystemThread
+  - ExInterlockedInsertHeadList
+  - ExInterlockedInsertTailList
+  - PsTerminateSystemThread
+  - KeWaitForSingleObject
+  - ExInterlockedRemoveHeadList
+  - KeSetEvent
+  - KeInitializeEvent
+  - IoFreeIrp
+  - IoAllocateIrp
+  - ZwQueryKey
+  - RtlUnicodeToMultiByteN
+  - RtlMultiByteToUnicodeN
+  - strrchr
+  - toupper
+  - isdigit
+  - IoBuildDeviceIoControlRequest
+  - strncmp
+  - IofCallDriver
+  - IoAdapterObjectType
+  - IoFileObjectType
+  - IoDriverObjectType
+  - ExDesktopObjectType
+  - ExEventObjectType
+  - ExFreePool
+  - IoDeleteSymbolicLink
+  - ZwQueryValueKey
+  - IofCompleteRequest
+  - IoCreateSymbolicLink
+  - _strupr
+  - RtlAnsiStringToUnicodeString
+  - RtlInitAnsiString
+  - RtlUnicodeStringToAnsiString
+  - RtlFreeAnsiString
+  - KeInitializeDpc
+  - KeSetTimerEx
+  - KeInitializeTimerEx
+  - KeWaitForMultipleObjects
+  - IoCreateSynchronizationEvent
+  - KeInitializeSemaphore
+  - KeReleaseSemaphore
+  - KeReadStateSemaphore
+  - IoAssignResources
+  - KeClearEvent
+  - KeResetEvent
+  - KeReadStateEvent
+  - IoGetCurrentProcess
+  - PsGetCurrentProcessId
+  - ZwSetInformationThread
+  - KeInitializeMutex
+  - KeReleaseMutex
+  - IoQueryDeviceDescription
+  - DbgPrint
+  - PoCallDriver
+  - _strlwr
+  - ZwEnumerateKey
+  - IoWriteErrorLogEntry
+  - IoAllocateErrorLogEntry
+  - KeSetPriorityThread
+  - ZwSetInformationFile
+  - ZwQueryInformationFile
+  - ZwWriteFile
+  - MmMapIoSpace
+  - IoDeviceObjectType
+  - MmUnmapIoSpace
+  - __C_specific_handler
+  - HalSetBusDataByOffset
+  - HalTranslateBusAddress
+  - HalGetBusDataByOffset
+  - KeQueryPerformanceCounter
+  - KeStallExecutionProcessor
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=US, ST=Texas, L=Houston, O=SSL Corp, CN=SSL.com EV Code Signing Intermediate
+        CA ECC R2
+      ValidFrom: '2019-03-07 19:37:45'
+      ValidTo: '2034-03-03 19:37:45'
+      Signature: 306402304a5bea809fba3692cf8c31edeca599ee3227bcc317eb878f57503005bf7595f73cf93f1952833420e11156ee393eb7ee023002b5b8d9f8781247c1c045ff15f6a066bb43e24f430e587797a4a2553424845a5619cfa655201bd9109a5300fb895e70
+      SignatureAlgorithmOID: 1.2.840.10045.4.3.3
+      IsCertificateAuthority: true
+      SerialNumber: 6edd4f25e7317d3981573134cfc1dca0
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 611350a193d046e140ef1a4f952e12d3
+        SHA1: 280bd286608fe3a3ea55209039b1d720cebb09a2
+        SHA256: 479f4114f068a455c4f9e6ec28b2f0161681613f155ad5a87b464693e33bdb24
+        SHA384: 68c2c4a03fb1c1ab754ab4e5413d224028c097a17b0380b290da95852ff61c26fd8d3177708f91f0afe21dae30ae32ab
+    - Subject: C=DE, ST=Bavaria, L=Reichertsheim, O=APSoft e. K., serialNumber=HRA
+        12182, CN=APSoft e. K., BUSINESS_CATEGORY=Private Organization, JURISDICTION_OF_INCORPORATION_L=Traunstein,
+        JURISDICTION_OF_INCORPORATION_SP=Bavaria, JURISDICTION_OF_INCORPORATION_C=DE
+      ValidFrom: '2025-12-10 14:39:27'
+      ValidTo: '2028-12-09 14:39:27'
+      Signature: 3066023100b00f2974c6fd6a9a87fced1620c5466a3119de9cc9d69f7630098f96421c48b8036b09a870753957ff1436d3ed1b9342023100afc36374380a77714670418d03051fc6e63498ff0ad5a1b8c6ade4e1cc4d5b4e748fbe64d31a72d0c24342458cf749d6
+      SignatureAlgorithmOID: 1.2.840.10045.4.3.3
+      IsCertificateAuthority: false
+      SerialNumber: 571ae028012f6b3e40d4cdcab8e3fe3e
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 9ce4617540fe261e78f2c937223df698
+        SHA1: 45a264b93bf8ab2ef734b4ddbbe296f2d6269709
+        SHA256: d919e1e5979dc5e27d3e98ebda4f8e28a834f924479ad0ba2a03aa163402c9a3
+        SHA384: 2f4db590d1f92e6bdecafebfbcdec713205d09d15f5b00d91c8ddf09bf6289f4b364285a438993915b153476e6d2db33
+    Signer:
+    - SerialNumber: 571ae028012f6b3e40d4cdcab8e3fe3e
+      Issuer: C=US, ST=Texas, L=Houston, O=SSL Corp, CN=SSL.com EV Code Signing Intermediate
+        CA ECC R2
+      Version: 1

--- a/yaml/a7bba474-815f-49be-bddc-4d76a64c866c.yaml
+++ b/yaml/a7bba474-815f-49be-bddc-4d76a64c866c.yaml
@@ -15,6 +15,9 @@ Commands:
   Usecase: Elevate privileges
 Resources:
 - https://github.com/namazso/physmem_drivers
+- https://github.com/Haider303/trinity-lpe
+- https://medium.com/@haider303mustafa/fastdump-sys-citmdrv-sys-567f57e9cd20
+- https://github.com/magicsword-io/LOLDrivers/issues/394
 Detection:
 - type: yara_signature
   value: https://github.com/magicsword-io/LOLDrivers/blob/main/detections/yara/09bedbf7a41e0f8dabe4f41d331db58373ce15b2e9204540873a1884f38bdde1.yara

--- a/yaml/d6dc9b52-9918-442d-b03a-f1f614aa4cce.yaml
+++ b/yaml/d6dc9b52-9918-442d-b03a-f1f614aa4cce.yaml
@@ -20,6 +20,9 @@ Commands:
 Resources:
 - https://github.com/magicsword-io/LOLDrivers/issues/315
 - https://github.com/KeServiceDescriptorTable/vulnerable-drivers
+- https://github.com/Haider303/trinity-2.0-lpe
+- https://medium.com/@haider303mustafa/teaccess-sys-adv64drv-sys-phymem-sys-kaslr-bypass-to-system-token-theft-69441310b7f4
+- https://github.com/magicsword-io/LOLDrivers/issues/395
 Detection: []
 Acknowledgement:
   Person: ''

--- a/yaml/f3215c19-8053-458c-81a5-90a74c5d2e6d.yaml
+++ b/yaml/f3215c19-8053-458c-81a5-90a74c5d2e6d.yaml
@@ -15,6 +15,9 @@ Commands:
   Usecase: Elevate privileges
 Resources:
 - https://github.com/namazso/physmem_drivers
+- https://github.com/Haider303/trinity-lpe
+- https://medium.com/@haider303mustafa/fastdump-sys-citmdrv-sys-567f57e9cd20
+- https://github.com/magicsword-io/LOLDrivers/issues/394
 Detection: []
 Acknowledgement:
   Handle: ''


### PR DESCRIPTION
## Summary

Adds four verified, non-duplicate driver samples reported through open issues:

- malicious `d39DuiY9sxtDSiu4LSvS.sys`, a reflective kernel PE loader exposed through `\\.\wifis` and IOCTL `0x222000`
- HP `HP_SWTOOLS_DRIVER.sys`, exposing MSR, PMC, physical/MMIO, PCI, and port-I/O primitives
- 32-bit SpeedFan `giveio.sys`, which grants the opening process unrestricted x86 I/O-port access
- APSoft PCIScope `PSKD64.SYS`, exposing arbitrary kernel virtual-memory read/write operations through IOCTL `0x220044`

The PR also adds the newly published exploit-chain references to the six existing FastDump/CITMDRV/NTIOLib and TEACCESS/ADV64DRV/PhyMem records, and updates the existing RootLaser record with its administrator-to-SYSTEM read/write PoC.

Closes #400
Closes #401
Closes #407
Closes #408

## Evidence

- all four binaries are stored through Git LFS and their pointer OIDs match the YAML SHA-256 values
- repository metadata extraction completed for every new binary
- headless static analysis confirmed the described reachable primitives and IOCTL paths
- the SpeedFan and PCIScope samples were independently verified against their published vendor packages

## Validation

- `python bin/validate.py`
- `python bin/yara-generator/validate-malicious-rules.py --skip-generate --json-output`
- `python bin/site.py -v`
- `python bin/gen-files.py`
- `git lfs fsck`
- `git diff --check`
