### PR TITLE
Add vulnerable kgameprotect.sys process-termination driver

### DIFF
--- a/drivers/cb1f1880aafd7d9bbdd70c54e56c9dd0.bin
+++ b/drivers/cb1f1880aafd7d9bbdd70c54e56c9dd0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c1d596d18213e24f0c88d58ea7f3ca24114eded806b6198a8abc701251126ee
+size 59592

--- a/yaml/a0006589-a811-4341-9be0-4512eae9febb.yaml
+++ b/yaml/a0006589-a811-4341-9be0-4512eae9febb.yaml
@@ -1,7 +1,7 @@
 Id: a0006589-a811-4341-9be0-4512eae9febb
 Tags:
 - kgameprotect.sys
-Verified: 'FALSE'
+Verified: 'TRUE'
 Author: Shiroko
 Created: '2026-09-11'
 MitreID: T1562.001

--- a/yaml/a0006589-a811-4341-9be0-4512eae9febb.yaml
+++ b/yaml/a0006589-a811-4341-9be0-4512eae9febb.yaml
@@ -1,0 +1,49 @@
+Id: a0006589-a811-4341-9be0-4512eae9febb
+Tags:
+- kgameprotect.sys
+Verified: 'FALSE'
+Author: Shiroko
+Created: '2026-09-11'
+MitreID: T1562.001
+Category: vulnerable driver
+Commands:
+  Command: sc.exe create kgameprotect binPath= C:\windows\temp\kgameprotect.sys type= kernel && sc.exe start kgameprotect
+  Description: >-
+    kgameprotect.sys exposes FILE_ANY_ACCESS IOCTL 0x222048 through
+    \\.\kgameprotect. The handler accepts a caller-selected PID and opens that
+    process from KernelMode with PROCESS_TERMINATE before calling
+    ZwTerminateProcess. It performs no caller, registered-client, or target-PID
+    authorization on this IOCTL branch.
+  Usecase: >-
+    Terminate selected non-PPL processes to cause denial of service or impair
+    security controls.
+  Privileges: >-
+    Administrator to load; potentially unprivileged to trigger if the applied
+    device DACL permits opening the control device.
+  OperatingSystem: Windows 10, Windows 11 (x64)
+Resources:
+- https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/defining-i-o-control-codes
+- https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-iocreatedevice
+Acknowledgement:
+  Person: Shiroko
+  Handle: '@ShirokoLEET'
+Detection: []
+KnownVulnerableSamples:
+- Filename: kgameprotect.sys
+  MD5: cb1f1880aafd7d9bbdd70c54e56c9dd0
+  SHA1: 86f3b8e26e80db804086f095dd6bee79980d810c
+  SHA256: 6c1d596d18213e24f0c88d58ea7f3ca24114eded806b6198a8abc701251126ee
+  Imphash: 4de3dfcde82ad8ff50165c62d0501064
+  Authentihash:
+    MD5: 1bbaf5dc91831f9138f4ad266a5841d9
+    SHA1: 9f7d0ad9493857ea85e2074688df4244399e6ca6
+    SHA256: abe670579d00b0dbc2c1fc477d8d6e41f3af642e48d60dcf558a171a819137e6
+  CreationTimestamp: '2026-08-05 08:09:11 UTC'
+  FileVersion: 2.7.1.7
+  ProductVersion: 2.7.1.7
+  MachineType: AMD64
+  Imports:
+  - FLTMGR.SYS
+  - ntoskrnl.exe
+  - HAL.dll
+  PDBPath: E:\yj_projects\source\driver\kgameprotect\x64\Release\kgameprotect.pdb


### PR DESCRIPTION
## Summary

Adds the Microsoft-attested AMD64 `kgameprotect.sys` driver and its LOLDrivers
metadata.

- SHA-256: `6c1d596d18213e24f0c88d58ea7f3ca24114eded806b6198a8abc701251126ee`
- Device: `\\.\kgameprotect`
- Vulnerable IOCTL: `0x222048` (`METHOD_BUFFERED`, `FILE_ANY_ACCESS`)

## Vulnerability

IOCTL `0x222048` accepts a caller-controlled PID and terminates that process
without caller, registered-client, or target-PID authorization.

The dispatch branch checks only that `InputBufferLength >= 4`, reads the first
DWORD from `Irp->AssociatedIrp.SystemBuffer`, and passes it to the termination
helper. The helper calls:

```c
PsLookupProcessByProcessId(pid, &process);
ObOpenObjectByPointer(
    process,
    OBJ_KERNEL_HANDLE,
    NULL,
    PROCESS_TERMINATE,
    *PsProcessType,
    KernelMode,
    &handle);
ZwTerminateProcess(handle, STATUS_ACCESS_DENIED);
```

Static-analysis locations:

- input-length check: `0x14000272B`
- caller-controlled PID load: `0x140002743`
- call to the termination helper: `0x140002774`
- `ObOpenObjectByPointer`: `0x1400088CD`
- `ZwTerminateProcess`: `0x1400088F6`

## Impact

If a low-privilege user can open the control device, the `FILE_ANY_ACCESS`
IOCTL lets that user terminate processes without possessing a user-mode
`PROCESS_TERMINATE` handle. This can cause cross-session denial of service and
impair non-PPL security processes.

The IOCTL behavior was dynamically validated in a virtual machine, and the
YAML is marked `Verified: 'TRUE'`. This contribution does not claim privilege
escalation, arbitrary kernel memory access, or PPL bypass.

## Validation

- confirmed the sample was absent from LOLDrivers by filename and SHA-256
- verified the Authenticode signature locally
- verified the LFS object OID matches the sample SHA-256 and size (59,592 bytes)
- dynamically validated IOCTL `0x222048` in a virtual machine
- parsed the YAML successfully with PyYAML
- reviewed the IOCTL and termination paths in IDA

## Maintainer verification (2026-09-18)

- Retained the exact 59,592-byte sample and original Shiroko attribution; added the missing per-file Git LFS tracking entry.
- Ran the repository metadata extractor to enrich PE fields, authentihashes, signing certificates, imports, and sections.
- Independently confirmed the PID input and kernel process-termination path in the exact binary using headless static analysis.
- Removed the incomplete plain-kernel service loading command: this sample also registers a file-system minifilter and needs the appropriate installation. The applied device ACL and PPL behavior remain explicit limitations.
- Full YAML/binary validation, API exporter tests, JSON/CSV generation, exact hash/LFS pointer checks, LFS fsck, and scoped diff checks passed locally. Hosted checks are recorded below by GitHub.
- Maintainer verification was static only; the dynamic observations above remain the submitter's report.
