### PR TITLE
Correct NeacSafe64.sys researcher attribution

### DIFF
--- a/yaml/d474d8ad-14d9-4664-addd-86b4a9b7a1a5.yaml
+++ b/yaml/d474d8ad-14d9-4664-addd-86b4a9b7a1a5.yaml
@@ -20,12 +20,12 @@ Commands:
   Privileges: kernel
   OperatingSystem: Windows 10, Windows 11
 Resources:
-- https://github.com/smallzhong/NeacController
+- https://github.com/za233/NeacController
 - https://github.com/hfiref0x/KDU/blob/master/Help/providers.md
 Detection: []
 Acknowledgement:
-  Person: smallzhong
-  Handle: '@smallzhong'
+  Person: za233
+  Handle: '@za233'
 KnownVulnerableSamples:
 - Filename: NeacSafe64.sys
   SHA256: 65447f727801e8be8a51aaaafc07618c8196553e683affb0721da441e2430bad


### PR DESCRIPTION
## Summary

- correct the NeacSafe64.sys research resource to the original NeacController repository
- credit @za233 for the CVE-2025-45737 research
- thank @smallzhong for identifying and clearly documenting the attribution issue

## Validation

- repository YAML validation passes
- scoped diff check passes

Closes #418