### PR TITLE
Complete DirectIo64.sys b1008 driver metadata

### DIFF
--- a/drivers/db6d09b6ea72411f715f3effe1b42ca7.bin
+++ b/drivers/db6d09b6ea72411f715f3effe1b42ca7.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b147a26dad59d9109710798b033ec3504a799f02e4356a358d6e32fdf7841b4a
+size 51152

--- a/yaml/a254e684-f6eb-40c4-a50a-7b76feb6cc02.yaml
+++ b/yaml/a254e684-f6eb-40c4-a50a-7b76feb6cc02.yaml
@@ -7,7 +7,7 @@ Author: Michael Haag
 Created: '2023-07-22'
 MitreID: T1068
 CVE:
-- ''
+- CVE-2025-52347
 Category: vulnerable driver
 Commands:
   Command: ''
@@ -17,12 +17,13 @@ Commands:
   Usecase: Elevate privileges
 Resources:
 - https://gist.github.com/mgraeber-rc/1bde6a2a83237f17b463d051d32e802c
+- https://github.com/floppywiggler/directio64-disclosure
 Detection:
 - type: ''
   value: ''
 Acknowledgement:
-  Handle: ''
-  Person: ''
+  Handle: floppywiggler
+  Person: Emil Sorbroden
 KnownVulnerableSamples:
 - Authentihash:
     MD5: 0c357509adc3c4e42390c50a6a79575d
@@ -208,3 +209,7 @@ KnownVulnerableSamples:
       Version: 1
   Imphash: cef6a450f196b28e634aa3c0655d8eda
   LoadsDespiteHVCI: 'FALSE'
+- Filename: DirectIo64.sys
+  MD5: db6d09b6ea72411f715f3effe1b42ca7
+  SHA1: 8e71859907ea3c2198a0b32a9b6c7b69feb8879a
+  SHA256: b147a26dad59d9109710798b033ec3504a799f02e4356a358d6e32fdf7841b4a

--- a/yaml/a254e684-f6eb-40c4-a50a-7b76feb6cc02.yaml
+++ b/yaml/a254e684-f6eb-40c4-a50a-7b76feb6cc02.yaml
@@ -11,7 +11,11 @@ CVE:
 Category: vulnerable driver
 Commands:
   Command: ''
-  Description: Confirmed vulnerable driver from Microsoft Block List
+  Description: PassMark DirectIo64.sys builds through b1008 expose permissively
+    accessible IOCTLs for physical memory, MSRs, PCI configuration space, x86 I/O
+    ports, and kernel or physical-memory dumps. These primitives can support local
+    SYSTEM elevation, kernel tampering, credential exposure, or denial of service.
+    PassMark hardened the driver in b1012.
   OperatingSystem: Windows
   Privileges: kernel
   Usecase: Elevate privileges
@@ -213,3 +217,176 @@ KnownVulnerableSamples:
   MD5: db6d09b6ea72411f715f3effe1b42ca7
   SHA1: 8e71859907ea3c2198a0b32a9b6c7b69feb8879a
   SHA256: b147a26dad59d9109710798b033ec3504a799f02e4356a358d6e32fdf7841b4a
+  Imphash: e8957f92fb9f2c1b4e23f2ae68c84a43
+  Authentihash:
+    MD5: 3d44547dd930c1f0451574129dc05f39
+    SHA1: b5674bde7cb1c49a23d6c937b80a1b1478e24bc2
+    SHA256: ed4e21364c3b077d5f5b53ff53db009ca735ad2b66b21559d25ef2c6689dfd1b
+  RichPEHeaderHash:
+    MD5: d845897ea399fa2048545f479aaf5eb5
+    SHA1: 44e7881e54893cf9122792e718f19216864b0218
+    SHA256: 4e9d63bd0805bfa5d878545d6456634be96466e1653c06bca576540b2d095c2f
+  Sections:
+    .text:
+      Entropy: 6.321782688271367
+      Virtual Size: '0x4e5a'
+    .rdata:
+      Entropy: 4.078497548099905
+      Virtual Size: '0x9e8'
+    .data:
+      Entropy: 0.9170036374986784
+      Virtual Size: '0x88'
+    .pdata:
+      Entropy: 3.9540732697774166
+      Virtual Size: '0x1f8'
+    PAGE:
+      Entropy: 5.154715390110382
+      Virtual Size: '0xb8'
+    INIT:
+      Entropy: 5.270741772071132
+      Virtual Size: '0x8fc'
+    .reloc:
+      Entropy: 3.586048612313037
+      Virtual Size: '0x24'
+  MagicHeader: 50 45 0 0
+  CreationTimestamp: '2025-04-14 22:17:54'
+  Description: ''
+  Company: ''
+  InternalName: ''
+  OriginalFilename: ''
+  FileVersion: ''
+  Product: ''
+  ProductVersion: ''
+  Copyright: ''
+  MachineType: AMD64
+  Imports:
+  - ntoskrnl.exe
+  - HAL.dll
+  ExportedFunctions: ''
+  ImportedFunctions:
+  - MmGetSystemRoutineAddress
+  - RtlWriteRegistryValue
+  - RtlAppendUnicodeStringToString
+  - RtlAppendUnicodeToString
+  - DbgPrintEx
+  - RtlGetVersion
+  - KeInitializeEvent
+  - KeWaitForSingleObject
+  - ExAllocatePool2
+  - ExFreePoolWithTag
+  - MmBuildMdlForNonPagedPool
+  - MmMapLockedPagesSpecifyCache
+  - MmUnmapLockedPages
+  - MmMapIoSpace
+  - MmUnmapIoSpace
+  - IoAllocateErrorLogEntry
+  - IoAllocateMdl
+  - IoBuildDeviceIoControlRequest
+  - IoBuildSynchronousFsdRequest
+  - IofCallDriver
+  - IofCompleteRequest
+  - IoCreateDevice
+  - IoCreateSymbolicLink
+  - IoDeleteDevice
+  - IoDeleteSymbolicLink
+  - IoFreeMdl
+  - IoGetAttachedDeviceReference
+  - IoGetDeviceObjectPointer
+  - IoWriteErrorLogEntry
+  - IoGetDeviceProperty
+  - RtlQueryRegistryValues
+  - ObReferenceObjectByPointer
+  - ObfDereferenceObject
+  - ZwCreateFile
+  - ZwWriteFile
+  - ZwClose
+  - ZwOpenSection
+  - ZwMapViewOfSection
+  - ZwUnmapViewOfSection
+  - ZwOpenKey
+  - ZwQueryValueKey
+  - MmGetPhysicalMemoryRanges
+  - PsGetProcessId
+  - KeStackAttachProcess
+  - KeUnstackDetachProcess
+  - IoEnumerateDeviceObjectList
+  - ObQueryNameString
+  - _vsnwprintf
+  - ObReferenceObjectByName
+  - __C_specific_handler
+  - IoFileObjectType
+  - PsProcessType
+  - PsInitialSystemProcess
+  - NtBuildNumber
+  - IoDriverObjectType
+  - KeEnterCriticalRegion
+  - KeLeaveCriticalRegion
+  - KdSystemDebugControl
+  - KdDebuggerEnabled
+  - KeQueryActiveProcessors
+  - KeBugCheckEx
+  - RtlInitUnicodeString
+  - RtlIntegerToUnicodeString
+  - ObReferenceObjectByHandle
+  - wcsrchr
+  - KeStallExecutionProcessor
+  - HalGetBusDataByOffset
+  - HalSetBusDataByOffset
+  Signatures:
+  - CertificatesInfo: ''
+    SignerInfo: ''
+    Certificates:
+    - Subject: C=GB, O=Sectigo Limited, CN=Sectigo Public Code Signing Root R46
+      ValidFrom: '2021-05-25 00:00:00'
+      ValidTo: '2028-12-31 23:59:59'
+      Signature: 12bfa1ef8b749a9844b86946b5ab240a0ca48a67b83a81bf458a7d5207a88d1f4e218539a36b5e2d2086bf10b8ae793b53cdb4fbd844be06d95c6367d44016874486722ad63215f51283c2f9e15d114067f6422772c523e202381a4c20e2db01f7cd464f26a27c66c05136b6890254c7fc58fb6c00eefe98a62e95a10c53291f6fd819a64f9ef7ac09ea5d82c68baf80a7bd8148528431da32ec15e4a64c3d6c3973d40b853920e0851a68e1a74838a9d1362577c18d1916c5884c667d2f63ce98e869dfac3ca85d9dc91c5baed8f32f74cfb87ef6d7839d1196629aae4513da7fdc47fbdfc3529fe60655e99d8cf23a6251bcec240f29d4588084e4457b5ad8
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 48fc93b46055948d36a7c98a89d69416
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: 207045ce7b7ab131e78e459b13825902
+        SHA1: bcf7530a1ab309fb1926cb720f9fd58cff1cb88f
+        SHA256: 0f31a4237992e1ea623baf4c29480afb6d913e10f1fb1d56bb56f5b03fbff13b
+        SHA384: a229d2722bc6091d73b1d979b81088c977cb028a6f7cbf264bb81d5cc8f099f87d7c296e48bf09d7ebe275f5498661a4
+    - Subject: C=GB, O=Sectigo Limited, CN=Sectigo Public Code Signing CA EV R36
+      ValidFrom: '2021-03-22 00:00:00'
+      ValidTo: '2036-03-21 23:59:59'
+      Signature: 5f36acfbf9f6725a14b7f00b1dded8fd9701d2fd01ee992d86e8f6b7f039ffd6814a5aa7424a0a2d159de694fdc5694ab2d74bf116124cf6be9066658b2d74d4ab08f76a110308777cbe69e1b0db9f248903d6de5ca4e0b2d6b4cfe338d5b96dcc27d6ce6411e8107276d3f9e0e92c89e949d3b39796060ae1f60ac8419a915d81d8367798ca804197a8f8913f639faacd54544b80eaf51766d39471fd9efd4731e3e91a861dd3be20d23fb1525fb293bd8c950998728f9501f49843a54afb1426aa9d36bf72b0fcdcbd840deced34a85e952b3816630575d9f6312e156be294b22ad27435b5989aa3fef82b2fb6174b276c5ae6b9765eda86ddab64d66aea8318881b3182f588b39425c0212f086902e34cbb4c2a1130eb817906e141952ad420f60b93e47c760c9d1d266b5f8401f62a99cdafdec7f0e418a24e9b2f2a0c66a6927526bed94035136faea6371a7ae8ad1c5163072a56066ced7e18f6e3ec6473a66d08368baf0f99ae756b172bc24d6ac351464156e98fc28dff13719bdaed9ed39fabe545a612c5145a524197a3060008c5e61cea27823c3bdbe646c4ef2d003513cd367d9de5aa270805cccec0360e4b194fd0639a6dbfc529533122db75507786d0f2f86aee6b061b3e85232b97c87e7a99410cdd587f0ea8c3123d3a359be09d2c8c17815444a87a1d989d967f5958a65465ff51420bf847ebcff8e5bf
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.12
+      IsCertificateAuthority: true
+      SerialNumber: 33d708a891405319e2a5bbd339b9ad6e
+      Version: 3
+      CertificateType: CA
+      IsCodeSigning: true
+      IsCA: true
+      TBS:
+        MD5: b81404c775a2621debdb7825b87b8316
+        SHA1: 47ae94067c3c59b13605192288705db7b52f3685
+        SHA256: 9893b35b3dcefe53d8d24b887569dfe21f9aef27bd57b61c06fcf7438b89c33a
+        SHA384: f55821c081b58e86eaa202923e715e1524c422c7be0469b13a9e7a319e50d70cb5b67e864273029a79250f9dc3203cbd
+    - Subject: serialNumber=49 099 321 392, JURISDICTION_OF_INCORPORATION_C=AU, BUSINESS_CATEGORY=Private
+        Organization, C=AU, ST=New South Wales, O=PassMark Software Pty Ltd, CN=PassMark
+        Software Pty Ltd
+      ValidFrom: '2024-01-18 00:00:00'
+      ValidTo: '2027-01-17 23:59:59'
+      Signature: 91b5f5ae708c4b61c5eb3b9010b2300f03d496eb38c55f040aa9c2b22c85e66154e3ca5dbb92e0ec189152962d85651207dd07dd548679778a6accb77ae422f1e8286ab60dd64f411f9f56d824127362018bab81e04139693e4931bf5615eeac4618e6f250f8df3bfe39f8e057fbdfabda4de937d8e38c4962f877c23edc279e21d8de70176c8af42f73eec79e68ba511829b5921d38db0286f188a106bd7f1f772a2a32f41e8b807e96099eab4ebe71e17ba4e9d3a5a92a6f6f0e0449394a9c9df7c001bdc1abf85b929a6698e84953b08c090fb8fff0931a95fc4b1ccac0aa8a210a718023e3c89fff46137a0ed215fe1cc4e0a7f2e62e425a2bec3254c3fbdaac3361dff600899daa665256442178b2da2bbdb78265b10663327160d942ffd7032a78050e1169324a00ae3c41b9d42c94747dc9091ef80d6d60613c7b3d9826ea01993b5a34c2107973ddb5fb996354746aa818ec38bac76096d21acb3b93cd1b4173c8af6841b424d158a89d1ed8151efa57ef9e9a55b7d4db22133b4ef5
+      SignatureAlgorithmOID: 1.2.840.113549.1.1.11
+      IsCertificateAuthority: false
+      SerialNumber: 00988b27911af5c9ac0ebc4e3f1240dacd
+      Version: 3
+      CertificateType: Leaf (Code Signing)
+      IsCodeSigning: true
+      IsCA: false
+      TBS:
+        MD5: 1cc8472a5a559acbaa138e76fb4c5a34
+        SHA1: 6efcab183c4940254949d80de54dd0552959c0c6
+        SHA256: 5e6768de69fd59e5aad00ecc900ad3922a803c29f272826af58965cc4483fe9b
+        SHA384: 54593b6d27a25050514007addceddab78658de1d94ef02f3085f0091ea813abdad3c60404feae59dd4231313f39f0a16
+    Signer:
+    - SerialNumber: 00988b27911af5c9ac0ebc4e3f1240dacd
+      Issuer: C=GB, O=Sectigo Limited, CN=Sectigo Public Code Signing CA EV R36
+      Version: 1


### PR DESCRIPTION
## Summary

Completes the DirectIo64.sys submission from #402 by adding the exact PerformanceTest 11.1 b1008 driver sample through Git LFS and enriching its catalog record with extracted PE, signature, section, import, Authentihash, and Rich-header metadata.

The description now reflects the affected driver's publicly documented physical-memory, MSR, PCI configuration, I/O-port, kernel-dump, and physical-memory-dump primitives. The record retains CVE-2025-52347, the original disclosure reference, and credit to @floppywiggler.

Supersedes #402 because GitHub does not permit maintainers to upload LFS objects to the contributor fork even when maintainer modification is enabled.

## Evidence

- the LFS pointer OID matches SHA-256 `b147a26dad59d9109710798b033ec3504a799f02e4356a358d6e32fdf7841b4a`
- MD5 and SHA-1 match the submitted catalog values
- the project metadata extractor completed successfully against the exact sample
- headless static analysis confirmed the documented IOCTL paths and privileged operations

## Validation

- `python bin/validate.py`
- `git lfs fsck`
- `git diff --check`
